### PR TITLE
Fix display cutout handling in landscape mode

### DIFF
--- a/app/src/main/java/eu/darken/myperm/common/EdgeToEdgeHelper.kt
+++ b/app/src/main/java/eu/darken/myperm/common/EdgeToEdgeHelper.kt
@@ -21,11 +21,12 @@ class EdgeToEdgeHelper(activity: Activity) {
     ) {
         ViewCompat.setOnApplyWindowInsetsListener(view) { v: View, insets: WindowInsetsCompat ->
             val systemBars: Insets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            val displayCutout: Insets = insets.getInsets(WindowInsetsCompat.Type.displayCutout())
             v.setPadding(
-                if (left) systemBars.left else v.paddingLeft,
-                if (top) systemBars.top else v.paddingTop,
-                if (right) systemBars.right else v.paddingRight,
-                if (bottom) systemBars.bottom else v.paddingBottom,
+                if (left) maxOf(systemBars.left, displayCutout.left) else v.paddingLeft,
+                if (top) maxOf(systemBars.top, displayCutout.top) else v.paddingTop,
+                if (right) maxOf(systemBars.right, displayCutout.right) else v.paddingRight,
+                if (bottom) maxOf(systemBars.bottom, displayCutout.bottom) else v.paddingBottom,
             )
             insets
         }


### PR DESCRIPTION
## Summary
- Fix UI content being obscured by camera cutouts (notches/punch holes) in landscape orientation
- `EdgeToEdgeHelper.insetsPadding()` now considers both `systemBars()` and `displayCutout()` insets, using the maximum value for each side

This is the same fix applied in [capod PR #374](https://github.com/d4rken-org/capod/pull/374).

## Test plan
- [x] Build the app and verify no compilation errors
- [x] Test on a device with display cutout in landscape mode to verify UI content is not obscured
- [x] Verify portrait mode still works correctly (no regression)