### PR TITLE
Fix NPE when viewing app details for secondary profile apps

### DIFF
--- a/app/src/main/java/eu/darken/myperm/apps/core/container/SecondaryProfilePkg.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/container/SecondaryProfilePkg.kt
@@ -8,6 +8,7 @@ import android.content.pm.PermissionInfo
 import android.graphics.drawable.Drawable
 import android.os.Process
 import android.os.UserHandle
+import eu.darken.myperm.R
 import eu.darken.myperm.apps.core.AppRepo
 import eu.darken.myperm.apps.core.GET_UNINSTALLED_PACKAGES_COMPAT
 import eu.darken.myperm.apps.core.Pkg
@@ -37,14 +38,34 @@ class SecondaryProfilePkg(
     override fun getLabel(context: Context): String {
         _label?.let { return it }
         val pm = context.packageManager
-        val newLabel = pm.getUserBadgedLabel(launcherAppInfo.loadLabel(pm).toString(), userHandle).toString()
+        val newLabel = try {
+            val loadedLabel = launcherAppInfo.loadLabel(pm).toString()
+            pm.getUserBadgedLabel(loadedLabel, userHandle).toString()
+        } catch (_: Exception) {
+            null
+        }
+            ?: twins.firstNotNullOfOrNull { it.getLabel(context) }
+            ?: super.getLabel(context)
+            ?: id.pkgName
         _label = newLabel
         return newLabel
     }
 
     override fun getIcon(context: Context): Drawable {
         val pm = context.packageManager
-        return pm.getUserBadgedIcon(launcherAppInfo.loadIcon(pm), userHandle)
+        return try {
+            val loadedIcon = launcherAppInfo.loadIcon(pm)
+            if (loadedIcon != null) {
+                pm.getUserBadgedIcon(loadedIcon, userHandle)
+            } else {
+                null
+            }
+        } catch (_: Exception) {
+            null
+        }
+            ?: twins.firstNotNullOfOrNull { it.getIcon(context) }
+            ?: super.getIcon(context)
+            ?: context.getDrawable(R.drawable.ic_default_app_icon_24)!!
     }
 
     override var siblings: Collection<Pkg> = emptyList()

--- a/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsFragmentVM.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsFragmentVM.kt
@@ -66,12 +66,17 @@ class AppDetailsFragmentVM @Inject constructor(
             AppOverviewVH.Item(
                 app = app,
                 onOpenApp = {
-                    try {
-                        val intent = context.packageManager.getLaunchIntentForPackage(it.packageName)!!
-                        context.startActivity(intent)
-                    } catch (e: Exception) {
-                        log(TAG, ERROR) { "Launch intent failed for $app: ${e.asLog()}" }
-                        errorEvents.postValue(e)
+                    val intent = context.packageManager.getLaunchIntentForPackage(it.packageName)
+                    if (intent != null) {
+                        try {
+                            context.startActivity(intent)
+                        } catch (e: Exception) {
+                            log(TAG, ERROR) { "Launch intent failed for $app: ${e.asLog()}" }
+                            errorEvents.postValue(e)
+                        }
+                    } else {
+                        log(TAG, ERROR) { "No launch intent available for ${it.packageName}" }
+                        errorEvents.postValue(IllegalStateException("No launch intent available"))
                     }
                 },
                 onGoToSettings = { events.postValue(AppDetailsEvents.ShowAppSystemDetails(it)) },


### PR DESCRIPTION
## Summary
- Add null safety and fallback chains for `SecondaryProfilePkg.getLabel()` and `getIcon()` methods
- Handle case where launch intent is unavailable in `AppDetailsFragmentVM.onOpenApp`

## User Reports
- https://discord.com/channels/548521543039189022/996859250758406235/1443056671784964218
- https://discord.com/channels/548521543039189022/996859250758406235/1461766031193411839

## Test plan
- [ ] View app details for apps in work profiles
- [ ] View app details for apps installed by another user
- [ ] Click "Open" on an app that cannot be launched
- [ ] View app details for apps without launcher activities