### PR TITLE
Complete missing translations for 9 locales

### DIFF
--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -6,6 +6,8 @@
 
     <string name="general_error_label">Chyba</string>
 
+    <string name="general_accept_action">Přijmout</string>
+    <string name="general_continue_action">Pokračovat</string>
     <string name="general_share_action">Sdílet</string>
     <string name="general_done_action">Hotovo</string>
     <string name="general_copy_action">Kopírovat</string>
@@ -24,6 +26,7 @@
     <string name="debug_notification_channel_label">Oznámení o ladění</string>
     <string name="debug_debuglog_file_label">Zaznamenaný soubor ladělí</string>
     <string name="debug_debuglog_record_action">Zaznamenat soubor ladění</string>
+    <string name="debug_debuglog_sensitive_information_message">Tento soubor obsahuje citlivé informace (např. vaše nainstalované aplikace). Sdílejte jej pouze s důvěryhodnými stranami.</string>
 
     <string name="settings_category_other_label">Další</string>
 
@@ -123,6 +126,7 @@
     <string name="apps_filter_multipleprofiles_label">Aplikace s klony</string>
     <string name="support_debuglog_label">Záznam ladění</string>
     <string name="support_debuglog_desc">Zaznamenávejte vše, co aplikace dělá do textového souboru, který můžete sdílet.</string>
+    <string name="settings_debuglog_explanation">Tato funkce zaznamenává vše, co aplikace dělá, do sdílitelného souboru. Vygenerovaný soubor obsahuje citlivé informace (např. vaše nainstalované aplikace). Sdílejte jej pouze s důvěryhodnými stranami (např. s vývojářem aplikace, pokud společně řešíte problém).</string>
     <string name="updated_at_x">Poslední aktualizace: %s</string>
     <string name="installed_at_x">První instalace: %s</string>
     <string name="apps_sort_install_source_label">Zdroj instalace</string>
@@ -254,4 +258,8 @@
     <string name="overview_summary_apps_sharedids_label">No. aplikací se SharedUserID</string>
     <string name="permission_bind_accessibility_service_label">Nabídka služeb přístupnosti</string>
     <string name="permission_bind_accessibility_service_description">Umožňuje aplikaci nabízet službu přístupnosti, kterou lze povolit v nastavení systému.</string>
+
+    <string name="onboarding_body1">Tato aplikace vám pomáhá procházet nainstalované aplikace a zjišťovat jejich oprávnění.</string>
+    <string name="onboarding_body2">Permission Pilot shromažďuje informace o nainstalovaných aplikacích, aby mohl zobrazovat seznam vašich aplikací a porovnávat jejich oprávnění při používání této aplikace.</string>
+    <string name="onboarding_body3">Permission Pilot neobsahuje reklamy a zpracovává data pouze lokálně.</string>
 </resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -14,6 +14,7 @@
     <string name="general_open_action">Åbn</string>
     <string name="general_continue_action">Fortsæt</string>
     <string name="general_accept_action">Acceptér</string>
+    <string name="general_refresh_action">Opdatér</string>
 
     <string name="upgrade_myperm_label">Opgradér Permission Pilot</string>
     <string name="upgrade_myperm_description">Kan du lide, at denne app ikke har reklamer og ikke indsamler dine data?\nKøb pro-versionen for at vise din støtte!</string>
@@ -63,6 +64,12 @@
     <string name="apps_filter_sideloaded_label">Sideloadede apps</string>
     <string name="apps_filter_gplay_label">Google Play Store</string>
     <string name="apps_filter_oemstore_label">OEM Store</string>
+    <string name="apps_filter_accessibility_label">Apps med tilgængelighedstjenester</string>
+    <string name="apps_filter_battery_optimization_label">Apps med tilpassede batteriindstillinger</string>
+    <string name="apps_filter_multipleprofiles_label">Apps med kloner</string>
+    <string name="apps_filter_profile_active_label">Apps i aktiv profil</string>
+    <string name="apps_filter_profile_secondary_label">Apps i administrerede profiler</string>
+    <string name="apps_filter_sharedid_label">Delt bruger-ID</string>
 
     <string name="apps_sort_permissions_granted_label">Tildelte tilladelser</string>
     <string name="apps_sort_permissions_requested_label">Anmodede tilladelser</string>
@@ -70,6 +77,7 @@
     <string name="apps_sort_app_name_label">App-navn</string>
     <string name="apps_sort_install_date_label">Installationsdato</string>
     <string name="apps_sort_update_date_label">Sidst opdateret</string>
+    <string name="apps_sort_install_source_label">Installationskilde</string>
 
     <string name="general_sort_action">Sortér</string>
     <string name="apps_permissions_x_of_x_granted">%1$d af %2$d tildelt.</string>
@@ -89,6 +97,7 @@
 
     <string name="permissions_sort_apps_granted_label">Antal apps tildelt</string>
     <string name="permissions_sort_apps_requested_label">Antal apps anmodet</string>
+    <string name="permissions_sort_apps_relevance_label">Relevans</string>
     <string name="permissions_search_list_hint">Søg tilladelser</string>
     <string name="apps_search_list_hint">Søg apps</string>
     <string name="permissions_details_protection_label">Beskyttelsesniveau</string>
@@ -103,6 +112,11 @@
     <string name="permissions_details_apps_granted_label">Tildelte apps</string>
     <string name="permissions_details_apps_requested_label">Anmodede apps</string>
     <string name="permissions_details_apps_declared_label">Erklærede apps</string>
+    <string name="permissions_details_count_system_apps">"System-apps: Tildelt til %1$d ud af %2$d."</string>
+    <string name="permissions_details_count_user_apps">"Bruger-apps: Tildelt til %1$d ud af %2$d."</string>
+    <string name="permissions_details_description_restrictions_caveat_description">Apps installeret i andre brugerprofiler er udelukket fra beregningen ovenfor på grund af Android-begrænsninger.</string>
+    <string name="permissions_permission_details_label">Tilladelsesdetaljer</string>
+    <string name="permissions_action_none_msg">Ingen handling tilgængelig for denne tilladelse</string>
 
     <string name="app_details_permission_granted_label">Tildelt</string>
     <string name="app_details_permission_requested_label">Anmodet</string>
@@ -120,6 +134,14 @@
     <string name="apps_details_target_sdk_label">Mål-SDK</string>
     <string name="apps_details_compile_sdk_label">Kompiler-SDK</string>
     <string name="apps_details_min_sdk_label">Minimum SDK</string>
+    <string name="apps_app_details_label">App-detaljer</string>
+    <string name="apps_details_description_primary_description">"%1$d af %2$d tilladelser tildelt."</string>
+    <string name="apps_details_description_restrictions_caveat_description">Denne app er installeret i en anden brugerprofil. Tildelte tilladelser kan kun bestemmes for apps installeret i den aktuelt aktive profil på grund af Android-begrænsninger.</string>
+    <string name="apps_details_description_secondary_description">"%d tilladelser anmodet."</string>
+    <string name="apps_details_shareduserid_label">Apps med delt bruger-ID</string>
+    <string name="apps_details_siblings_label">Søskende</string>
+    <string name="apps_details_twins_descriptions">Installeret i andre brugerprofiler.</string>
+    <string name="apps_details_twins_label">Kloner</string>
 
     <string name="apps_details_signing_certificate_label">Signeringscertifikat</string>
     <string name="apps_details_signing_certificate_sha256_label">SHA-256 fingeraftryk</string>
@@ -135,6 +157,7 @@
 
     <string name="apps_details_overview_label">Oversigt</string>
     <string name="overview_label">Oversigt</string>
+    <string name="overview_page_label">Oversigt</string>
     <string name="overview_summary_label">Sammendrag</string>
     <string name="overview_apps_label">Apps</string>
     <string name="overview_permissions_label">Tilladelser</string>
@@ -147,6 +170,31 @@
 
     <string name="overview_info_label">Information</string>
     <string name="overview_device_label">Enhed</string>
+
+    <string name="apps_known_android_system_label">Android System</string>
+    <string name="apps_known_installer_gplay_label">Google Play Store</string>
+    <string name="apps_known_installer_huawei_label">Huawei AppGallery</string>
+    <string name="apps_known_installer_oppo_label">Oppo App Market</string>
+    <string name="apps_known_installer_samsung_label">Samsung Galaxy Store</string>
+    <string name="apps_known_installer_vivo_label">Vivo V-AppStore</string>
+    <string name="apps_known_installer_xiaomi_label">Xiaomi GetApps</string>
+
+    <string name="install_date_label">Installationsdato</string>
+    <string name="installed_at_x">Først installeret: %s</string>
+    <string name="updated_at_x">Sidst opdateret: %s</string>
+
+    <string name="api_build_level_x">Kompileringsversion: %s</string>
+    <string name="api_minimum_level_x">Minimumversion: %s</string>
+    <string name="api_target_level_x">Målversion: %s</string>
+
+    <string name="generic_loading_label_0">Snart™</string>
+    <string name="generic_loading_label_1">Rækker smørret</string>
+    <string name="generic_loading_label_2">Downloader mere RAM</string>
+    <string name="generic_loading_label_3">Stadig hurtigere end en iPhone</string>
+    <string name="generic_loading_label_4">Hvad er det bag dig?</string>
+    <string name="generic_loading_label_5">CPU\'en holder kaffepause</string>
+    <string name="generic_loading_label_6">Afventer data fra Pepe Silvia</string>
+    <string name="generic_loading_label_7">Turboencabulatoren startes op</string>
 
     <string name="permission_write_calendar_label">Skriv kalender</string>
     <string name="permission_write_calendar_description">Tillader at tilføje, fjerne og ændre kalenderbegivenheder på din enhed.</string>
@@ -196,6 +244,18 @@
     <string name="permission_premium_sms_services_description">Tillader apps at bruge premium tekstbeskedtjenester. Dette vil koste dig penge.</string>
     <string name="permission_unlimited_data_access_label">Ubegrænset dataadgang</string>
     <string name="permission_unlimited_data_access_description">Tillader apps adgang til ubegrænsede data. Apps kan forbruge data, selv når Dataspar er TIL.</string>
+    <string name="permission_bluetooth_advertise_label">Bluetooth-annoncering</string>
+    <string name="permission_bluetooth_advertise_description">Tillader apps at annoncere til nærliggende Bluetooth-enheder.</string>
+    <string name="permission_manage_media_label">Administrer medier</string>
+    <string name="permission_manage_media_description">Tillader apps at ændre eller slette mediefiler oprettet med andre apps UDEN at spørge dig. Apps skal have tilladelse til at tilgå filer og medier.</string>
+    <string name="permission_modify_system_settings_label">Ændr systemindstillinger</string>
+    <string name="permission_modify_system_settings_description">Tillader apps at ændre systemets indstillingsdata. Ondsindede apps kan ødelægge dit systems konfiguration.</string>
+    <string name="permission_nfc_label">NFC</string>
+    <string name="permission_nfc_description">Tillader apps at kommunikere med Near Field Communication (NFC) tags, kort og læsere.</string>
+    <string name="permission_reboot_label">Genstart enhed</string>
+    <string name="permission_reboot_description">Tillader appen at genstarte enheden. Kun tilgængelig for system-apps.</string>
+    <string name="permission_usage_data_access_label">Adgang til brugsdata</string>
+    <string name="permission_usage_data_access_description">Tillader apps at spore, hvilke andre apps du bruger og hvor ofte, identificere din tjenesteudbyder, sprogindstillinger og andre brugsdata.</string>
     <string name="permission_group_calendar_label">Kalender</string>
     <string name="permission_group_calendar_description"><![CDATA[Kalenderrelaterede tilladelser, f.eks. vis og rediger indtastninger.]]></string>
     <string name="permission_group_files_label">Filer og medier</string>
@@ -241,4 +301,28 @@
     <string name="onboarding_body1">Denne app hjælper dig med at navigere installerede applikationer og opdage tilladelser.</string>
     <string name="onboarding_body2">Permission Pilot indsamler installerede applikationsoplysninger for at kunne liste dine apps og krydshenvise deres tilladelser, når du bruger denne applikation.</string>
     <string name="onboarding_body3">Permission Pilot har ingen reklamer og behandler kun data lokalt.</string>
+
+    <string name="support_debuglog_label">Debug-log</string>
+    <string name="support_debuglog_desc">Optag alt, hvad appen laver, i en tekstfil, som du kan dele.</string>
+
+    <plurals name="generic_x_apps_label">
+        <item quantity="one">%d app</item>
+        <item quantity="other">%d apps</item>
+    </plurals>
+    <plurals name="generic_x_apps_system_label">
+        <item quantity="one">%d system-app</item>
+        <item quantity="other">%d system-apps</item>
+    </plurals>
+    <plurals name="generic_x_apps_user_label">
+        <item quantity="one">%d bruger-app</item>
+        <item quantity="other">%d bruger-apps</item>
+    </plurals>
+    <plurals name="generic_x_groups_label">
+        <item quantity="one">%s gruppe</item>
+        <item quantity="other">%s grupper</item>
+    </plurals>
+    <plurals name="generic_x_items_label">
+        <item quantity="one">%s element</item>
+        <item quantity="other">%s elementer</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -6,6 +6,8 @@
 
     <string name="general_error_label">Σφάλμα</string>
 
+    <string name="general_accept_action">Αποδοχή</string>
+    <string name="general_continue_action">Συνέχεια</string>
     <string name="general_share_action">Κοινοποίηση</string>
     <string name="general_done_action">Ολοκληρώθηκε</string>
     <string name="general_copy_action">Αντιγραφή</string>
@@ -24,6 +26,7 @@
     <string name="debug_notification_channel_label">Ειδοποιήσεις εντοπισμού σφαλμάτων</string>
     <string name="debug_debuglog_file_label">Καταγεγραμμένο αρχείο καταγραφής</string>
     <string name="debug_debuglog_record_action">Καταγραφή αρχείου εντοπισμού σφαλμάτων</string>
+    <string name="debug_debuglog_sensitive_information_message">Αυτό το αρχείο περιέχει ευαίσθητες πληροφορίες (π.χ. τις εγκατεστημένες εφαρμογές σας). Μοιραστείτε το μόνο με αξιόπιστα άτομα.</string>
 
     <string name="settings_category_other_label">Διάφορα</string>
 
@@ -36,6 +39,10 @@
     <string name="settings_licenses_label">Άδειες</string>
     <string name="settings_privacy_policy_label">Πολιτική απορρήτου</string>
     <string name="settings_privacy_policy_desc">Χειρισμός δεδομένων με υπευθυνότητα.</string>
+
+    <string name="onboarding_body1">Αυτή η εφαρμογή σας βοηθά να πλοηγηθείτε στις εγκατεστημένες εφαρμογές και να ανακαλύψετε τις άδειές τους.</string>
+    <string name="onboarding_body2">Το Permission Pilot συλλέγει πληροφορίες για τις εγκατεστημένες εφαρμογές, ώστε να μπορεί να τις εμφανίζει και να συσχετίζει τις άδειές τους κατά τη χρήση της εφαρμογής.</string>
+    <string name="onboarding_body3">Το Permission Pilot δεν έχει διαφημίσεις και επεξεργάζεται δεδομένα μόνο τοπικά.</string>
 
     <string name="settings_support_label">Υποστήριξη</string>
     <string name="documentation_label">Οδηγίες</string>
@@ -123,6 +130,7 @@
     <string name="apps_filter_multipleprofiles_label">Εφαρμογές με Κλώνους</string>
     <string name="support_debuglog_label">Αρχείο καταγραφής εντοπισμού σφαλμάτων</string>
     <string name="support_debuglog_desc">Καταγράψτε όλα όσα κάνει η εφαρμογή σε ένα αρχείο κειμένου το οποίο μπορείτε να μοιραστείτε.</string>
+    <string name="settings_debuglog_explanation">Αυτή η λειτουργία καταγράφει όλα όσα κάνει η εφαρμογή σε ένα αρχείο που μπορείτε να μοιραστείτε. Το αρχείο που δημιουργείται περιέχει ευαίσθητες πληροφορίες (π.χ. τις εγκατεστημένες εφαρμογές σας). Μοιραστείτε το μόνο με αξιόπιστα άτομα (π.χ. τον προγραμματιστή της εφαρμογής αν αντιμετωπίζετε κάποιο πρόβλημα μαζί).</string>
     <string name="updated_at_x">Τελευταία ενημέρωση: %s</string>
     <string name="installed_at_x">Πρώτη εγκατάσταση: %s</string>
     <string name="apps_sort_install_source_label">Πηγή εγκατάστασης</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -265,4 +265,84 @@
     <string name="permissions_stats_categories_x_normal">%1$d normaali</string>
     <string name="permissions_stats_categories_x_dangerous">%1$d vaarallinen</string>
     <string name="permissions_stats_categories_x_signature">%1$d allekirjoitus</string>
+
+    <string name="api_build_level_x">Käännösversio: %s</string>
+    <string name="api_minimum_level_x">Minimiversio: %s</string>
+    <string name="api_target_level_x">Kohdeversio: %s</string>
+    <string name="apps_app_details_label">Sovelluksen tiedot</string>
+    <string name="apps_details_description_primary_description">"%1$d / %2$d käyttöoikeudesta myönnetty."</string>
+    <string name="apps_details_description_restrictions_caveat_description">Tämä sovellus on asennettu toiseen käyttäjäprofiiliin. Myönnetyt käyttöoikeudet voidaan määrittää vain aktiiviseen profiiliin asennetuille sovelluksille Androidin rajoitusten vuoksi.</string>
+    <string name="apps_details_description_secondary_description">"%d käyttöoikeutta pyydetty."</string>
+    <string name="apps_details_shareduserid_label">Sovellukset jaetulla käyttäjätunnuksella</string>
+    <string name="apps_details_siblings_label">Sisarukset</string>
+    <string name="apps_details_twins_descriptions">Asennettu muihin käyttäjäprofiileihin.</string>
+    <string name="apps_details_twins_label">Kloonit</string>
+    <string name="apps_filter_accessibility_label">Sovellukset saavutettavuuspalveluilla</string>
+    <string name="apps_filter_battery_optimization_label">Sovellukset mukautetuilla akkuasetuksilla</string>
+    <string name="apps_filter_multipleprofiles_label">Sovellukset klooneilla</string>
+    <string name="apps_filter_profile_active_label">Sovellukset aktiivisessa profiilissa</string>
+    <string name="apps_filter_profile_secondary_label">Sovellukset hallituissa profiileissa</string>
+    <string name="apps_filter_sharedid_label">Jaettu käyttäjätunnus</string>
+    <string name="apps_known_android_system_label">Android-järjestelmä</string>
+    <string name="apps_known_installer_gplay_label">Google Play -kauppa</string>
+    <string name="apps_known_installer_huawei_label">Huawei AppGallery</string>
+    <string name="apps_known_installer_oppo_label">Oppo App Market</string>
+    <string name="apps_known_installer_samsung_label">Samsung Galaxy Store</string>
+    <string name="apps_known_installer_vivo_label">Vivo V-AppStore</string>
+    <string name="apps_known_installer_xiaomi_label">Xiaomi GetApps</string>
+    <string name="apps_sort_install_source_label">Asennuslähde</string>
+    <string name="general_refresh_action">Päivitä</string>
+    <string name="generic_loading_label_0">Kohta valmista™</string>
+    <string name="generic_loading_label_1">Syötetään kissalle dataa</string>
+    <string name="generic_loading_label_2">Ladataan lisää RAM-muistia</string>
+    <string name="generic_loading_label_3">Silti nopeampi kuin iPhone</string>
+    <string name="generic_loading_label_4">Mitä tuolla takanasi on?</string>
+    <string name="generic_loading_label_5">Prosessori on kahvitauolla</string>
+    <string name="generic_loading_label_6">Odotetaan dataa Pertti Pasaselta</string>
+    <string name="generic_loading_label_7">Turbokapasitaattori käynnistyy</string>
+    <string name="install_date_label">Asennuspäivä</string>
+    <string name="installed_at_x">Ensimmäinen asennus: %s</string>
+    <string name="overview_page_label">Yleiskatsaus</string>
+    <string name="permission_bluetooth_advertise_description">Sallii sovellusten mainostaa läheisille Bluetooth-laitteille.</string>
+    <string name="permission_bluetooth_advertise_label">Bluetooth-mainostus</string>
+    <string name="permission_manage_media_description">Sallii sovellusten muokata tai poistaa muiden sovellusten luomia mediatiedostoja KYSYMÄTTÄ sinulta. Sovelluksilla täytyy olla käyttöoikeus tiedostoihin ja mediaan.</string>
+    <string name="permission_manage_media_label">Median hallinta</string>
+    <string name="permission_modify_system_settings_description">Sallii sovellusten muokata järjestelmän asetustietoja. Haitalliset sovellukset voivat vahingoittaa järjestelmäsi kokoonpanoa.</string>
+    <string name="permission_modify_system_settings_label">Muokkaa järjestelmäasetuksia</string>
+    <string name="permission_nfc_description">Sallii sovellusten kommunikoida NFC (Near Field Communication) -tunnisteiden, korttien ja lukijoiden kanssa.</string>
+    <string name="permission_nfc_label">NFC</string>
+    <string name="permission_reboot_description">Sallii sovelluksen käynnistää laitteen uudelleen. Saatavilla vain järjestelmäsovelluksille.</string>
+    <string name="permission_reboot_label">Käynnistä laite uudelleen</string>
+    <string name="permission_usage_data_access_description">Sallii sovellusten seurata mitä muita sovelluksia käytät ja kuinka usein, tunnistaa palveluntarjoajasi, kieliasetukset ja muut käyttötiedot.</string>
+    <string name="permission_usage_data_access_label">Käyttötietojen käyttöoikeus</string>
+    <string name="permissions_action_none_msg">Tälle käyttöoikeudelle ei ole toimintoa saatavilla</string>
+    <string name="permissions_details_count_system_apps">"Järjestelmäsovellukset: Myönnetty %1$d / %2$d."</string>
+    <string name="permissions_details_count_user_apps">"Käyttäjäsovellukset: Myönnetty %1$d / %2$d."</string>
+    <string name="permissions_details_description_restrictions_caveat_description">Muihin käyttäjäprofiileihin asennetut sovellukset on jätetty pois yllä olevasta laskelmasta Androidin rajoitusten vuoksi.</string>
+    <string name="permissions_permission_details_label">Käyttöoikeuden tiedot</string>
+    <string name="permissions_sort_apps_relevance_label">Merkityksellisyys</string>
+    <string name="support_debuglog_desc">Tallenna kaikki sovelluksen toiminta tekstitiedostoon, jonka voit jakaa.</string>
+    <string name="support_debuglog_label">Virheenkorjausloki</string>
+    <string name="updated_at_x">Viimeksi päivitetty: %s</string>
+
+    <plurals name="generic_x_apps_label">
+        <item quantity="one">%d sovellus</item>
+        <item quantity="other">%d sovellusta</item>
+    </plurals>
+    <plurals name="generic_x_apps_system_label">
+        <item quantity="one">%d järjestelmäsovellus</item>
+        <item quantity="other">%d järjestelmäsovellusta</item>
+    </plurals>
+    <plurals name="generic_x_apps_user_label">
+        <item quantity="one">%d käyttäjäsovellus</item>
+        <item quantity="other">%d käyttäjäsovellusta</item>
+    </plurals>
+    <plurals name="generic_x_groups_label">
+        <item quantity="one">%s ryhmä</item>
+        <item quantity="other">%s ryhmää</item>
+    </plurals>
+    <plurals name="generic_x_items_label">
+        <item quantity="one">%s kohde</item>
+        <item quantity="other">%s kohdetta</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -14,6 +14,7 @@
     <string name="general_open_action">खोलें</string>
     <string name="general_continue_action">जारी रखें</string>
     <string name="general_accept_action">स्वीकार करें</string>
+    <string name="general_refresh_action">रीफ़्रेश करें</string>
 
     <string name="upgrade_myperm_label">Permission Pilot अपग्रेड करें</string>
     <string name="upgrade_myperm_description">क्या आपको पसंद है कि इस ऐप में कोई विज्ञापन नहीं हैं और यह आपका डेटा एकत्र नहीं करता?\nअपना समर्थन दिखाने के लिए प्रो संस्करण खरीदें!</string>
@@ -26,6 +27,7 @@
     <string name="debug_notification_channel_label">डिबग सूचनाएं</string>
     <string name="debug_debuglog_file_label">रिकॉर्ड की गई लॉग फ़ाइल</string>
     <string name="debug_debuglog_record_action">डिबग लॉग रिकॉर्ड करें</string>
+    <string name="debug_debuglog_sensitive_information_message">इस फ़ाइल में संवेदनशील जानकारी है (जैसे आपके इंस्टॉल किए गए ऐप्स)। इसे केवल विश्वसनीय पक्षों के साथ साझा करें।</string>
 
     <string name="settings_category_other_label">अन्य</string>
 
@@ -40,6 +42,9 @@
     <string name="settings_privacy_policy_desc">डेटा को जिम्मेदारी से संभालना।</string>
 
     <string name="settings_support_label">सहायता</string>
+    <string name="settings_debuglog_explanation">यह सुविधा ऐप जो कुछ भी कर रहा है उसे एक साझा करने योग्य फ़ाइल में रिकॉर्ड करती है। जनरेट की गई फ़ाइल में संवेदनशील जानकारी होती है (जैसे आपके इंस्टॉल किए गए ऐप्स)। इसे केवल विश्वसनीय पक्षों के साथ साझा करें (जैसे ऐप डेवलपर यदि आप किसी समस्या का मिलकर समाधान कर रहे हैं)।</string>
+    <string name="support_debuglog_desc">ऐप जो कुछ भी कर रहा है उसे एक टेक्स्ट फ़ाइल में रिकॉर्ड करें जिसे आप साझा कर सकते हैं।</string>
+    <string name="support_debuglog_label">डिबग लॉग</string>
     <string name="documentation_label">दस्तावेज़ीकरण</string>
     <string name="discord_label">Discord</string>
     <string name="discord_description">घूमने और प्रश्न पूछने के लिए एक स्थान।</string>
@@ -63,6 +68,12 @@
     <string name="apps_filter_sideloaded_label">साइडलोड किए गए ऐप्स</string>
     <string name="apps_filter_gplay_label">Google Play Store</string>
     <string name="apps_filter_oemstore_label">OEM Store</string>
+    <string name="apps_filter_accessibility_label">एक्सेसिबिलिटी सेवाओं वाले ऐप्स</string>
+    <string name="apps_filter_battery_optimization_label">कस्टम बैटरी विकल्पों वाले ऐप्स</string>
+    <string name="apps_filter_multipleprofiles_label">क्लोन वाले ऐप्स</string>
+    <string name="apps_filter_profile_active_label">सक्रिय प्रोफ़ाइल में ऐप्स</string>
+    <string name="apps_filter_profile_secondary_label">प्रबंधित प्रोफ़ाइल(ओं) में ऐप्स</string>
+    <string name="apps_filter_sharedid_label">साझा उपयोगकर्ता ID</string>
 
     <string name="apps_sort_permissions_granted_label">प्रदान की गई अनुमतियां</string>
     <string name="apps_sort_permissions_requested_label">अनुरोधित अनुमतियां</string>
@@ -70,6 +81,7 @@
     <string name="apps_sort_app_name_label">ऐप का नाम</string>
     <string name="apps_sort_install_date_label">इंस्टॉल की तारीख</string>
     <string name="apps_sort_update_date_label">अंतिम बार अपडेट किया गया</string>
+    <string name="apps_sort_install_source_label">इंस्टॉल स्रोत</string>
 
     <string name="general_sort_action">क्रम</string>
     <string name="apps_permissions_x_of_x_granted">%2$d में से %1$d प्रदान किए गए।</string>
@@ -89,6 +101,7 @@
 
     <string name="permissions_sort_apps_granted_label"># ऐप्स प्रदान किए गए</string>
     <string name="permissions_sort_apps_requested_label"># ऐप्स अनुरोधित</string>
+    <string name="permissions_sort_apps_relevance_label">प्रासंगिकता</string>
     <string name="permissions_search_list_hint">अनुमतियां खोजें</string>
     <string name="apps_search_list_hint">ऐप्स खोजें</string>
     <string name="permissions_details_protection_label">सुरक्षा स्तर</string>
@@ -109,12 +122,18 @@
     <string name="permissions_details_apps_granted_label">प्रदान किए गए ऐप्स</string>
     <string name="permissions_details_apps_requested_label">अनुरोधित ऐप्स</string>
     <string name="permissions_details_apps_declared_label">घोषित ऐप्स</string>
+    <string name="permissions_details_count_system_apps">"सिस्टम ऐप्स: %2$d में से %1$d को प्रदान किया गया।"</string>
+    <string name="permissions_details_count_user_apps">"उपयोगकर्ता ऐप्स: %2$d में से %1$d को प्रदान किया गया।"</string>
+    <string name="permissions_details_description_restrictions_caveat_description">Android प्रतिबंधों के कारण अन्य उपयोगकर्ता प्रोफ़ाइल में इंस्टॉल किए गए ऐप्स को ऊपर की गणना से बाहर रखा गया है।</string>
+    <string name="permissions_permission_details_label">अनुमति विवरण</string>
+    <string name="permissions_action_none_msg">इस अनुमति के लिए कोई कार्रवाई उपलब्ध नहीं है</string>
 
     <string name="app_details_permission_granted_label">प्रदान किया गया</string>
     <string name="app_details_permission_requested_label">अनुरोधित</string>
     <string name="app_details_permission_declared_label">घोषित</string>
 
     <string name="app_details_permissions_label">अनुमतियां</string>
+    <string name="apps_app_details_label">ऐप विवरण</string>
     <string name="apps_details_app_type_label">ऐप प्रकार</string>
     <string name="apps_details_app_type_system_label">सिस्टम ऐप</string>
     <string name="apps_details_app_type_user_label">उपयोगकर्ता ऐप</string>
@@ -126,6 +145,13 @@
     <string name="apps_details_target_sdk_label">लक्ष्य SDK</string>
     <string name="apps_details_compile_sdk_label">कंपाइल SDK</string>
     <string name="apps_details_min_sdk_label">न्यूनतम SDK</string>
+    <string name="apps_details_description_primary_description">"%2$d में से %1$d अनुमतियां प्रदान की गईं।"</string>
+    <string name="apps_details_description_restrictions_caveat_description">यह ऐप किसी अन्य उपयोगकर्ता प्रोफ़ाइल में इंस्टॉल है। Android प्रतिबंधों के कारण, प्रदान की गई अनुमतियां केवल वर्तमान सक्रिय प्रोफ़ाइल में इंस्टॉल किए गए ऐप्स के लिए निर्धारित की जा सकती हैं।</string>
+    <string name="apps_details_description_secondary_description">"%d अनुमतियां अनुरोधित।"</string>
+    <string name="apps_details_shareduserid_label">साझा उपयोगकर्ता ID वाले ऐप्स</string>
+    <string name="apps_details_siblings_label">सिबलिंग्स</string>
+    <string name="apps_details_twins_descriptions">अन्य उपयोगकर्ता प्रोफ़ाइल(ओं) में इंस्टॉल।</string>
+    <string name="apps_details_twins_label">क्लोन</string>
 
     <string name="apps_details_signing_certificate_label">हस्ताक्षर प्रमाणपत्र</string>
     <string name="apps_details_signing_certificate_sha256_label">SHA-256 फिंगरप्रिंट</string>
@@ -150,9 +176,49 @@
     <string name="overview_permissions_special_label">विशेष अनुमतियां</string>
     <string name="overview_permissions_runtime_label">रनटाइम अनुमतियां</string>
     <string name="overview_permissions_install_label">इंस्टॉल अनुमतियां</string>
+    <string name="overview_page_label">अवलोकन</string>
+    <string name="overview_device_android_patch_label">पैच स्तर</string>
+    <string name="overview_device_android_version_label">Android संस्करण</string>
+    <string name="overview_device_name_label">डिवाइस</string>
+    <string name="overview_summary_apps_active_profile_label">सक्रिय प्रोफ़ाइल में ऐप्स</string>
+    <string name="overview_summary_apps_clones_label">अन्य प्रोफ़ाइल में क्लोन वाले ऐप्स</string>
+    <string name="overview_summary_apps_installers_label">\'अज्ञात स्रोतों से इंस्टॉल करें\' सक्षम वाले ऐप्स</string>
+    <string name="overview_summary_apps_offline_label">\'कोई इंटरनेट नहीं\' अनुमति वाले ऐप्स</string>
+    <string name="overview_summary_apps_other_profile_label">प्रबंधित उपयोगकर्ता प्रोफ़ाइल(ओं) में ऐप्स, क्लोन को छोड़कर</string>
+    <string name="overview_summary_apps_overlayers_label">\'शीर्ष पर दिखाई दें\' सकने वाले ऐप्स</string>
+    <string name="overview_summary_apps_sharedids_label">SharedUserID वाले ऐप्स</string>
+    <string name="overview_summary_apps_sideloaded_label">बाहरी स्रोतों से साइडलोड किए गए ऐप्स</string>
 
     <string name="overview_info_label">जानकारी</string>
     <string name="overview_device_label">डिवाइस</string>
+
+    <string name="apps_known_android_system_label">Android सिस्टम</string>
+    <string name="apps_known_installer_gplay_label">Google Play Store</string>
+    <string name="apps_known_installer_huawei_label">Huawei AppGallery</string>
+    <string name="apps_known_installer_oppo_label">Oppo App Market</string>
+    <string name="apps_known_installer_samsung_label">Samsung Galaxy Store</string>
+    <string name="apps_known_installer_vivo_label">Vivo V-AppStore</string>
+    <string name="apps_known_installer_xiaomi_label">Xiaomi GetApps</string>
+
+    <string name="api_build_level_x">कंपाइल संस्करण: %s</string>
+    <string name="api_minimum_level_x">न्यूनतम संस्करण: %s</string>
+    <string name="api_target_level_x">लक्ष्य संस्करण: %s</string>
+    <string name="install_date_label">इंस्टॉल तिथि</string>
+    <string name="installed_at_x">पहली बार इंस्टॉल: %s</string>
+    <string name="updated_at_x">अंतिम अपडेट: %s</string>
+
+    <string name="onboarding_body1">यह ऐप आपको इंस्टॉल किए गए ऐप्लिकेशन नेविगेट करने और अनुमतियां खोजने में मदद करता है।</string>
+    <string name="onboarding_body2">Permission Pilot आपके ऐप्स की सूची और उनकी अनुमतियों के क्रॉस-रेफरेंस को सक्षम करने के लिए इंस्टॉल किए गए ऐप्लिकेशन की जानकारी एकत्र करता है।</string>
+    <string name="onboarding_body3">Permission Pilot में कोई विज्ञापन नहीं है और यह केवल स्थानीय रूप से डेटा प्रोसेस करता है।</string>
+
+    <string name="generic_loading_label_0">जल्द ही</string>
+    <string name="generic_loading_label_1">मक्खन पास कर रहे हैं</string>
+    <string name="generic_loading_label_2">और RAM डाउनलोड कर रहे हैं</string>
+    <string name="generic_loading_label_3">iPhone से तो तेज़ है</string>
+    <string name="generic_loading_label_4">आपके पीछे क्या है?</string>
+    <string name="generic_loading_label_5">CPU चाय की छुट्टी पर है</string>
+    <string name="generic_loading_label_6">पेपे सिल्विया से डेटा का इंतज़ार</string>
+    <string name="generic_loading_label_7">टर्बो एनकैब्युलेटर शुरू हो रहा है</string>
 
     <string name="permission_write_calendar_label">कैलेंडर लिखें</string>
     <string name="permission_write_calendar_description">आपके डिवाइस पर कैलेंडर इवेंट्स को जोड़ने, हटाने और बदलने की अनुमति देता है।</string>
@@ -202,6 +268,35 @@
     <string name="permission_premium_sms_services_description">ऐप्स को प्रीमियम टेक्स्ट मैसेजिंग सेवाओं का उपयोग करने की अनुमति देता है। इससे आपका पैसा खर्च होगा।</string>
     <string name="permission_unlimited_data_access_label">असीमित डेटा पहुंच</string>
     <string name="permission_unlimited_data_access_description">ऐप्स को असीमित डेटा तक पहुंचने की अनुमति देता है। जब डेटा सेवर चालू हो तब भी ऐप्स डेटा खर्च कर सकते हैं।</string>
+    <string name="permission_bind_accessibility_service_description">ऐप को एक एक्सेसिबिलिटी सेवा प्रदान करने की अनुमति देता है जिसे सिस्टम सेटिंग्स में सक्षम किया जा सकता है।</string>
+    <string name="permission_bind_accessibility_service_label">एक्सेसिबिलिटी सेवा प्रदान करें</string>
+    <string name="permission_bluetooth_advertise_description">ऐप्स को पास के Bluetooth उपकरणों को विज्ञापित करने की अनुमति देता है।</string>
+    <string name="permission_bluetooth_advertise_label">Bluetooth विज्ञापन</string>
+    <string name="permission_manage_media_description">ऐप्स को आपसे पूछे बिना अन्य ऐप्स द्वारा बनाई गई मीडिया फ़ाइलों को संशोधित या हटाने की अनुमति देता है। ऐप्स के पास फ़ाइलों और मीडिया तक पहुंचने की अनुमति होनी चाहिए।</string>
+    <string name="permission_manage_media_label">मीडिया प्रबंधित करें</string>
+    <string name="permission_modify_system_settings_description">ऐप्स को सिस्टम की सेटिंग्स डेटा को संशोधित करने की अनुमति देता है। दुर्भावनापूर्ण ऐप्स आपके सिस्टम के कॉन्फ़िगरेशन को दूषित कर सकते हैं।</string>
+    <string name="permission_modify_system_settings_label">सिस्टम सेटिंग्स संशोधित करें</string>
+    <string name="permission_nfc_description">ऐप्स को Near Field Communication (NFC) टैग, कार्ड और रीडर के साथ संवाद करने की अनुमति देता है।</string>
+    <string name="permission_nfc_label">NFC</string>
+    <string name="permission_picture_in_picture_label">पिक्चर इन पिक्चर</string>
+    <string name="permission_reboot_description">ऐप को डिवाइस को रीबूट करने की अनुमति देता है। केवल सिस्टम ऐप्स के लिए उपलब्ध।</string>
+    <string name="permission_reboot_label">डिवाइस रीबूट करें</string>
+    <string name="permission_usage_data_access_description">ऐप्स को ट्रैक करने की अनुमति देता है कि आप कौन से अन्य ऐप्स उपयोग करते हैं और कितनी बार, आपके सेवा प्रदाता, भाषा सेटिंग्स और अन्य उपयोग डेटा की पहचान करने की।</string>
+    <string name="permission_usage_data_access_label">उपयोग डेटा पहुंच</string>
+
+    <string name="permission_group_apps_description">विशेष पहुंच अनुमतियां जिनके लिए स्पष्ट उपयोगकर्ता सहमति आवश्यक है।</string>
+    <string name="permission_group_apps_label">ऐप्स</string>
+    <string name="permission_group_audio_description">माइक्रोफ़ोन संबंधित अनुमतियां।</string>
+    <string name="permission_group_audio_label">माइक्रोफ़ोन</string>
+    <string name="permission_group_battery_description">बैटरी संबंधित अनुमतियां।</string>
+    <string name="permission_group_battery_label">बैटरी</string>
+    <string name="permission_group_calls_description">कॉल संबंधित अनुमतियां</string>
+    <string name="permission_group_camera_description">कैमरा संबंधित अनुमतियां।</string>
+    <string name="permission_group_camera_label">कैमरा</string>
+    <string name="permission_group_contacts_description">"संपर्क पढ़ना और लिखना।"</string>
+    <string name="permission_group_contacts_label">संपर्क</string>
+    <string name="permission_group_location_description">स्थान संबंधित अनुमतियां।</string>
+    <string name="permission_group_location_label">स्थान</string>
     <string name="permission_group_calendar_label">कैलेंडर</string>
     <string name="permission_group_calendar_description"><![CDATA[कैलेंडर संबंधी अनुमतियां, जैसे प्रविष्टियों को देखना और संपादित करना।]]></string>
     <string name="permission_group_files_label">फ़ाइलें और मीडिया</string>
@@ -215,4 +310,25 @@
     <string name="permission_group_sensors_label">सेंसर</string>
     <string name="permission_group_sensors_description">एक्सेलेरोमीटर, जायरोस्कोप, शरीर सेंसर, गतिविधि पहचान और अन्य। आपका डिवाइस इनपुट एकत्र करने के तरीके।</string>
     <string name="permission_group_calls_label">कॉल</string>
+
+    <plurals name="generic_x_apps_label">
+        <item quantity="one">%d ऐप</item>
+        <item quantity="other">%d ऐप्स</item>
+    </plurals>
+    <plurals name="generic_x_apps_system_label">
+        <item quantity="one">%d सिस्टम ऐप</item>
+        <item quantity="other">%d सिस्टम ऐप्स</item>
+    </plurals>
+    <plurals name="generic_x_apps_user_label">
+        <item quantity="one">%d उपयोगकर्ता ऐप</item>
+        <item quantity="other">%d उपयोगकर्ता ऐप्स</item>
+    </plurals>
+    <plurals name="generic_x_groups_label">
+        <item quantity="one">%s समूह</item>
+        <item quantity="other">%s समूह</item>
+    </plurals>
+    <plurals name="generic_x_items_label">
+        <item quantity="one">%s आइटम</item>
+        <item quantity="other">%s आइटम</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -4,6 +4,8 @@
     <string name="label_settings">Configurações</string>
     <string name="label_help">Ajuda</string>
     <string name="general_error_label">Erro</string>
+    <string name="general_accept_action">Aceitar</string>
+    <string name="general_continue_action">Continuar</string>
     <string name="general_share_action">Compartilhe</string>
     <string name="general_done_action">Feito</string>
     <string name="general_copy_action">Copiar</string>
@@ -19,6 +21,7 @@
     <string name="debug_debuglog_size_compressed_label">Tamanho compactado</string>
     <string name="debug_notification_channel_label">Notificações de depuração</string>
     <string name="debug_debuglog_file_label">Arquivo de depuração salvo</string>
+    <string name="debug_debuglog_sensitive_information_message">Este ficheiro contém informação sensível (por exemplo, as suas aplicações instaladas). Partilhe-o apenas com entidades de confiança.</string>
     <string name="debug_debuglog_record_action">Registrar um log de depuração</string>
     <string name="settings_category_other_label">Outro</string>
     <string name="general_settings_label">Geral</string>
@@ -108,6 +111,7 @@
     <string name="apps_filter_multipleprofiles_label">Apps que estão clonados</string>
     <string name="support_debuglog_label">Registro de depuração</string>
     <string name="support_debuglog_desc">Registre tudo o que app está fazendo num arquivo de texto que você pode compartilhar.</string>
+    <string name="settings_debuglog_explanation">Esta funcionalidade regista tudo o que a aplicação está a fazer num ficheiro partilhável. O ficheiro gerado contém informação sensível (por exemplo, as suas aplicações instaladas). Partilhe-o apenas com entidades de confiança (por exemplo, o programador da aplicação se estiver a resolver um problema em conjunto).</string>
     <string name="updated_at_x">Última atualização: %s</string>
     <string name="installed_at_x">Primeira instalação: %s</string>
     <string name="apps_sort_install_source_label">Fonte da instalação</string>
@@ -123,9 +127,26 @@
     <string name="api_build_level_x">Versão da compilação: %s</string>
     <string name="permission_reboot_label">Reiniciar dispositivo</string>
     <string name="permission_reboot_description">Permite que o app reinicie o dispositivo. Disponível apenas para apps do sistema.</string>
+    <string name="permission_bind_accessibility_service_label">Oferecer serviço de acessibilidade</string>
+    <string name="permission_bind_accessibility_service_description">Permite que a aplicação ofereça um serviço de acessibilidade que pode ser ativado nas definições do sistema.</string>
+    <string name="permission_picture_in_picture_label">Imagem em Imagem</string>
     <string name="permissions_sort_apps_relevance_label">Relevância</string>
     <string name="apps_filter_profile_active_label">Apps em perfil ativo</string>
     <string name="overview_page_label">Visão geral</string>
+    <string name="overview_device_name_label">Dispositivo</string>
+    <string name="overview_device_android_version_label">Versão do Android</string>
+    <string name="overview_device_android_patch_label">Nível de correção</string>
+    <string name="overview_summary_apps_active_profile_label">Aplicações no Perfil Ativo</string>
+    <string name="overview_summary_apps_other_profile_label">Aplicações em Perfil(s) de Utilizador Gerido(s), excluindo Clones</string>
+    <string name="overview_summary_apps_clones_label">Aplicações com clones noutros perfis</string>
+    <string name="overview_summary_apps_sideloaded_label">Aplicações instaladas de fontes externas</string>
+    <string name="overview_summary_apps_installers_label">Aplicações com \'Instalar de Fontes Desconhecidas\' ativado</string>
+    <string name="overview_summary_apps_overlayers_label">Aplicações que podem \'Aparecer por Cima\'</string>
+    <string name="overview_summary_apps_offline_label">Aplicações que têm permissões \'Sem Internet\'</string>
+    <string name="overview_summary_apps_sharedids_label">Aplicações com SharedUserID</string>
+    <string name="onboarding_body1">Esta aplicação ajuda-o a navegar pelas aplicações instaladas e a descobrir permissões.</string>
+    <string name="onboarding_body2">O Permission Pilot recolhe informações sobre Aplicações Instaladas para permitir listar as suas aplicações e fazer referência cruzada das suas permissões ao utilizar esta aplicação.</string>
+    <string name="onboarding_body3">O Permission Pilot não tem anúncios e processa dados apenas localmente.</string>
     <plurals name="generic_x_items_label">
         <item quantity="one">%s item</item>
         <item quantity="other">%s itens</item>
@@ -220,4 +241,9 @@
     <string name="permission_group_apps_label">Apps</string>
     <string name="permission_group_apps_description">Permissões especiais que requerem consentimento explícito do usuário.</string>
     <string name="permission_group_battery_label">Bateria</string>
+    <string name="permission_group_battery_description">Permissões relacionadas com a bateria.</string>
+    <string name="permission_group_audio_label">Microfone</string>
+    <string name="permission_group_audio_description">Permissões relacionadas com o microfone.</string>
+    <string name="permission_group_camera_label">Câmara</string>
+    <string name="permission_group_camera_description">Permissões relacionadas com a câmara.</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -436,4 +436,139 @@
     <string name="permission_group_calendar_label">Calendar</string>
     <string name="permission_group_calendar_description"><![CDATA[Permisiuni legate de calendar, de ex. vizualizarea și editarea intrărilor.]]></string>
     <string name="permission_group_files_label">Fișiere și media</string>
+    <string name="permission_group_files_description">Permisiuni legate de fișiere. Acces la stocare, documente și media.</string>
+    <string name="permission_group_other_label">Altele</string>
+    <string name="permission_group_other_description">Alte permisiuni fără categorie specifică.</string>
+    <string name="permission_group_messaging_label">Mesagerie</string>
+    <string name="permission_group_messaging_description">SMS, MMS și altele. Tot ce ține de mesagerie.</string>
+    <string name="permission_group_connectivity_label">Conectivitate</string>
+    <string name="permission_group_connectivity_description">WiFi, LTE, Bluetooth și altele. Permisiuni legate de comunicarea cu lumea exterioară.</string>
+    <string name="permission_group_sensors_label">Senzori</string>
+    <string name="permission_group_sensors_description">Accelerometru, giroscop, senzori corporali, recunoașterea activității și altele. Moduri prin care dispozitivul poate capta date.</string>
+    <string name="permission_group_calls_label">Apeluri</string>
+    <string name="permission_group_calls_description">Permisiuni legate de apeluri.</string>
+    <string name="permission_group_location_label">Locație</string>
+    <string name="permission_group_location_description">Permisiuni legate de locație.</string>
+    <string name="permission_group_contacts_label">Contacte</string>
+    <string name="permission_group_contacts_description">"Citirea și scrierea contactelor."</string>
+    <string name="permission_group_apps_label">Aplicații</string>
+    <string name="permission_group_apps_description">Permisiuni de acces special care necesită consimțământ explicit al utilizatorului.</string>
+    <string name="permission_group_battery_label">Baterie</string>
+    <string name="permission_group_battery_description">Permisiuni legate de baterie.</string>
+    <string name="permission_group_camera_label">Cameră</string>
+    <string name="permission_group_camera_description">Permisiuni legate de cameră.</string>
+    <string name="permission_group_audio_label">Microfon</string>
+    <string name="permission_group_audio_description">Permisiuni legate de microfon.</string>
+    <string name="permission_picture_in_picture_label">Imagine în imagine</string>
+    <string name="permission_nfc_label">NFC</string>
+    <string name="permission_nfc_description">Permite aplicațiilor să comunice cu etichete, carduri și cititoare NFC (Near Field Communication).</string>
+    <string name="permission_manage_media_label">Gestionare media</string>
+    <string name="permission_manage_media_description">Permite aplicațiilor să modifice sau să șteargă fișiere media create cu alte aplicații FĂRĂ a vă întreba. Aplicațiile trebuie să aibă permisiunea de a accesa fișiere și media.</string>
+    <string name="permission_usage_data_access_label">Acces la datele de utilizare</string>
+    <string name="permission_usage_data_access_description">Permite aplicațiilor să urmărească ce alte aplicații utilizați și cât de des, să identifice furnizorul de servicii, setările de limbă și alte date de utilizare.</string>
+    <string name="permission_modify_system_settings_label">Modificare setări sistem</string>
+    <string name="permission_modify_system_settings_description">Permite aplicațiilor să modifice datele de setări ale sistemului. Aplicațiile malițioase pot corupe configurația sistemului.</string>
+    <string name="permission_bluetooth_advertise_label">Publicitate Bluetooth</string>
+    <string name="permission_bluetooth_advertise_description">Permite aplicațiilor să facă publicitate către dispozitivele Bluetooth din apropiere.</string>
+    <string name="permission_reboot_label">Repornire dispozitiv</string>
+    <string name="permission_reboot_description">Permite aplicației să repornească dispozitivul. Disponibil doar pentru aplicațiile de sistem.</string>
+    <string name="permission_bind_accessibility_service_label">Oferire serviciu de accesibilitate</string>
+    <string name="permission_bind_accessibility_service_description">Permite aplicației să ofere un serviciu de accesibilitate care poate fi activat din setările sistemului.</string>
+
+    <string name="api_build_level_x">Versiune de compilare: %s</string>
+    <string name="api_minimum_level_x">Versiune minimă: %s</string>
+    <string name="api_target_level_x">Versiune țintă: %s</string>
+
+    <string name="apps_app_details_label">Detalii aplicație</string>
+    <string name="apps_details_description_primary_description">"%1$d din %2$d permisiuni acordate."</string>
+    <string name="apps_details_description_restrictions_caveat_description">Această aplicație este instalată într-un alt profil de utilizator. Permisiunile acordate pot fi determinate doar pentru aplicațiile instalate în Profilul Activ curent, din cauza restricțiilor Android.</string>
+    <string name="apps_details_description_secondary_description">"%d permisiuni solicitate."</string>
+    <string name="apps_details_shareduserid_label">Aplicații cu ID Utilizator Partajat</string>
+    <string name="apps_details_siblings_label">Aplicații înrudite</string>
+    <string name="apps_details_twins_descriptions">Instalat în alt(e) profil(uri) de utilizator.</string>
+    <string name="apps_details_twins_label">Clone</string>
+
+    <string name="apps_filter_accessibility_label">Aplicații cu servicii de accesibilitate</string>
+    <string name="apps_filter_battery_optimization_label">Aplicații cu opțiuni personalizate de baterie</string>
+    <string name="apps_filter_multipleprofiles_label">Aplicații cu Clone</string>
+    <string name="apps_filter_profile_active_label">Aplicații în profilul Activ</string>
+    <string name="apps_filter_profile_secondary_label">Aplicații în Profil(uri) Administrat(e)</string>
+    <string name="apps_filter_sharedid_label">ID Utilizator Partajat</string>
+
+    <string name="apps_known_android_system_label">Sistem Android</string>
+    <string name="apps_known_installer_gplay_label">Google Play Store</string>
+    <string name="apps_known_installer_huawei_label">Huawei AppGallery</string>
+    <string name="apps_known_installer_oppo_label">Oppo App Market</string>
+    <string name="apps_known_installer_samsung_label">Samsung Galaxy Store</string>
+    <string name="apps_known_installer_vivo_label">Vivo V-AppStore</string>
+    <string name="apps_known_installer_xiaomi_label">Xiaomi GetApps</string>
+    <string name="apps_sort_install_source_label">Sursă de instalare</string>
+
+    <string name="generic_loading_label_0">În curând™</string>
+    <string name="generic_loading_label_1">Întindem untul</string>
+    <string name="generic_loading_label_2">Descărcăm mai multă memorie RAM</string>
+    <string name="generic_loading_label_3">Tot mai rapid decât un iPhone</string>
+    <string name="generic_loading_label_4">Ce-i acolo în spatele tău?</string>
+    <string name="generic_loading_label_5">Procesorul ia o pauză de cafea</string>
+    <string name="generic_loading_label_6">Așteptăm date de la Pepe Silvia</string>
+    <string name="generic_loading_label_7">Turbo encabulatorul se inițializează</string>
+
+    <string name="install_date_label">Data instalării</string>
+    <string name="installed_at_x">Prima instalare: %s</string>
+    <string name="updated_at_x">Ultima actualizare: %s</string>
+
+    <string name="overview_page_label">Prezentare generală</string>
+    <string name="overview_device_android_patch_label">Nivel patch</string>
+    <string name="overview_device_android_version_label">Versiune Android</string>
+    <string name="overview_device_name_label">Dispozitiv</string>
+    <string name="overview_summary_apps_active_profile_label">Aplicații în Profilul Activ</string>
+    <string name="overview_summary_apps_clones_label">Aplicații cu clone în alte profiluri</string>
+    <string name="overview_summary_apps_installers_label">Aplicații cu \'Instalare din Surse Necunoscute\' activată</string>
+    <string name="overview_summary_apps_offline_label">Aplicații cu permisiuni \'Fără Internet\'</string>
+    <string name="overview_summary_apps_other_profile_label">Aplicații în Profil(uri) de Utilizator Administrat(e), excluzând Clone</string>
+    <string name="overview_summary_apps_overlayers_label">Aplicații care pot \'Apărea Deasupra\'</string>
+    <string name="overview_summary_apps_sharedids_label">Aplicații cu SharedUserID</string>
+    <string name="overview_summary_apps_sideloaded_label">Aplicații încărcate lateral din surse externe</string>
+
+    <string name="debug_debuglog_sensitive_information_message">Acest fișier conține informații sensibile (de ex. aplicațiile instalate). Partajați-l doar cu persoane de încredere.</string>
+    <string name="settings_debuglog_explanation">Această funcție înregistrează tot ce face aplicația într-un fișier care poate fi partajat. Fișierul generat conține informații sensibile (de ex. aplicațiile instalate). Partajați-l doar cu persoane de încredere (de ex. dezvoltatorul aplicației dacă depanați o problemă împreună).</string>
+    <string name="support_debuglog_label">Jurnal de depanare</string>
+    <string name="support_debuglog_desc">Înregistrați tot ce face aplicația într-un fișier text pe care îl puteți partaja.</string>
+
+    <string name="onboarding_body1">Această aplicație vă ajută să navigați prin aplicațiile instalate și să descoperiți permisiunile.</string>
+    <string name="onboarding_body2">Permission Pilot colectează informații despre aplicațiile instalate pentru a permite listarea aplicațiilor și compararea permisiunilor acestora când utilizați această aplicație.</string>
+    <string name="onboarding_body3">Permission Pilot nu are reclame și procesează datele doar local.</string>
+
+    <string name="permissions_permission_details_label">Detalii permisiune</string>
+    <string name="permissions_action_none_msg">Nicio acțiune disponibilă pentru această permisiune</string>
+    <string name="permissions_sort_apps_relevance_label">Relevanță</string>
+    <string name="permissions_details_count_user_apps">"Aplicații de utilizator: Acordate la %1$d din %2$d."</string>
+    <string name="permissions_details_count_system_apps">"Aplicații de sistem: Acordate la %1$d din %2$d."</string>
+    <string name="permissions_details_description_restrictions_caveat_description">Aplicațiile instalate în alte profiluri de utilizator sunt excluse din calculul de mai sus din cauza restricțiilor Android.</string>
+
+    <plurals name="generic_x_items_label">
+        <item quantity="one">%s element</item>
+        <item quantity="few">%s elemente</item>
+        <item quantity="other">%s de elemente</item>
+    </plurals>
+    <plurals name="generic_x_groups_label">
+        <item quantity="one">%s grup</item>
+        <item quantity="few">%s grupuri</item>
+        <item quantity="other">%s de grupuri</item>
+    </plurals>
+    <plurals name="generic_x_apps_label">
+        <item quantity="one">%d aplicație</item>
+        <item quantity="few">%d aplicații</item>
+        <item quantity="other">%d de aplicații</item>
+    </plurals>
+    <plurals name="generic_x_apps_user_label">
+        <item quantity="one">%d aplicație de utilizator</item>
+        <item quantity="few">%d aplicații de utilizator</item>
+        <item quantity="other">%d de aplicații de utilizator</item>
+    </plurals>
+    <plurals name="generic_x_apps_system_label">
+        <item quantity="one">%d aplicație de sistem</item>
+        <item quantity="few">%d aplicații de sistem</item>
+        <item quantity="other">%d de aplicații de sistem</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -6,6 +6,8 @@
 
     <string name="general_error_label">Ошибка</string>
 
+    <string name="general_accept_action">Принять</string>
+    <string name="general_continue_action">Продолжить</string>
     <string name="general_share_action">Поделиться</string>
     <string name="general_done_action">Готово</string>
     <string name="general_copy_action">Копировать</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -14,6 +14,7 @@
     <string name="general_open_action">Otvoriť</string>
     <string name="general_continue_action">Pokračovať</string>
     <string name="general_accept_action">Prijať</string>
+    <string name="general_refresh_action">Obnoviť</string>
 
     <string name="upgrade_myperm_label">Aktualizovať Permission Pilot</string>
     <string name="upgrade_myperm_description">Páči sa vám, že táto aplikácia nemá reklamy a nezbiera vaše údaje?\nKúpte si pro verziu na podporu vývoja!</string>
@@ -63,6 +64,12 @@
     <string name="apps_filter_sideloaded_label">Bočne načítané aplikácie</string>
     <string name="apps_filter_gplay_label">Google Play Store</string>
     <string name="apps_filter_oemstore_label">OEM Store</string>
+    <string name="apps_filter_accessibility_label">Aplikácie so službami prístupnosti</string>
+    <string name="apps_filter_battery_optimization_label">Aplikácie s vlastnými možnosťami batérie</string>
+    <string name="apps_filter_multipleprofiles_label">Aplikácie s klonmi</string>
+    <string name="apps_filter_profile_active_label">Aplikácie v aktívnom profile</string>
+    <string name="apps_filter_profile_secondary_label">Aplikácie v spravovaných profiloch</string>
+    <string name="apps_filter_sharedid_label">Zdieľané ID používateľa</string>
 
     <string name="apps_sort_permissions_granted_label">Udelené oprávnenia</string>
     <string name="apps_sort_permissions_requested_label">Požadované oprávnenia</string>
@@ -70,6 +77,7 @@
     <string name="apps_sort_app_name_label">Názov aplikácie</string>
     <string name="apps_sort_install_date_label">Dátum inštalácie</string>
     <string name="apps_sort_update_date_label">Posledná aktualizácia</string>
+    <string name="apps_sort_install_source_label">Zdroj inštalácie</string>
 
     <string name="general_sort_action">Triediť</string>
     <string name="apps_permissions_x_of_x_granted">%1$d z %2$d udelených.</string>
@@ -89,6 +97,7 @@
 
     <string name="permissions_sort_apps_granted_label"># aplikácií s udeleným oprávnením</string>
     <string name="permissions_sort_apps_requested_label"># aplikácií požadujúcich</string>
+    <string name="permissions_sort_apps_relevance_label">Relevancia</string>
     <string name="permissions_search_list_hint">Hľadať oprávnenia</string>
     <string name="apps_search_list_hint">Hľadať aplikácie</string>
     <string name="permissions_details_protection_label">Úroveň ochrany</string>
@@ -109,6 +118,11 @@
     <string name="permissions_details_apps_granted_label">Aplikácie s udelenými oprávneniami</string>
     <string name="permissions_details_apps_requested_label">Aplikácie požadujúce oprávnenia</string>
     <string name="permissions_details_apps_declared_label">Aplikácie deklarujúce oprávnenia</string>
+    <string name="permissions_details_count_system_apps">"Systémové aplikácie: Udelené %1$d z %2$d."</string>
+    <string name="permissions_details_count_user_apps">"Používateľské aplikácie: Udelené %1$d z %2$d."</string>
+    <string name="permissions_details_description_restrictions_caveat_description">Aplikácie nainštalované v iných používateľských profiloch sú z výpočtu vyššie vylúčené kvôli obmedzeniam Androidu.</string>
+    <string name="permissions_permission_details_label">Podrobnosti oprávnenia</string>
+    <string name="permissions_action_none_msg">Pre toto oprávnenie nie je dostupná žiadna akcia</string>
 
     <string name="app_details_permission_granted_label">Udelené</string>
     <string name="app_details_permission_requested_label">Požadované</string>
@@ -140,7 +154,17 @@
     <string name="apps_details_apk_size_label">Veľkosť APK</string>
 
     <string name="apps_details_overview_label">Prehľad</string>
+    <string name="apps_app_details_label">Podrobnosti aplikácie</string>
+    <string name="apps_details_description_primary_description">"%1$d z %2$d oprávnení udelených."</string>
+    <string name="apps_details_description_restrictions_caveat_description">Táto aplikácia je nainštalovaná v inom používateľskom profile. Udelené oprávnenia možno zistiť len pre aplikácie nainštalované v aktuálne aktívnom profile kvôli obmedzeniam Androidu.</string>
+    <string name="apps_details_description_secondary_description">"%d oprávnení požadovaných."</string>
+    <string name="apps_details_shareduserid_label">Aplikácie so Shared User ID</string>
+    <string name="apps_details_siblings_label">Súrodenci</string>
+    <string name="apps_details_twins_descriptions">Nainštalované v iných používateľských profiloch.</string>
+    <string name="apps_details_twins_label">Klony</string>
+
     <string name="overview_label">Prehľad</string>
+    <string name="overview_page_label">Prehľad</string>
     <string name="overview_summary_label">Súhrn</string>
     <string name="overview_apps_label">Aplikácie</string>
     <string name="overview_permissions_label">Oprávnenia</string>
@@ -198,10 +222,22 @@
     <string name="permission_do_not_disturb_permission_description">Umožňuje aplikáciám zapínať/vypínať režim Nerušiť (DND) a meniť súvisiace nastavenia.</string>
     <string name="permission_alarms_and_reminders_label">Budíky a pripomienky</string>
     <string name="permission_alarms_and_reminders_description">Umožňuje aplikáciám nastavovať budíky a plánovať časovo citlivé akcie. Umožňuje aplikáciám bežať na pozadí, čo môže spotrebovať viac batérie. Vypnutie tohto oprávnenia pre aplikáciu spôsobí, že naplánované budíky a časovo založené udalosti prestanú fungovať.</string>
-    <string name="permission_premium_sms_services_label">Prístup k prémilovým SMS službám</string>
+    <string name="permission_premium_sms_services_label">Prístup k prémiovým SMS službám</string>
     <string name="permission_premium_sms_services_description">Umožňuje aplikáciám používať prémiové textové služby. Bude vás to stáť peniaze.</string>
     <string name="permission_unlimited_data_access_label">Neobmedzený prístup k údajom</string>
     <string name="permission_unlimited_data_access_description">Umožňuje aplikáciám pristupovať k neobmedzeným údajom. Aplikácie môžu spotrebovávať údaje aj keď je Šetrič údajov ZAPNUTÝ.</string>
+    <string name="permission_bluetooth_advertise_label">Bluetooth inzercia</string>
+    <string name="permission_bluetooth_advertise_description">Umožňuje aplikáciám inzerovať blízkym Bluetooth zariadeniam.</string>
+    <string name="permission_manage_media_label">Správa médií</string>
+    <string name="permission_manage_media_description">Umožňuje aplikáciám upravovať alebo mazať mediálne súbory vytvorené inými aplikáciami BEZ vášho pýtania. Aplikácie musia mať oprávnenie na prístup k súborom a médiám.</string>
+    <string name="permission_modify_system_settings_label">Upraviť systémové nastavenia</string>
+    <string name="permission_modify_system_settings_description">Umožňuje aplikáciám upravovať údaje systémových nastavení. Škodlivé aplikácie môžu poškodiť konfiguráciu vášho systému.</string>
+    <string name="permission_nfc_label">NFC</string>
+    <string name="permission_nfc_description">Umožňuje aplikáciám komunikovať so značkami, kartami a čítačkami Near Field Communication (NFC).</string>
+    <string name="permission_reboot_label">Reštartovať zariadenie</string>
+    <string name="permission_reboot_description">Umožňuje aplikácii reštartovať zariadenie. Dostupné len pre systémové aplikácie.</string>
+    <string name="permission_usage_data_access_label">Prístup k údajom o používaní</string>
+    <string name="permission_usage_data_access_description">Umožňuje aplikáciám sledovať, aké iné aplikácie používate a ako často, identifikovať vášho poskytovateľa služieb, nastavenia jazyka a ďalšie údaje o používaní.</string>
     <string name="permission_group_calendar_label">Kalendár</string>
     <string name="permission_group_calendar_description"><![CDATA[Oprávnenia súvisiace s kalendárom, napr. zobrazovanie a úprava záznamov.]]></string>
     <string name="permission_group_files_label">Súbory a médiá</string>
@@ -231,7 +267,7 @@
     <string name="permission_picture_in_picture_label">Obraz v obraze</string>
     <string name="overview_device_android_version_label">Verzia Androidu</string>
     <string name="overview_device_name_label">Zariadenie</string>
-    <string name="overview_device_android_patch_label">Úroveň oprávky</string>
+    <string name="overview_device_android_patch_label">Úroveň opravy</string>
     <string name="overview_summary_apps_active_profile_label">Aplikácie v aktívnom profile</string>
     <string name="overview_summary_apps_other_profile_label">Aplikácie v spravovaných používateľských profiloch, okrem klonov</string>
     <string name="overview_summary_apps_sideloaded_label">Aplikácie načítané z externých zdrojov</string>
@@ -247,4 +283,65 @@
     <string name="onboarding_body1">Táto aplikácia vám pomáha prechádzať nainštalovanými aplikáciami a objavovať oprávnenia.</string>
     <string name="onboarding_body2">Permission Pilot zbiera informácie o nainštalovaných aplikáciách, aby umožnil výpis vašich aplikácií a krížové referencovanie ich oprávnení pri používaní tejto aplikácie.</string>
     <string name="onboarding_body3">Permission Pilot nemá reklamy a spracováva údaje len lokálne.</string>
+
+    <string name="apps_known_android_system_label">Android System</string>
+    <string name="apps_known_installer_gplay_label">Google Play Store</string>
+    <string name="apps_known_installer_huawei_label">Huawei AppGallery</string>
+    <string name="apps_known_installer_oppo_label">Oppo App Market</string>
+    <string name="apps_known_installer_samsung_label">Samsung Galaxy Store</string>
+    <string name="apps_known_installer_vivo_label">Vivo V-AppStore</string>
+    <string name="apps_known_installer_xiaomi_label">Xiaomi GetApps</string>
+
+    <string name="api_build_level_x">Kompilačná verzia: %s</string>
+    <string name="api_minimum_level_x">Minimálna verzia: %s</string>
+    <string name="api_target_level_x">Cieľová verzia: %s</string>
+
+    <string name="install_date_label">Dátum inštalácie</string>
+    <string name="installed_at_x">Prvá inštalácia: %s</string>
+    <string name="updated_at_x">Naposledy aktualizované: %s</string>
+
+    <string name="support_debuglog_label">Ladiaci denník</string>
+    <string name="support_debuglog_desc">Zaznamenajte všetko, čo aplikácia robí, do textového súboru, ktorý môžete zdieľať.</string>
+
+    <!-- Humorous loading labels -->
+    <string name="generic_loading_label_0">Čoskoro(TM)</string>
+    <string name="generic_loading_label_1">Podávam maslo</string>
+    <string name="generic_loading_label_2">Sťahujem ďalšiu RAM</string>
+    <string name="generic_loading_label_3">Stále rýchlejšie ako iPhone</string>
+    <string name="generic_loading_label_4">Čo je to za tebou?</string>
+    <string name="generic_loading_label_5">CPU si dáva kávu</string>
+    <string name="generic_loading_label_6">Čakám na dáta od Pepe Silvia</string>
+    <string name="generic_loading_label_7">Turbo enkabulátor sa inicializuje</string>
+
+    <!-- Plurals -->
+    <plurals name="generic_x_apps_label">
+        <item quantity="one">%d aplikácia</item>
+        <item quantity="few">%d aplikácie</item>
+        <item quantity="many">%d aplikácií</item>
+        <item quantity="other">%d aplikácií</item>
+    </plurals>
+    <plurals name="generic_x_apps_system_label">
+        <item quantity="one">%d systémová aplikácia</item>
+        <item quantity="few">%d systémové aplikácie</item>
+        <item quantity="many">%d systémových aplikácií</item>
+        <item quantity="other">%d systémových aplikácií</item>
+    </plurals>
+    <plurals name="generic_x_apps_user_label">
+        <item quantity="one">%d používateľská aplikácia</item>
+        <item quantity="few">%d používateľské aplikácie</item>
+        <item quantity="many">%d používateľských aplikácií</item>
+        <item quantity="other">%d používateľských aplikácií</item>
+    </plurals>
+    <plurals name="generic_x_groups_label">
+        <item quantity="one">%s skupina</item>
+        <item quantity="few">%s skupiny</item>
+        <item quantity="many">%s skupín</item>
+        <item quantity="other">%s skupín</item>
+    </plurals>
+    <plurals name="generic_x_items_label">
+        <item quantity="one">%s položka</item>
+        <item quantity="few">%s položky</item>
+        <item quantity="many">%s položiek</item>
+        <item quantity="other">%s položiek</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
## Summary
- Completes missing translations to bring all 36 locales to 100% coverage
- Adds translations for: Russian, Czech, Greek, Portuguese, Danish, Finnish, Slovak, Hindi, and Romanian
- Total of ~430 new string translations added

## Changes by locale

| Locale | Language | Strings Added |
|--------|----------|---------------|
| ru | Russian | 2 |
| cs | Czech | 7 |
| el | Greek | 7 |
| pt | Portuguese (European) | 26 |
| da | Danish | 68 (incl. plurals) |
| fi | Finnish | 68 (incl. plurals) |
| sk | Slovak | 68 (incl. plurals) |
| hi | Hindi | 100 (incl. plurals) |
| ro | Romanian | 109 (incl. plurals) |

## Test plan
- [x] Build passes (`./gradlew assembleDebug`)
- [ ] Verify translations display correctly on device for affected locales