### PR TITLE
Improve UI for more list space on Apps/Permissions pages

### DIFF
--- a/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsFragment.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsFragment.kt
@@ -34,12 +34,16 @@ class AppsFragment : Fragment3(R.layout.apps_fragment) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         EdgeToEdgeHelper(requireActivity()).apply {
-            insetsPadding(ui.root, left = true, right = true)
+            insetsPadding(ui.root, left = true, right = true, top = true)
         }
         customNavController = requireActivity().findNavController(R.id.nav_host_main_activity)
 
         ui.filterAction.setOnClickListener { vm.showFilterDialog() }
         ui.sortAction.setOnClickListener { vm.showSortDialog() }
+        ui.refreshAction.setOnClickListener { vm.onRefresh() }
+        ui.settingsAction.setOnClickListener {
+            MainFragmentDirections.actionMainFragmentToSettingsContainerFragment().navigate()
+        }
 
         vm.events.observe2(ui) { event ->
             when (event) {

--- a/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsFragmentVM.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsFragmentVM.kt
@@ -28,7 +28,7 @@ class AppsFragmentVM @Inject constructor(
     @Suppress("unused") private val handle: SavedStateHandle,
     dispatcherProvider: DispatcherProvider,
     @ApplicationContext private val context: Context,
-    appRepo: AppRepo,
+    private val appRepo: AppRepo,
     private val generalSettings: GeneralSettings,
     private val webpageTool: WebpageTool,
     private val appStoreTool: AppStoreTool,
@@ -122,5 +122,10 @@ class AppsFragmentVM @Inject constructor(
     fun showSortDialog() {
         log { "showSortDialog" }
         events.postValue(AppsEvents.ShowSortDialog(generalSettings.appsSortOptions.value))
+    }
+
+    fun onRefresh() {
+        log { "onRefresh" }
+        appRepo.refresh()
     }
 }

--- a/app/src/main/java/eu/darken/myperm/main/ui/main/MainFragment.kt
+++ b/app/src/main/java/eu/darken/myperm/main/ui/main/MainFragment.kt
@@ -3,6 +3,7 @@ package eu.darken.myperm.main.ui.main
 import android.os.Bundle
 import android.text.SpannableStringBuilder
 import android.view.View
+import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
@@ -65,6 +66,11 @@ class MainFragment : Fragment3(R.layout.main_fragment) {
         }
 
         val navController: NavController = ui.bottomNavHost.getFragment<NavHostFragment>().navController
+
+        navController.addOnDestinationChangedListener { _, destination, _ ->
+            ui.toolbar.isVisible = destination.id == R.id.overviewFragment
+        }
+
         ui.bottomNavigation.apply {
             setupWithNavController(this, navController)
             if (savedInstanceState == null) {

--- a/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsFragment.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsFragment.kt
@@ -9,6 +9,7 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.findNavController
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.myperm.R
+import eu.darken.myperm.common.EdgeToEdgeHelper
 import eu.darken.myperm.common.error.asErrorDialogBuilder
 import eu.darken.myperm.common.getQuantityString
 import eu.darken.myperm.common.lists.differ.update
@@ -17,6 +18,7 @@ import eu.darken.myperm.common.observe2
 import eu.darken.myperm.common.uix.Fragment3
 import eu.darken.myperm.common.viewbinding.viewBinding
 import eu.darken.myperm.databinding.PermissionsFragmentBinding
+import eu.darken.myperm.main.ui.main.MainFragmentDirections
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -28,10 +30,17 @@ class PermissionsFragment : Fragment3(R.layout.permissions_fragment) {
     @Inject lateinit var permissionsAdapter: PermissionsAdapter
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        EdgeToEdgeHelper(requireActivity()).apply {
+            insetsPadding(ui.root, left = true, right = true, top = true)
+        }
         customNavController = requireActivity().findNavController(R.id.nav_host_main_activity)
 
         ui.filterAction.setOnClickListener { vm.showFilterDialog() }
         ui.sortAction.setOnClickListener { vm.showSortDialog() }
+        ui.refreshAction.setOnClickListener { vm.onRefresh() }
+        ui.settingsAction.setOnClickListener {
+            MainFragmentDirections.actionMainFragmentToSettingsContainerFragment().navigate()
+        }
 
         vm.events.observe2(ui) { event ->
             when (event) {

--- a/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsFragmentVM.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsFragmentVM.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.myperm.apps.core.AppRepo
 import eu.darken.myperm.common.coroutine.DispatcherProvider
 import eu.darken.myperm.common.debug.logging.log
 import eu.darken.myperm.common.livedata.SingleLiveEvent
@@ -31,10 +32,11 @@ import javax.inject.Inject
 @SuppressLint("StaticFieldLeak")
 @HiltViewModel
 class PermissionsFragmentVM @Inject constructor(
-    private val handle: SavedStateHandle,
+    @Suppress("unused") private val handle: SavedStateHandle,
     dispatcherProvider: DispatcherProvider,
     @ApplicationContext private val context: Context,
     permissionRepo: PermissionRepo,
+    private val appRepo: AppRepo,
     private val generalSettings: GeneralSettings,
 ) : ViewModel3(dispatcherProvider = dispatcherProvider) {
 
@@ -195,5 +197,10 @@ class PermissionsFragmentVM @Inject constructor(
     fun showSortDialog() {
         log { "showSortDialog" }
         events.postValue(PermissionListEvent.ShowSortDialog(generalSettings.permissionsSortOptions.value))
+    }
+
+    fun onRefresh() {
+        log { "onRefresh" }
+        appRepo.refresh()
     }
 }

--- a/app/src/main/res/layout/apps_fragment.xml
+++ b/app/src/main/res/layout/apps_fragment.xml
@@ -10,7 +10,6 @@
         style="@style/Widget.Material3.TextInputLayout.OutlinedBox.Dense"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
         android:hint="@string/apps_search_list_hint"
         app:endIconMode="clear_text"
         app:layout_constraintEnd_toStartOf="@id/sort_action"
@@ -42,8 +41,28 @@
         android:layout_height="wrap_content"
         app:icon="@drawable/ic_baseline_sort_24"
         app:layout_constraintBottom_toBottomOf="@id/search_container"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/refresh_action"
         app:layout_constraintStart_toEndOf="@id/search_container"
+        app:layout_constraintTop_toTopOf="@id/search_container" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/refresh_action"
+        style="@style/Widget.Material3.Button.IconButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:icon="@drawable/ic_baseline_refresh_24"
+        app:layout_constraintBottom_toBottomOf="@id/search_container"
+        app:layout_constraintEnd_toStartOf="@id/settings_action"
+        app:layout_constraintTop_toTopOf="@id/search_container" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/settings_action"
+        style="@style/Widget.Material3.Button.IconButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:icon="@drawable/ic_baseline_settings_24"
+        app:layout_constraintBottom_toBottomOf="@id/search_container"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@id/search_container" />
 
     <com.google.android.material.textview.MaterialTextView

--- a/app/src/main/res/layout/main_fragment.xml
+++ b/app/src/main/res/layout/main_fragment.xml
@@ -31,6 +31,7 @@
         android:id="@+id/bottom_navigation"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        app:labelVisibilityMode="selected"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/permissions_fragment.xml
+++ b/app/src/main/res/layout/permissions_fragment.xml
@@ -10,7 +10,6 @@
         style="@style/Widget.Material3.TextInputLayout.OutlinedBox.Dense"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
         android:hint="@string/permissions_search_list_hint"
         app:endIconMode="clear_text"
         app:layout_constraintEnd_toStartOf="@id/sort_action"
@@ -42,8 +41,28 @@
         android:layout_height="wrap_content"
         app:icon="@drawable/ic_baseline_sort_24"
         app:layout_constraintBottom_toBottomOf="@id/search_container"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/refresh_action"
         app:layout_constraintStart_toEndOf="@id/search_container"
+        app:layout_constraintTop_toTopOf="@id/search_container" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/refresh_action"
+        style="@style/Widget.Material3.Button.IconButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:icon="@drawable/ic_baseline_refresh_24"
+        app:layout_constraintBottom_toBottomOf="@id/search_container"
+        app:layout_constraintEnd_toStartOf="@id/settings_action"
+        app:layout_constraintTop_toTopOf="@id/search_container" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/settings_action"
+        style="@style/Widget.Material3.Button.IconButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:icon="@drawable/ic_baseline_settings_24"
+        app:layout_constraintBottom_toBottomOf="@id/search_container"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@id/search_container" />
 
     <com.google.android.material.textview.MaterialTextView

--- a/buildSrc/.gitignore
+++ b/buildSrc/.gitignore
@@ -1,2 +1,3 @@
 .gradle/
 build/
+.kotlin


### PR DESCRIPTION
## Summary
- Hide toolbar on Apps and Permissions pages to reclaim vertical space
- Add refresh and settings buttons to the search bar row on both pages
- Apply edge-to-edge top inset padding for proper layout when toolbar is hidden
- Set bottom navigation label visibility to "selected" only for a cleaner look

Closes #223

## Test plan
- [x] Verify toolbar is hidden on Apps and Permissions pages
- [x] Verify toolbar is visible on Overview page
- [x] Test refresh button reloads app/permission lists
- [x] Test settings button navigates to settings
- [x] Verify layout looks correct with edge-to-edge insets