### PR TITLE
Add user/system app filter to Permission Details screen

### DIFF
--- a/app/src/main/java/eu/darken/myperm/permissions/ui/details/PermissionDetailsEvents.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/details/PermissionDetailsEvents.kt
@@ -6,4 +6,5 @@ import eu.darken.myperm.permissions.core.features.PermissionAction
 sealed class PermissionDetailsEvents {
     data class ShowAppSystemDetails(val pkg: Pkg) : PermissionDetailsEvents()
     data class PermissionEvent(val permAction: PermissionAction) : PermissionDetailsEvents()
+    data class ShowFilterDialog(val options: PermissionDetailsFilterOptions) : PermissionDetailsEvents()
 }

--- a/app/src/main/java/eu/darken/myperm/permissions/ui/details/PermissionDetailsFilterDialog.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/details/PermissionDetailsFilterDialog.kt
@@ -1,0 +1,40 @@
+package eu.darken.myperm.permissions.ui.details
+
+import android.app.Activity
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import eu.darken.myperm.R
+import eu.darken.myperm.common.dialog.BaseDialogBuilder
+
+class PermissionDetailsFilterDialog(private val activity: Activity) : BaseDialogBuilder(activity) {
+
+    fun show(
+        options: PermissionDetailsFilterOptions,
+        onResult: (PermissionDetailsFilterOptions) -> Unit
+    ) {
+        val itemLabels = PermissionDetailsFilterOptions.Filter.values().map {
+            getString(it.labelRes)
+        }.toTypedArray<CharSequence>()
+
+        val checkedItems = PermissionDetailsFilterOptions.Filter.values().map {
+            options.keys.contains(it)
+        }.toBooleanArray()
+
+        MaterialAlertDialogBuilder(context).apply {
+            setTitle(R.string.general_filter_action)
+            setNegativeButton(R.string.general_cancel_action) { _, _ -> }
+
+            setPositiveButton(android.R.string.ok) { _, _ ->
+                val new = options.copy(
+                    keys = PermissionDetailsFilterOptions.Filter.values().filterIndexed { index, _ ->
+                        checkedItems[index]
+                    }.toSet()
+                )
+                onResult(new)
+            }
+
+            setMultiChoiceItems(itemLabels, checkedItems) { _, which, isChecked ->
+                checkedItems[which] = isChecked
+            }
+        }.show()
+    }
+}

--- a/app/src/main/java/eu/darken/myperm/permissions/ui/details/PermissionDetailsFilterOptions.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/details/PermissionDetailsFilterOptions.kt
@@ -1,0 +1,33 @@
+package eu.darken.myperm.permissions.ui.details
+
+import android.os.Parcelable
+import androidx.annotation.StringRes
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import eu.darken.myperm.R
+import eu.darken.myperm.apps.core.Pkg
+import eu.darken.myperm.apps.core.features.Installed
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+@JsonClass(generateAdapter = true)
+data class PermissionDetailsFilterOptions(
+    @Json(name = "filters") val keys: Set<Filter> = setOf(Filter.USER_APP, Filter.SYSTEM_APP)
+) : Parcelable {
+
+    @JsonClass(generateAdapter = false)
+    enum class Filter(
+        @StringRes val labelRes: Int,
+        val matches: (Pkg) -> Boolean
+    ) {
+        USER_APP(
+            labelRes = R.string.apps_filter_userapps_label,
+            matches = { it is Installed && !it.isSystemApp }
+        ),
+        SYSTEM_APP(
+            labelRes = R.string.apps_filter_systemapps_label,
+            matches = { it is Installed && it.isSystemApp }
+        ),
+        ;
+    }
+}

--- a/app/src/main/java/eu/darken/myperm/permissions/ui/details/PermissionDetailsFragment.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/details/PermissionDetailsFragment.kt
@@ -35,7 +35,19 @@ class PermissionDetailsFragment : Fragment3(R.layout.permissions_details_fragmen
             insetsPadding(ui.list, bottom = true)
         }
         ui.list.setupDefaults(detailsAdapter)
-        ui.toolbar.setupWithNavController(findNavController())
+        ui.toolbar.apply {
+            setupWithNavController(findNavController())
+            inflateMenu(R.menu.menu_permission_details)
+            setOnMenuItemClickListener {
+                when (it.itemId) {
+                    R.id.menu_item_filter -> {
+                        vm.showFilterDialog()
+                        true
+                    }
+                    else -> false
+                }
+            }
+        }
 
         vm.events.observe2(ui) { event ->
             when (event) {
@@ -50,6 +62,11 @@ class PermissionDetailsFragment : Fragment3(R.layout.permissions_details_fragmen
                     event.permAction.execute(requireActivity())
                 } catch (e: Exception) {
                     e.asErrorDialogBuilder(requireContext()).show()
+                }
+                is PermissionDetailsEvents.ShowFilterDialog -> {
+                    PermissionDetailsFilterDialog(requireActivity()).show(event.options) { newOptions ->
+                        vm.updateFilterOptions { newOptions }
+                    }
                 }
             }
         }

--- a/app/src/main/java/eu/darken/myperm/settings/core/GeneralSettings.kt
+++ b/app/src/main/java/eu/darken/myperm/settings/core/GeneralSettings.kt
@@ -14,6 +14,7 @@ import eu.darken.myperm.common.preferences.Settings
 import eu.darken.myperm.common.preferences.createFlowPreference
 import eu.darken.myperm.common.preferences.moshiReader
 import eu.darken.myperm.common.preferences.moshiWriter
+import eu.darken.myperm.permissions.ui.details.PermissionDetailsFilterOptions
 import eu.darken.myperm.permissions.ui.list.PermsFilterOptions
 import eu.darken.myperm.permissions.ui.list.PermsSortOptions
 import javax.inject.Inject
@@ -52,6 +53,12 @@ class GeneralSettings @Inject constructor(
     val permissionsSortOptions = preferences.createFlowPreference(
         "permissions.list.options.sort",
         moshiReader(moshi, PermsSortOptions(), fallbackToDefault = true),
+        moshiWriter(moshi),
+    )
+
+    val permissionDetailsFilterOptions = preferences.createFlowPreference(
+        "permissions.details.options.filter",
+        moshiReader(moshi, PermissionDetailsFilterOptions(), fallbackToDefault = true),
         moshiWriter(moshi),
     )
 

--- a/app/src/main/res/menu/menu_permission_details.xml
+++ b/app/src/main/res/menu/menu_permission_details.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context="eu.darken.myperm.main.ui.MainActivity">
+    <item
+        android:id="@+id/menu_item_filter"
+        android:icon="@drawable/ic_baseline_filter_list_24"
+        android:orderInCategory="100"
+        android:title="@string/general_filter_action"
+        app:showAsAction="always" />
+</menu>


### PR DESCRIPTION
## Summary
- Add filtering capability to the Permission Details screen so users can filter apps by user vs system type
- Follows the existing filter pattern from the Apps list (`AppsFilterOptions`, `FilterDialog`)
- Filter icon in toolbar opens a multi-select dialog

## Test plan
- [x] Navigate to any permission details screen (e.g., WRITE_SETTINGS)
- [x] Tap filter icon in toolbar
- [x] Uncheck "System Apps" → list should show only user apps
- [x] Uncheck "User Apps" → list should show only system apps  
- [x] Verify filter persists after leaving and returning to screen

Closes #165