### PR TITLE
Add filter functionality to App Details and Permission Details screens

### DIFF
--- a/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsEvents.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsEvents.kt
@@ -6,4 +6,5 @@ import eu.darken.myperm.permissions.core.features.PermissionAction
 sealed class AppDetailsEvents {
     data class ShowAppSystemDetails(val pkg: Pkg) : AppDetailsEvents()
     data class PermissionEvent(val permAction: PermissionAction) : AppDetailsEvents()
+    data class ShowFilterDialog(val options: AppDetailsFilterOptions) : AppDetailsEvents()
 }

--- a/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsFilterDialog.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsFilterDialog.kt
@@ -1,0 +1,40 @@
+package eu.darken.myperm.apps.ui.details
+
+import android.app.Activity
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import eu.darken.myperm.R
+import eu.darken.myperm.common.dialog.BaseDialogBuilder
+
+class AppDetailsFilterDialog(private val activity: Activity) : BaseDialogBuilder(activity) {
+
+    fun show(
+        options: AppDetailsFilterOptions,
+        onResult: (AppDetailsFilterOptions) -> Unit
+    ) {
+        val itemLabels = AppDetailsFilterOptions.Filter.values().map {
+            getString(it.labelRes)
+        }.toTypedArray<CharSequence>()
+
+        val checkedItems = AppDetailsFilterOptions.Filter.values().map {
+            options.keys.contains(it)
+        }.toBooleanArray()
+
+        MaterialAlertDialogBuilder(context).apply {
+            setTitle(R.string.general_filter_action)
+            setNegativeButton(R.string.general_cancel_action) { _, _ -> }
+
+            setPositiveButton(android.R.string.ok) { _, _ ->
+                val new = options.copy(
+                    keys = AppDetailsFilterOptions.Filter.values().filterIndexed { index, _ ->
+                        checkedItems[index]
+                    }.toSet()
+                )
+                onResult(new)
+            }
+
+            setMultiChoiceItems(itemLabels, checkedItems) { _, which, isChecked ->
+                checkedItems[which] = isChecked
+            }
+        }.show()
+    }
+}

--- a/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsFilterOptions.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsFilterOptions.kt
@@ -1,0 +1,36 @@
+package eu.darken.myperm.apps.ui.details
+
+import android.os.Parcelable
+import androidx.annotation.StringRes
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import eu.darken.myperm.R
+import eu.darken.myperm.apps.core.features.UsesPermission
+import eu.darken.myperm.permissions.core.container.BasePermission
+import eu.darken.myperm.permissions.core.features.RuntimeGrant
+import eu.darken.myperm.permissions.core.features.SpecialAccess
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+@JsonClass(generateAdapter = true)
+data class AppDetailsFilterOptions(
+    @Json(name = "filters") val keys: Set<Filter> = setOf(Filter.GRANTED, Filter.DENIED, Filter.CONFIGURABLE)
+) : Parcelable {
+
+    @JsonClass(generateAdapter = false)
+    enum class Filter(
+        @StringRes val labelRes: Int
+    ) {
+        GRANTED(R.string.filter_granted_label),
+        DENIED(R.string.filter_denied_label),
+        CONFIGURABLE(R.string.filter_configurable_label);
+
+        fun matches(usesPerm: UsesPermission, basePerm: BasePermission): Boolean = when (this) {
+            GRANTED -> usesPerm.status == UsesPermission.Status.GRANTED ||
+                    usesPerm.status == UsesPermission.Status.GRANTED_IN_USE
+
+            DENIED -> usesPerm.status == UsesPermission.Status.DENIED
+            CONFIGURABLE -> basePerm.tags.contains(RuntimeGrant) || basePerm.tags.contains(SpecialAccess)
+        }
+    }
+}

--- a/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsFragment.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsFragment.kt
@@ -38,6 +38,11 @@ class AppDetailsFragment : Fragment3(R.layout.apps_details_fragment) {
             setupWithNavController(findNavController())
             setOnMenuItemClickListener {
                 when (it.itemId) {
+                    R.id.menu_item_filter -> {
+                        vm.showFilterDialog()
+                        true
+                    }
+
                     R.id.menu_item_settings -> {
                         vm.onGoSettings()
                         true
@@ -57,10 +62,17 @@ class AppDetailsFragment : Fragment3(R.layout.apps_details_fragment) {
                         Toast.makeText(requireContext(), e.toString(), Toast.LENGTH_SHORT).show()
                     }
                 }
+
                 is AppDetailsEvents.PermissionEvent -> try {
                     event.permAction.execute(requireActivity())
                 } catch (e: Exception) {
                     e.asErrorDialogBuilder(requireContext()).show()
+                }
+
+                is AppDetailsEvents.ShowFilterDialog -> {
+                    AppDetailsFilterDialog(requireActivity()).show(event.options) { newOptions ->
+                        vm.updateFilterOptions { newOptions }
+                    }
                 }
             }
         }
@@ -72,6 +84,7 @@ class AppDetailsFragment : Fragment3(R.layout.apps_details_fragment) {
             detailsAdapter.update(details.items)
             list.isVisible = true
             loadingContainer.isGone = details.app != null
+            emptyState.isVisible = details.isEmptyDueToFilter
         }
         super.onViewCreated(view, savedInstanceState)
     }

--- a/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsFragmentVM.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsFragmentVM.kt
@@ -12,7 +12,11 @@ import eu.darken.myperm.apps.core.Pkg
 import eu.darken.myperm.apps.core.apps
 import eu.darken.myperm.apps.core.features.ReadableApk
 import eu.darken.myperm.apps.core.features.UsesPermission
-import eu.darken.myperm.apps.ui.details.items.*
+import eu.darken.myperm.apps.ui.details.items.AppOverviewVH
+import eu.darken.myperm.apps.ui.details.items.AppSiblingsVH
+import eu.darken.myperm.apps.ui.details.items.AppTwinsVH
+import eu.darken.myperm.apps.ui.details.items.UnknownPermissionVH
+import eu.darken.myperm.apps.ui.details.items.UsesPermissionVH
 import eu.darken.myperm.common.WebpageTool
 import eu.darken.myperm.common.coroutine.DispatcherProvider
 import eu.darken.myperm.common.debug.logging.Logging.Priority.ERROR
@@ -29,6 +33,8 @@ import eu.darken.myperm.permissions.core.container.UnknownPermission
 import eu.darken.myperm.permissions.core.features.RuntimeGrant
 import eu.darken.myperm.permissions.core.features.SpecialAccess
 import eu.darken.myperm.permissions.core.permissions
+import eu.darken.myperm.settings.core.GeneralSettings
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
@@ -44,10 +50,12 @@ class AppDetailsFragmentVM @Inject constructor(
     private val webpageTool: WebpageTool,
     appRepo: AppRepo,
     permissionRepo: PermissionRepo,
-    appStoreTool: AppStoreTool
+    appStoreTool: AppStoreTool,
+    private val generalSettings: GeneralSettings
 ) : ViewModel3(dispatcherProvider = dispatcherProvider) {
 
     private val navArgs: AppDetailsFragmentArgs by handle.navArgs()
+    private val filterOptions = generalSettings.appDetailsFilterOptions.flow
 
     val events = SingleLiveEvent<AppDetailsEvents>()
 
@@ -55,126 +63,149 @@ class AppDetailsFragmentVM @Inject constructor(
         val label: String,
         val app: Pkg? = null,
         val items: List<AppDetailsAdapter.Item> = emptyList(),
+        val isEmptyDueToFilter: Boolean = false,
     )
 
-    val details: LiveData<Details> = appRepo.apps
-        .map { apps -> apps.single { it.id == navArgs.appId } }
-        .map { app ->
-            val infoItems = mutableListOf<AppDetailsAdapter.Item>()
-            val permissions = permissionRepo.permissions.first()
+    val details: LiveData<Details> = combine(
+        appRepo.apps.map { apps -> apps.single { it.id == navArgs.appId } },
+        filterOptions
+    ) { app, filterOpts ->
+        val infoItems = mutableListOf<AppDetailsAdapter.Item>()
+        val permissions = permissionRepo.permissions.first()
 
-            AppOverviewVH.Item(
-                app = app,
-                onOpenApp = {
-                    val intent = context.packageManager.getLaunchIntentForPackage(it.packageName)
-                    if (intent != null) {
-                        try {
-                            context.startActivity(intent)
-                        } catch (e: Exception) {
-                            log(TAG, ERROR) { "Launch intent failed for $app: ${e.asLog()}" }
-                            errorEvents.postValue(e)
-                        }
-                    } else {
-                        log(TAG, ERROR) { "No launch intent available for ${it.packageName}" }
-                        errorEvents.postValue(IllegalStateException("No launch intent available"))
+        AppOverviewVH.Item(
+            app = app,
+            onOpenApp = {
+                val intent = context.packageManager.getLaunchIntentForPackage(it.packageName)
+                if (intent != null) {
+                    try {
+                        context.startActivity(intent)
+                    } catch (e: Exception) {
+                        log(TAG, ERROR) { "Launch intent failed for $app: ${e.asLog()}" }
+                        errorEvents.postValue(e)
                     }
-                },
-                onGoToSettings = { events.postValue(AppDetailsEvents.ShowAppSystemDetails(it)) },
-                onInstallerTextClicked = { installer ->
-                    AppDetailsFragmentDirections.toSelf(appId = installer.id).navigate()
-                },
-                onInstallerIconClicked = { installer -> appStoreTool.openAppStoreFor(app, installer) }
+                } else {
+                    log(TAG, ERROR) { "No launch intent available for ${it.packageName}" }
+                    errorEvents.postValue(IllegalStateException("No launch intent available"))
+                }
+            },
+            onGoToSettings = { events.postValue(AppDetailsEvents.ShowAppSystemDetails(it)) },
+            onInstallerTextClicked = { installer ->
+                AppDetailsFragmentDirections.toSelf(appId = installer.id).navigate()
+            },
+            onInstallerIconClicked = { installer -> appStoreTool.openAppStoreFor(app, installer) }
+        ).run { infoItems.add(this) }
+
+        if (app.twins.isNotEmpty()) {
+            AppTwinsVH.Item(
+                app,
+                onTwinClicked = {
+                    AppDetailsFragmentDirections.toSelf(it.id, it.getLabel(context)).navigate()
+                }
             ).run { infoItems.add(this) }
-
-            if (app.twins.isNotEmpty()) {
-                AppTwinsVH.Item(
-                    app,
-                    onTwinClicked = {
-                        AppDetailsFragmentDirections.toSelf(it.id, it.getLabel(context)).navigate()
-                    }
-                ).run { infoItems.add(this) }
-            }
-
-            if (app.sharedUserId != null || app.siblings.isNotEmpty()) {
-                AppSiblingsVH.Item(
-                    app,
-                    onSiblingClicked = {
-                        AppDetailsFragmentDirections.toSelf(
-                            appId = it.id,
-                            appLabel = it.getLabel(context),
-                        ).navigate()
-                    }
-                ).run { infoItems.add(this) }
-            }
-
-            (app as? ReadableApk)?.requestedPermissions
-                ?.map { usesPerm ->
-                    val basePerm = permissions.singleOrNull { it.id == usesPerm.id }
-                        ?: throw IllegalArgumentException("Can't find $usesPerm")
-                    usesPerm to basePerm
-                }
-                ?.sortedWith(
-                    compareByDescending<Pair<UsesPermission, BasePermission>> { (usesPerm, basePerm) ->
-                        when (basePerm) {
-                            is DeclaredPermission -> 2
-                            is ExtraPermission -> 1
-                            is UnknownPermission -> 0
-                        }
-                    }.thenBy { (usesPerm, basePerm) ->
-                        usesPerm.status.ordinal
-                    }.thenBy { (usesPerm, basePerm) ->
-                        when {
-                            basePerm.tags.contains(RuntimeGrant) -> 2
-                            basePerm.tags.contains(SpecialAccess) -> 1
-                            else -> 0
-                        }
-                    }
-                )
-                ?.map { (usesPerm, basePerm) ->
-                    when (basePerm) {
-                        is DeclaredPermission, is ExtraPermission -> UsesPermissionVH.Item(
-                            pkg = app,
-                            appPermission = usesPerm,
-                            permission = basePerm,
-                            onItemClicked = {
-                                AppDetailsFragmentDirections.actionAppDetailsFragmentToPermissionDetailsFragment(
-                                    permissionId = it.permission.id,
-                                    permissionLabel = it.permission.getLabel(context)
-                                ).navigate()
-                            },
-                            onTogglePermission = {
-                                events.postValue(
-                                    AppDetailsEvents.PermissionEvent(it.permission.getAction(context, app))
-                                )
-                            }
-                        )
-                        is UnknownPermission -> UnknownPermissionVH.Item(
-                            pkg = app,
-                            appPermission = usesPerm,
-                            permission = basePerm,
-                            onItemClicked = {
-                                AppDetailsFragmentDirections.actionAppDetailsFragmentToPermissionDetailsFragment(
-                                    permissionId = it.permission.id,
-                                    permissionLabel = it.permission.getLabel(context)
-                                ).navigate()
-                            }
-                        )
-                    }
-                }
-                ?.run { infoItems.addAll(this) }
-
-
-            Details(
-                app = app,
-                label = navArgs.appLabel ?: app.getLabel(context) ?: app.id.toString(),
-                items = infoItems
-            )
         }
+
+        if (app.sharedUserId != null || app.siblings.isNotEmpty()) {
+            AppSiblingsVH.Item(
+                app,
+                onSiblingClicked = {
+                    AppDetailsFragmentDirections.toSelf(
+                        appId = it.id,
+                        appLabel = it.getLabel(context),
+                    ).navigate()
+                }
+            ).run { infoItems.add(this) }
+        }
+
+        val allPermissions = (app as? ReadableApk)?.requestedPermissions
+            ?.map { usesPerm ->
+                val basePerm = permissions.singleOrNull { it.id == usesPerm.id }
+                    ?: throw IllegalArgumentException("Can't find $usesPerm")
+                usesPerm to basePerm
+            }
+            ?: emptyList()
+
+        val filteredPermissions = allPermissions
+            .filter { (usesPerm, basePerm) ->
+                // Always show UNKNOWN status permissions
+                usesPerm.status == UsesPermission.Status.UNKNOWN ||
+                        filterOpts.keys.any { filter -> filter.matches(usesPerm, basePerm) }
+            }
+            .sortedWith(
+                compareByDescending<Pair<UsesPermission, BasePermission>> { (_, basePerm) ->
+                    when (basePerm) {
+                        is DeclaredPermission -> 2
+                        is ExtraPermission -> 1
+                        is UnknownPermission -> 0
+                    }
+                }.thenBy { (usesPerm, _) ->
+                    usesPerm.status.ordinal
+                }.thenBy { (_, basePerm) ->
+                    when {
+                        basePerm.tags.contains(RuntimeGrant) -> 2
+                        basePerm.tags.contains(SpecialAccess) -> 1
+                        else -> 0
+                    }
+                }
+            )
+            .map { (usesPerm, basePerm) ->
+                when (basePerm) {
+                    is DeclaredPermission, is ExtraPermission -> UsesPermissionVH.Item(
+                        pkg = app,
+                        appPermission = usesPerm,
+                        permission = basePerm,
+                        onItemClicked = {
+                            AppDetailsFragmentDirections.actionAppDetailsFragmentToPermissionDetailsFragment(
+                                permissionId = it.permission.id,
+                                permissionLabel = it.permission.getLabel(context)
+                            ).navigate()
+                        },
+                        onTogglePermission = {
+                            events.postValue(
+                                AppDetailsEvents.PermissionEvent(it.permission.getAction(context, app))
+                            )
+                        }
+                    )
+
+                    is UnknownPermission -> UnknownPermissionVH.Item(
+                        pkg = app,
+                        appPermission = usesPerm,
+                        permission = basePerm,
+                        onItemClicked = {
+                            AppDetailsFragmentDirections.actionAppDetailsFragmentToPermissionDetailsFragment(
+                                permissionId = it.permission.id,
+                                permissionLabel = it.permission.getLabel(context)
+                            ).navigate()
+                        }
+                    )
+                }
+            }
+
+        infoItems.addAll(filteredPermissions)
+
+        // Check if permissions were filtered out (app has permissions but none match filter)
+        val isEmptyDueToFilter = allPermissions.isNotEmpty() && filteredPermissions.isEmpty()
+
+        Details(
+            app = app,
+            label = navArgs.appLabel ?: app.getLabel(context) ?: app.id.toString(),
+            items = infoItems,
+            isEmptyDueToFilter = isEmptyDueToFilter
+        )
+    }
         .onStart { navArgs.appLabel?.let { emit(Details(label = it)) } }
         .asLiveData2()
 
     fun onGoSettings() {
         val pkg = details.value?.app ?: return
         events.postValue(AppDetailsEvents.ShowAppSystemDetails(pkg))
+    }
+
+    fun showFilterDialog() {
+        events.postValue(AppDetailsEvents.ShowFilterDialog(generalSettings.appDetailsFilterOptions.value))
+    }
+
+    fun updateFilterOptions(action: (AppDetailsFilterOptions) -> AppDetailsFilterOptions) {
+        generalSettings.appDetailsFilterOptions.update { action(it) }
     }
 }

--- a/app/src/main/java/eu/darken/myperm/permissions/ui/details/PermissionDetailsFragment.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/details/PermissionDetailsFragment.kt
@@ -44,6 +44,7 @@ class PermissionDetailsFragment : Fragment3(R.layout.permissions_details_fragmen
                         vm.showFilterDialog()
                         true
                     }
+
                     else -> false
                 }
             }
@@ -58,11 +59,13 @@ class PermissionDetailsFragment : Fragment3(R.layout.permissions_details_fragmen
                         Toast.makeText(requireContext(), e.toString(), Toast.LENGTH_SHORT).show()
                     }
                 }
+
                 is PermissionDetailsEvents.PermissionEvent -> try {
                     event.permAction.execute(requireActivity())
                 } catch (e: Exception) {
                     e.asErrorDialogBuilder(requireContext()).show()
                 }
+
                 is PermissionDetailsEvents.ShowFilterDialog -> {
                     PermissionDetailsFilterDialog(requireActivity()).show(event.options) { newOptions ->
                         vm.updateFilterOptions { newOptions }
@@ -77,6 +80,7 @@ class PermissionDetailsFragment : Fragment3(R.layout.permissions_details_fragmen
             detailsAdapter.update(details.items)
             list.isVisible = true
             loadingContainer.isGone = details.perm != null
+            emptyState.isVisible = details.isEmptyDueToFilter
         }
         super.onViewCreated(view, savedInstanceState)
     }

--- a/app/src/main/java/eu/darken/myperm/settings/core/GeneralSettings.kt
+++ b/app/src/main/java/eu/darken/myperm/settings/core/GeneralSettings.kt
@@ -5,6 +5,7 @@ import android.content.SharedPreferences
 import androidx.preference.PreferenceDataStore
 import com.squareup.moshi.Moshi
 import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.myperm.apps.ui.details.AppDetailsFilterOptions
 import eu.darken.myperm.apps.ui.list.AppsFilterOptions
 import eu.darken.myperm.apps.ui.list.AppsSortOptions
 import eu.darken.myperm.common.debug.autoreport.DebugSettings
@@ -42,6 +43,12 @@ class GeneralSettings @Inject constructor(
     val appsSortOptions = preferences.createFlowPreference(
         "apps.list.options.sort",
         moshiReader(moshi, AppsSortOptions(), fallbackToDefault = true),
+        moshiWriter(moshi),
+    )
+
+    val appDetailsFilterOptions = preferences.createFlowPreference(
+        "apps.details.options.filter",
+        moshiReader(moshi, AppDetailsFilterOptions(), fallbackToDefault = true),
         moshiWriter(moshi),
     )
 

--- a/app/src/main/res/layout/apps_details_fragment.xml
+++ b/app/src/main/res/layout/apps_details_fragment.xml
@@ -37,4 +37,19 @@
         app:layout_constraintStart_toStartOf="@id/list"
         app:layout_constraintTop_toTopOf="@id/list" />
 
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/empty_state"
+        style="@style/TextAppearance.Material3.BodyLarge"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:gravity="center"
+        android:padding="32dp"
+        android:text="@string/apps_details_empty_filter_message"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@id/list"
+        app:layout_constraintEnd_toEndOf="@id/list"
+        app:layout_constraintStart_toStartOf="@id/list"
+        app:layout_constraintTop_toTopOf="@id/list"
+        tools:visibility="visible" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/permissions_details_fragment.xml
+++ b/app/src/main/res/layout/permissions_details_fragment.xml
@@ -36,4 +36,19 @@
         app:layout_constraintStart_toStartOf="@id/list"
         app:layout_constraintTop_toTopOf="@id/list" />
 
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/empty_state"
+        style="@style/TextAppearance.Material3.BodyLarge"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:gravity="center"
+        android:padding="32dp"
+        android:text="@string/permissions_details_empty_filter_message"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@id/list"
+        app:layout_constraintEnd_toEndOf="@id/list"
+        app:layout_constraintStart_toStartOf="@id/list"
+        app:layout_constraintTop_toTopOf="@id/list"
+        tools:visibility="visible" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/menu_app_details.xml
+++ b/app/src/main/res/menu/menu_app_details.xml
@@ -4,6 +4,12 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:context="eu.darken.myperm.main.ui.MainActivity">
     <item
+        android:id="@+id/menu_item_filter"
+        android:icon="@drawable/ic_baseline_filter_list_24"
+        android:orderInCategory="90"
+        android:title="@string/general_filter_action"
+        app:showAsAction="always" />
+    <item
         android:id="@+id/menu_item_settings"
         android:icon="@drawable/ic_baseline_settings_applications_24"
         android:orderInCategory="100"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,6 +87,10 @@
     <string name="permissions_filter_installtime_label">Granted automatically</string>
     <string name="permissions_filter_installtime_hide_label">Not granted automatically</string>
 
+    <string name="filter_granted_label">Granted</string>
+    <string name="filter_denied_label">Denied</string>
+    <string name="filter_configurable_label">Configurable</string>
+
     <string name="permissions_sort_apps_granted_label"># of apps granted</string>
     <string name="permissions_sort_apps_requested_label"># of apps requested</string>
     <string name="permissions_search_list_hint">Search permissions</string>
@@ -136,6 +140,7 @@
     <string name="apps_details_description_uninstalled_caveat">This app has been uninstalled but its data has been retained. Permission states cannot be determined for uninstalled apps.</string>
     <string name="apps_details_description_secondary_description">"%d permissions requested."</string>
     <string name="apps_details_description_primary_description">"%1$d of %2$d permissions granted."</string>
+    <string name="apps_details_empty_filter_message">No permissions match current filters. Tap the filter icon to adjust.</string>
     <string name="api_target_level_x">Target version: %s</string>
     <string name="api_minimum_level_x">Minimum version: %s</string>
     <string name="api_build_level_x">Compile version: %s</string>
@@ -167,6 +172,7 @@
     <string name="permissions_details_count_user_apps">"User Apps: Granted to %1$d out of %2$d."</string>
     <string name="permissions_details_count_system_apps">"System Apps: Granted to %1$d out of %2$d."</string>
     <string name="permissions_details_description_restrictions_caveat_description">Apps installed in other user profiles are excluded from the computation above due to Android restrictions.</string>
+    <string name="permissions_details_empty_filter_message">No apps match current filters. Tap the filter icon to adjust.</string>
     <string name="permission_nfc_label">NFC</string>
     <string name="permission_nfc_description">Allows apps to communicate with Near Field Communication (NFC) tags, cards and readers.</string>
     <string name="permission_manage_media_label">Manage Media</string>


### PR DESCRIPTION
## Summary

- **App Details**: Add filter dialog with Granted/Denied/Configurable permission filter options
- **Permission Details**: Add User Apps/System Apps filter with bypass for non-Installed apps (apps from secondary profiles that can't be categorized)
- **Both screens**: Show empty state message when filter settings result in no visible items
- Filter preferences are persisted to GeneralSettings

## Implementation Notes

The original feature requests (#136, #137) suggested a "quick filter bar" with toggle buttons visible on screen. This implementation uses a filter icon in the toolbar that opens a dialog instead, keeping the UI cleaner while providing the same filtering functionality.

## Test plan

- [x] Open App Details for any app
- [ ] Tap filter icon, uncheck all options → verify empty state message appears
- [ ] Check Granted only → verify only granted permissions shown
- [ ] Open Permission Details for any permission  
- [ ] Tap filter icon, uncheck all options → verify empty state message appears
- [x] Verify filter settings persist across screen navigation

Closes #136, closes #137