### PR TITLE
Move toolbar actions to overflow menus for cleaner UI

### DIFF
--- a/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsFragmentVM.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsFragmentVM.kt
@@ -93,6 +93,7 @@ class PermissionsFragmentVM @Inject constructor(
                             events.postValue(PermissionListEvent.PermissionEvent(it.permission.getAction(context)))
                         },
                     )
+
                     is ExtraPermission -> ExtraPermissionVH.Item(
                         permission = permission,
                         onClickAction = {
@@ -106,6 +107,7 @@ class PermissionsFragmentVM @Inject constructor(
                             events.postValue(PermissionListEvent.PermissionEvent(it.permission.getAction(context)))
                         },
                     )
+
                     is UnknownPermission -> UnknownPermissionVH.Item(
                         permission = permission,
                         onClickAction = { },
@@ -174,6 +176,17 @@ class PermissionsFragmentVM @Inject constructor(
 
     private fun MutableStateFlow<Map<PermissionGroup.Id, Boolean>>.toggle(id: PermissionGroup.Id) {
         value = value.toMutableMap().apply { this[id] = !(this[id] ?: false) }
+    }
+
+    fun expandAll() {
+        log { "expandAll" }
+        val allGroupIds = APermGrp.values.map { it.id }
+        expandedGroups.value = allGroupIds.associateWith { true }
+    }
+
+    fun collapseAll() {
+        log { "collapseAll" }
+        expandedGroups.value = emptyMap()
     }
 
     fun onSearchInputChanged(term: String?) {

--- a/app/src/main/res/drawable/ic_baseline_more_vert_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_more_vert_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,8c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM12,10c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM12,16c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2z" />
+</vector>

--- a/app/src/main/res/drawable/ic_unfold_less_24.xml
+++ b/app/src/main/res/drawable/ic_unfold_less_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M7.41,18.59L8.83,20 12,16.83 15.17,20l1.41,-1.41L12,14l-4.59,4.59zM16.59,5.41L15.17,4 12,7.17 8.83,4 7.41,5.41 12,10l4.59,-4.59z" />
+</vector>

--- a/app/src/main/res/drawable/ic_unfold_more_24.xml
+++ b/app/src/main/res/drawable/ic_unfold_more_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,5.83L15.17,9l1.41,-1.41L12,3 7.41,7.59 8.83,9 12,5.83zM12,18.17L8.83,15l-1.41,1.41L12,21l4.59,-4.59L15.17,15 12,18.17z" />
+</vector>

--- a/app/src/main/res/layout/apps_fragment.xml
+++ b/app/src/main/res/layout/apps_fragment.xml
@@ -41,26 +41,17 @@
         android:layout_height="wrap_content"
         app:icon="@drawable/ic_baseline_sort_24"
         app:layout_constraintBottom_toBottomOf="@id/search_container"
-        app:layout_constraintEnd_toStartOf="@id/refresh_action"
+        app:layout_constraintEnd_toStartOf="@id/more_action"
         app:layout_constraintStart_toEndOf="@id/search_container"
         app:layout_constraintTop_toTopOf="@id/search_container" />
 
     <com.google.android.material.button.MaterialButton
-        android:id="@+id/refresh_action"
+        android:id="@+id/more_action"
         style="@style/Widget.Material3.Button.IconButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:icon="@drawable/ic_baseline_refresh_24"
-        app:layout_constraintBottom_toBottomOf="@id/search_container"
-        app:layout_constraintEnd_toStartOf="@id/settings_action"
-        app:layout_constraintTop_toTopOf="@id/search_container" />
-
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/settings_action"
-        style="@style/Widget.Material3.Button.IconButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:icon="@drawable/ic_baseline_settings_24"
+        android:contentDescription="@string/general_more_options_action"
+        app:icon="@drawable/ic_baseline_more_vert_24"
         app:layout_constraintBottom_toBottomOf="@id/search_container"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@id/search_container" />

--- a/app/src/main/res/layout/permissions_fragment.xml
+++ b/app/src/main/res/layout/permissions_fragment.xml
@@ -41,26 +41,17 @@
         android:layout_height="wrap_content"
         app:icon="@drawable/ic_baseline_sort_24"
         app:layout_constraintBottom_toBottomOf="@id/search_container"
-        app:layout_constraintEnd_toStartOf="@id/refresh_action"
+        app:layout_constraintEnd_toStartOf="@id/more_action"
         app:layout_constraintStart_toEndOf="@id/search_container"
         app:layout_constraintTop_toTopOf="@id/search_container" />
 
     <com.google.android.material.button.MaterialButton
-        android:id="@+id/refresh_action"
+        android:id="@+id/more_action"
         style="@style/Widget.Material3.Button.IconButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:icon="@drawable/ic_baseline_refresh_24"
-        app:layout_constraintBottom_toBottomOf="@id/search_container"
-        app:layout_constraintEnd_toStartOf="@id/settings_action"
-        app:layout_constraintTop_toTopOf="@id/search_container" />
-
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/settings_action"
-        style="@style/Widget.Material3.Button.IconButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:icon="@drawable/ic_baseline_settings_24"
+        android:contentDescription="@string/general_more_options_action"
+        app:icon="@drawable/ic_baseline_more_vert_24"
         app:layout_constraintBottom_toBottomOf="@id/search_container"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@id/search_container" />

--- a/app/src/main/res/menu/menu_apps_list.xml
+++ b/app/src/main/res/menu/menu_apps_list.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/menu_item_refresh"
+        android:icon="@drawable/ic_baseline_refresh_24"
+        android:title="@string/general_refresh_action" />
+    <item
+        android:id="@+id/menu_item_settings"
+        android:icon="@drawable/ic_baseline_settings_24"
+        android:title="@string/label_settings" />
+</menu>

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -1,13 +1,11 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     tools:context="eu.darken.myperm.main.ui.MainActivity">
     <item
         android:id="@+id/menu_item_refresh"
         android:icon="@drawable/ic_baseline_refresh_24"
         android:orderInCategory="10"
-        android:title="@string/general_refresh_action"
-        app:showAsAction="always" />
+        android:title="@string/general_refresh_action" />
     <item
         android:id="@+id/menu_item_donate"
         android:icon="@drawable/ic_baseline_heart_24"

--- a/app/src/main/res/menu/menu_permissions_list.xml
+++ b/app/src/main/res/menu/menu_permissions_list.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/menu_item_expand_all"
+        android:icon="@drawable/ic_unfold_more_24"
+        android:title="@string/general_expand_all_action" />
+    <item
+        android:id="@+id/menu_item_collapse_all"
+        android:icon="@drawable/ic_unfold_less_24"
+        android:title="@string/general_collapse_all_action" />
+    <item
+        android:id="@+id/menu_item_refresh"
+        android:icon="@drawable/ic_baseline_refresh_24"
+        android:title="@string/general_refresh_action" />
+    <item
+        android:id="@+id/menu_item_settings"
+        android:icon="@drawable/ic_baseline_settings_24"
+        android:title="@string/label_settings" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,6 +122,9 @@
     <string name="apps_known_installer_xiaomi_label">Xiaomi GetApps</string>
     <string name="apps_known_android_system_label">Android System</string>
     <string name="general_refresh_action">Refresh</string>
+    <string name="general_expand_all_action">Expand all</string>
+    <string name="general_collapse_all_action">Collapse all</string>
+    <string name="general_more_options_action">More options</string>
     <string name="apps_details_twins_label">Clones</string>
     <string name="apps_details_twins_descriptions">Installed in other user profile(s).</string>
     <string name="install_date_label">Install date</string>


### PR DESCRIPTION
## Summary
- Replace individual refresh and settings buttons with a single overflow menu (⋮) on Apps and Permissions screens
- Add expand all/collapse all options to Permissions screen overflow menu
- Move refresh to overflow menu on Overview screen

Closes #126

## Test plan
- [ ] Open Apps tab, verify overflow menu shows Refresh and Settings
- [ ] Open Permissions tab, verify overflow menu shows Expand all, Collapse all, Refresh, and Settings
- [ ] Open Overview tab, verify refresh is now in toolbar overflow menu
- [ ] Verify all menu actions work correctly