### PR TITLE
Fix special permission grant status detection

### DIFF
--- a/app/src/main/java/eu/darken/myperm/apps/core/features/ExtraPermissionScanner.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/features/ExtraPermissionScanner.kt
@@ -1,9 +1,20 @@
 package eu.darken.myperm.apps.core.features
 
+import android.app.AppOpsManager
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
+import android.os.Build
 import eu.darken.myperm.common.IPCFunnel
+import eu.darken.myperm.common.debug.logging.Logging.Priority.WARN
+import eu.darken.myperm.common.debug.logging.asLog
+import eu.darken.myperm.common.debug.logging.log
+import eu.darken.myperm.common.hasApiLevel
+import eu.darken.myperm.permissions.core.Permission
+import eu.darken.myperm.common.debug.logging.logTag
 import eu.darken.myperm.permissions.core.known.AExtraPerm
+import eu.darken.myperm.permissions.core.known.APerm
+
+private val TAG = logTag("ExtraPermissionScanner")
 
 suspend fun PackageInfo.determineSpecialPermissions(ipcFunnel: IPCFunnel): Collection<UsesPermission> {
     val permissions = mutableSetOf<UsesPermission>()
@@ -19,4 +30,56 @@ suspend fun PackageInfo.determineSpecialPermissions(ipcFunnel: IPCFunnel): Colle
     }
 
     return permissions
+}
+
+private data class SpecialPermissionDef(
+    val permission: APerm,
+    val appOp: String,
+    val minApiLevel: Int
+)
+
+private val SPECIAL_PERMISSIONS = listOf(
+    SpecialPermissionDef(APerm.MANAGE_EXTERNAL_STORAGE, "android:manage_external_storage", Build.VERSION_CODES.R),
+    SpecialPermissionDef(APerm.SCHEDULE_EXACT_ALARM, "android:schedule_exact_alarm", Build.VERSION_CODES.S),
+    SpecialPermissionDef(APerm.REQUEST_INSTALL_PACKAGES, "android:request_install_packages", Build.VERSION_CODES.O),
+    SpecialPermissionDef(APerm.SYSTEM_ALERT_WINDOW, AppOpsManager.OPSTR_SYSTEM_ALERT_WINDOW, Build.VERSION_CODES.M),
+    SpecialPermissionDef(APerm.WRITE_SETTINGS, AppOpsManager.OPSTR_WRITE_SETTINGS, Build.VERSION_CODES.M),
+    SpecialPermissionDef(APerm.PACKAGE_USAGE_STATS, AppOpsManager.OPSTR_GET_USAGE_STATS, 1), // Always available (minSdk >= 21)
+)
+
+/**
+ * Checks special permission states via AppOpsManager for permissions that are not
+ * reflected in requestedPermissionsFlags.
+ *
+ * @param uidOverride Optional UID to use instead of applicationInfo.uid (useful for secondary profiles)
+ * @return map of Permission.Id to UsesPermission.Status for special permissions that the app has requested.
+ */
+suspend fun PackageInfo.getSpecialPermissionStatuses(
+    ipcFunnel: IPCFunnel,
+    uidOverride: Int? = null
+): Map<Permission.Id, UsesPermission.Status> {
+    val uid = uidOverride ?: applicationInfo?.uid ?: return emptyMap()
+    val requestedPerms = requestedPermissions?.toSet() ?: return emptyMap()
+
+    val statuses = mutableMapOf<Permission.Id, UsesPermission.Status>()
+
+    for (def in SPECIAL_PERMISSIONS) {
+        if (!hasApiLevel(def.minApiLevel)) continue
+        if (!requestedPerms.contains(def.permission.id.value)) continue
+
+        try {
+            val result = ipcFunnel.appOpsManager.checkOpNoThrow(def.appOp, uid, packageName)
+            statuses[def.permission.id] = mapAppOpResult(result)
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Failed to check ${def.permission.id} for $packageName: ${e.asLog()}" }
+        }
+    }
+
+    return statuses
+}
+
+private fun mapAppOpResult(result: Int): UsesPermission.Status = when (result) {
+    AppOpsManager.MODE_ALLOWED -> UsesPermission.Status.GRANTED
+    AppOpsManager.MODE_FOREGROUND -> UsesPermission.Status.GRANTED_IN_USE
+    else -> UsesPermission.Status.DENIED
 }

--- a/app/src/main/java/eu/darken/myperm/apps/core/features/UsesPermission.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/features/UsesPermission.kt
@@ -15,13 +15,27 @@ sealed class UsesPermission {
         UNKNOWN,
     }
 
-    data class WithState(override val id: Permission.Id, val flags: Int?) : UsesPermission() {
+    class WithState(
+        override val id: Permission.Id,
+        val flags: Int?,
+        private val overrideStatus: Status? = null
+    ) : UsesPermission() {
 
-        override val status: Status = when {
+        override val status: Status = overrideStatus ?: when {
             flags == null -> Status.UNKNOWN
             flags and PackageInfo.REQUESTED_PERMISSION_GRANTED != 0 -> Status.GRANTED
             else -> Status.DENIED
         }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is WithState) return false
+            return id == other.id && flags == other.flags
+        }
+
+        override fun hashCode(): Int = 31 * id.hashCode() + (flags ?: 0)
+
+        override fun toString(): String = "WithState(id=$id, flags=$flags, status=$status)"
     }
 
     data class Unknown(override val id: Permission.Id) : UsesPermission() {

--- a/app/src/main/java/eu/darken/myperm/common/IPCFunnel.kt
+++ b/app/src/main/java/eu/darken/myperm/common/IPCFunnel.kt
@@ -1,6 +1,7 @@
 package eu.darken.myperm.common
 
 import android.accessibilityservice.AccessibilityServiceInfo
+import android.app.AppOpsManager
 import android.content.Context
 import android.content.pm.LauncherActivityInfo
 import android.content.pm.PackageInfo
@@ -133,6 +134,19 @@ class IPCFunnel @Inject constructor(
 
         suspend fun tryCreateUserHandle(handle: Int) = ipcFunnel.execute {
             service.tryCreateUserHandle(handle)
+        }
+    }
+
+    val appOpsManager by lazy { AppOpsManager2(this) }
+
+    class AppOpsManager2(private val ipcFunnel: IPCFunnel) {
+        private val service by lazy {
+            ContextCompat.getSystemService(ipcFunnel.context, AppOpsManager::class.java)
+                ?: error("AppOpsManager not available")
+        }
+
+        suspend fun checkOpNoThrow(op: String, uid: Int, packageName: String): Int = ipcFunnel.execute {
+            service.unsafeCheckOpNoThrow(op, uid, packageName)
         }
     }
 


### PR DESCRIPTION
## Summary
- Fix special permissions (e.g., `MANAGE_EXTERNAL_STORAGE`, `SYSTEM_ALERT_WINDOW`) incorrectly showing as denied when actually granted
- Use `AppOpsManager` to query the actual grant state for special permissions
- Apply fix to all package types (primary, secondary profiles, uninstalled)

## Details
Special permissions are managed through AppOps/Settings rather than the standard permission mechanism, so `PackageInfo.requestedPermissionsFlags` doesn't reflect their actual state. This PR adds AppOps-based checking for:
- `MANAGE_EXTERNAL_STORAGE` (API 30+)
- `SCHEDULE_EXACT_ALARM` (API 31+)
- `REQUEST_INSTALL_PACKAGES` (API 26+)
- `SYSTEM_ALERT_WINDOW` (API 23+)
- `WRITE_SETTINGS` (API 23+)
- `PACKAGE_USAGE_STATS` (API 21+)

## Test plan
- Install on Android 11+ device
- Install an app requesting `MANAGE_EXTERNAL_STORAGE` (e.g., MiXplorer)
- Grant "All Files" access via Settings
- Verify Permission Pilot shows the permission as granted
- Test "Display over other apps" permission similarly

Closes #163
Closes #178