### PR TITLE
Fix permission intent shortcuts crashing on older Android versions

### DIFF
--- a/app/src/main/java/eu/darken/myperm/permissions/core/features/PermissionAction.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/core/features/PermissionAction.kt
@@ -4,7 +4,7 @@ import android.app.Activity
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
+import android.os.Build
 import android.provider.Settings
 import android.widget.Toast
 import eu.darken.myperm.R
@@ -12,6 +12,7 @@ import eu.darken.myperm.apps.core.Pkg
 import eu.darken.myperm.permissions.core.Permission
 import eu.darken.myperm.permissions.core.known.AExtraPerm
 import eu.darken.myperm.permissions.core.known.APerm
+import androidx.core.net.toUri
 
 sealed class PermissionAction {
 
@@ -32,12 +33,12 @@ sealed class PermissionAction {
             } else {
                 val intent = when (permission.id) {
                     else -> Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
-                        data = Uri.parse("package:${pkg.packageName}")
+                        data = "package:${pkg.packageName}".toUri()
                     }
                 }
 
                 intent.resolveToActivity(activity)?.apply {
-                    data = Uri.parse("package:${pkg.packageName}")
+                    data = "package:${pkg.packageName}".toUri()
                 } ?: throw IllegalArgumentException("Unavailable for ${permission.id.value}")
             }
 
@@ -48,30 +49,48 @@ sealed class PermissionAction {
     data class SpecialAccess(override val permission: Permission, override val pkg: Pkg?) : PermissionAction() {
         override fun execute(activity: Activity) {
             val intent = when (permission.id) {
-                APerm.SYSTEM_ALERT_WINDOW.id -> Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION).apply {
-                    pkg?.let { data = Uri.parse("package:${it.packageName}") }
-                }
+                APerm.SYSTEM_ALERT_WINDOW.id -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION).apply {
+                        pkg?.let { data = "package:${it.packageName}".toUri() }
+                    }
+                } else null
                 APerm.PACKAGE_USAGE_STATS.id -> Intent(Settings.ACTION_USAGE_ACCESS_SETTINGS).apply {
-                    pkg?.let { data = Uri.parse("package:${it.packageName}") }
+                    pkg?.let { data = "package:${it.packageName}".toUri() }
                 }
-                APerm.REQUEST_COMPANION_USE_DATA_IN_BACKGROUND.id -> Intent(Settings.ACTION_IGNORE_BACKGROUND_DATA_RESTRICTIONS_SETTINGS).apply {
-                    pkg?.let { data = Uri.parse("package:${it.packageName}") }
-                }
-                APerm.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS.id -> Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
-                    pkg?.let { data = Uri.parse("package:${it.packageName}") }
-                }
-                APerm.MANAGE_EXTERNAL_STORAGE.id -> Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION).apply {
-                    pkg?.let { data = Uri.parse("package:${it.packageName}") }
-                }
-                APerm.WRITE_SETTINGS.id -> Intent(Settings.ACTION_MANAGE_WRITE_SETTINGS).apply {
-                    pkg?.let { data = Uri.parse("package:${it.packageName}") }
-                }
-                APerm.MANAGE_MEDIA.id -> Intent(Settings.ACTION_REQUEST_MANAGE_MEDIA).apply {
-                    pkg?.let { data = Uri.parse("package:${it.packageName}") }
-                }
-                APerm.SCHEDULE_EXACT_ALARM.id -> Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM).apply {
-                    pkg?.let { data = Uri.parse("package:${it.packageName}") }
-                }
+                APerm.REQUEST_COMPANION_USE_DATA_IN_BACKGROUND.id -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                    Intent(Settings.ACTION_IGNORE_BACKGROUND_DATA_RESTRICTIONS_SETTINGS).apply {
+                        pkg?.let { data = "package:${it.packageName}".toUri() }
+                    }
+                } else null
+                APerm.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS.id -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
+                        pkg?.let { data = "package:${it.packageName}".toUri() }
+                    }
+                } else null
+                APerm.MANAGE_EXTERNAL_STORAGE.id -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    if (pkg != null) {
+                        Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION).apply {
+                            data = "package:${pkg.packageName}".toUri()
+                        }
+                    } else {
+                        Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION)
+                    }
+                } else null
+                APerm.WRITE_SETTINGS.id -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    Intent(Settings.ACTION_MANAGE_WRITE_SETTINGS).apply {
+                        pkg?.let { data = "package:${it.packageName}".toUri() }
+                    }
+                } else null
+                APerm.MANAGE_MEDIA.id -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    Intent(Settings.ACTION_REQUEST_MANAGE_MEDIA).apply {
+                        pkg?.let { data = "package:${it.packageName}".toUri() }
+                    }
+                } else null
+                APerm.SCHEDULE_EXACT_ALARM.id -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM).apply {
+                        pkg?.let { data = "package:${it.packageName}".toUri() }
+                    }
+                } else null
                 // We don't have specific intents for these
 //                APerm.MANAGE_ONGOING_CALLS.id -> Intent(Settings.)
 //                APerm.INSTANT_APP_FOREGROUND_SERVICE.id -> Intent(Settings.)
@@ -114,22 +133,30 @@ sealed class PermissionAction {
                         "com.android.settings.Settings\$AccessibilitySettingsActivity"
                     )
                 }
-                else -> throw IllegalArgumentException("No action found for: ${permission.id.value}")
+                APerm.REQUEST_INSTALL_PACKAGES.id -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    Intent(Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES).apply {
+                        pkg?.let { data = "package:${it.packageName}".toUri() }
+                    }
+                } else null
+                else -> null
             }
 
-            val resolvedIntent = intent.resolveToActivity(activity)
-                ?.apply {
-                    pkg?.let { data = Uri.parse("package:${it.packageName}") }
-                }
-                ?: throw IllegalArgumentException("Action unavailable for ${permission.id.value}")
+            val resolvedIntent = intent?.resolveToActivity(activity)?.apply {
+                pkg?.let { data = "package:${it.packageName}".toUri() }
+            } ?: pkg?.let {
+                // Fallback to App Info
+                Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+                    .resolveToActivity(activity)
+                    ?.apply { data = "package:${it.packageName}".toUri() }
+            } ?: throw IllegalArgumentException("No action available for ${permission.id.value}")
 
             activity.startActivity(resolvedIntent)
         }
     }
 
     data class None(override val permission: Permission, override val pkg: Pkg?) : PermissionAction() {
-        override fun execute(context: Activity) {
-            Toast.makeText(context, R.string.permissions_action_none_msg, Toast.LENGTH_SHORT).show()
+        override fun execute(activity: Activity) {
+            Toast.makeText(activity, R.string.permissions_action_none_msg, Toast.LENGTH_SHORT).show()
         }
     }
 }

--- a/app/src/main/java/eu/darken/myperm/permissions/core/known/APerm.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/core/known/APerm.kt
@@ -627,7 +627,7 @@ sealed class APerm(val id: Permission.Id) {
         override val labelRes: Int = R.string.permission_install_unknown_apps_label
         override val descriptionRes: Int = R.string.permission_install_unknown_apps_description
         override val groupIds: Set<PermissionGroup.Id> = grpIds(APermGrp.Apps)
-        override val tags = setOf(ManifestDoc)
+        override val tags = setOf(ManifestDoc, SpecialAccess)
     }
 
     object SCHEDULE_EXACT_ALARM : APerm("android.permission.SCHEDULE_EXACT_ALARM") {


### PR DESCRIPTION
## Summary
- Add API level checks for permission intent actions that require specific Android versions
- Fall back to App Info screen when a direct intent isn't available
- Fix MANAGE_EXTERNAL_STORAGE to use the correct app-specific action
- Mark REQUEST_INSTALL_PACKAGES as SpecialAccess

## Permissions Fixed
| Permission | Required API |
|------------|--------------|
| SYSTEM_ALERT_WINDOW | 23 (M) |
| REQUEST_IGNORE_BATTERY_OPTIMIZATIONS | 23 (M) |
| WRITE_SETTINGS | 23 (M) |
| REQUEST_COMPANION_USE_DATA_IN_BACKGROUND | 24 (N) |
| MANAGE_EXTERNAL_STORAGE | 30 (R) |
| MANAGE_MEDIA | 31 (S) |
| SCHEDULE_EXACT_ALARM | 31 (S) |
| REQUEST_INSTALL_PACKAGES | 26 (O) |

Closes #140