### PR TITLE
Expand AppOps-based permission grant status detection

### DIFF
--- a/app/src/main/java/eu/darken/myperm/apps/core/features/ExtraPermissionScanner.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/features/ExtraPermissionScanner.kt
@@ -39,12 +39,25 @@ private data class SpecialPermissionDef(
 )
 
 private val SPECIAL_PERMISSIONS = listOf(
-    SpecialPermissionDef(APerm.MANAGE_EXTERNAL_STORAGE, "android:manage_external_storage", Build.VERSION_CODES.R),
-    SpecialPermissionDef(APerm.SCHEDULE_EXACT_ALARM, "android:schedule_exact_alarm", Build.VERSION_CODES.S),
-    SpecialPermissionDef(APerm.REQUEST_INSTALL_PACKAGES, "android:request_install_packages", Build.VERSION_CODES.O),
+    // API 1 (always available, minSdk >= 21)
+    SpecialPermissionDef(APerm.PACKAGE_USAGE_STATS, AppOpsManager.OPSTR_GET_USAGE_STATS, 1),
+    SpecialPermissionDef(APerm.ACCESS_NOTIFICATIONS, "android:access_notifications", 1),
+    // API 23 (M)
     SpecialPermissionDef(APerm.SYSTEM_ALERT_WINDOW, AppOpsManager.OPSTR_SYSTEM_ALERT_WINDOW, Build.VERSION_CODES.M),
     SpecialPermissionDef(APerm.WRITE_SETTINGS, AppOpsManager.OPSTR_WRITE_SETTINGS, Build.VERSION_CODES.M),
-    SpecialPermissionDef(APerm.PACKAGE_USAGE_STATS, AppOpsManager.OPSTR_GET_USAGE_STATS, 1), // Always available (minSdk >= 21)
+    // API 24 (N)
+    SpecialPermissionDef(APerm.CHANGE_WIFI_STATE, "android:change_wifi_state", Build.VERSION_CODES.N),
+    // API 26 (O)
+    SpecialPermissionDef(APerm.REQUEST_INSTALL_PACKAGES, "android:request_install_packages", Build.VERSION_CODES.O),
+    SpecialPermissionDef(APerm.TURN_SCREEN_ON, "android:turn_screen_on", Build.VERSION_CODES.O),
+    // API 30 (R)
+    SpecialPermissionDef(APerm.MANAGE_EXTERNAL_STORAGE, "android:manage_external_storage", Build.VERSION_CODES.R),
+    SpecialPermissionDef(APerm.INTERACT_ACROSS_PROFILES, "android:interact_across_profiles", Build.VERSION_CODES.R),
+    SpecialPermissionDef(APerm.LOADER_USAGE_STATS, "android:loader_usage_stats", Build.VERSION_CODES.R),
+    // API 31 (S)
+    SpecialPermissionDef(APerm.SCHEDULE_EXACT_ALARM, "android:schedule_exact_alarm", Build.VERSION_CODES.S),
+    SpecialPermissionDef(APerm.MANAGE_MEDIA, "android:manage_media", Build.VERSION_CODES.S),
+    SpecialPermissionDef(APerm.USE_FULL_SCREEN_INTENT, "android:use_full_screen_intent", Build.VERSION_CODES.S),
 )
 
 /**

--- a/app/src/main/java/eu/darken/myperm/permissions/core/known/APerm.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/core/known/APerm.kt
@@ -46,7 +46,7 @@ sealed class APerm(val id: Permission.Id) {
         override val labelRes: Int = R.string.permission_manage_media_label
         override val descriptionRes: Int = R.string.permission_manage_media_description
         override val groupIds: Set<PermissionGroup.Id> = grpIds(APermGrp.Files)
-        override val tags = setOf(ManifestDoc)
+        override val tags = setOf(ManifestDoc, SpecialAccess)
     }
 
     object WRITE_MEDIA_STORAGE : APerm("android.permission.WRITE_MEDIA_STORAGE") {
@@ -738,6 +738,14 @@ sealed class APerm(val id: Permission.Id) {
         override val tags = setOf(ManifestDoc)
     }
 
+    object TURN_SCREEN_ON : APerm("android.permission.TURN_SCREEN_ON") {
+        override val iconRes: Int = R.drawable.ic_baseline_phone_android_24
+        override val labelRes: Int = R.string.permission_turn_screen_on_label
+        override val descriptionRes: Int = R.string.permission_turn_screen_on_description
+        override val groupIds: Set<PermissionGroup.Id> = grpIds(APermGrp.Apps)
+        override val tags = setOf(ManifestDoc, SpecialAccess)
+    }
+
 
     /**
      * OTHER
@@ -944,7 +952,11 @@ sealed class APerm(val id: Permission.Id) {
     }
 
     object INTERACT_ACROSS_PROFILES : APerm("android.permission.INTERACT_ACROSS_PROFILES") {
-        override val tags = setOf(ManifestDoc)
+        override val iconRes: Int = R.drawable.ic_baseline_work_24
+        override val labelRes: Int = R.string.permission_interact_across_profiles_label
+        override val descriptionRes: Int = R.string.permission_interact_across_profiles_description
+        override val groupIds: Set<PermissionGroup.Id> = grpIds(APermGrp.Apps)
+        override val tags = setOf(ManifestDoc, SpecialAccess)
     }
 
     object KILL_BACKGROUND_PROCESSES : APerm("android.permission.KILL_BACKGROUND_PROCESSES") {
@@ -952,7 +964,11 @@ sealed class APerm(val id: Permission.Id) {
     }
 
     object LOADER_USAGE_STATS : APerm("android.permission.LOADER_USAGE_STATS") {
-        override val tags = setOf(ManifestDoc)
+        override val iconRes: Int = R.drawable.ic_usage_data_access_24
+        override val labelRes: Int = R.string.permission_loader_usage_stats_label
+        override val descriptionRes: Int = R.string.permission_loader_usage_stats_description
+        override val groupIds: Set<PermissionGroup.Id> = grpIds(APermGrp.Apps)
+        override val tags = setOf(ManifestDoc, SpecialAccess)
     }
 
     object MASTER_CLEAR : APerm("android.permission.MASTER_CLEAR") {
@@ -1087,7 +1103,11 @@ sealed class APerm(val id: Permission.Id) {
     }
 
     object USE_FULL_SCREEN_INTENT : APerm("android.permission.USE_FULL_SCREEN_INTENT") {
-        override val tags = setOf(ManifestDoc)
+        override val iconRes: Int = R.drawable.ic_baseline_picture_in_picture_24
+        override val labelRes: Int = R.string.permission_full_screen_intent_label
+        override val descriptionRes: Int = R.string.permission_full_screen_intent_description
+        override val groupIds: Set<PermissionGroup.Id> = grpIds(APermGrp.Apps)
+        override val tags = setOf(ManifestDoc, SpecialAccess)
     }
 
     object USE_ICC_AUTH_WITH_DEVICE_IDENTIFIER : APerm("android.permission.USE_ICC_AUTH_WITH_DEVICE_IDENTIFIER") {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -222,6 +222,14 @@
     <string name="permission_do_not_disturb_permission_description">Allows apps to turn Do Not Disturb (DND) ON or OFF and change related settings.</string>
     <string name="permission_alarms_and_reminders_label">Alarms and Reminders</string>
     <string name="permission_alarms_and_reminders_description">Allows apps to set alarms and schedule time-sensitive actions. This allows apps to run in the background, which may use more battery. Turning OFF this permission for an app would cause existing alarms and time-based events that are scheduled by that particular app to stop working.</string>
+    <string name="permission_turn_screen_on_label">Turn Screen On</string>
+    <string name="permission_turn_screen_on_description">Allows apps to turn on the device screen when they need your attention, such as for alarms or incoming calls.</string>
+    <string name="permission_full_screen_intent_label">Full-Screen Notifications</string>
+    <string name="permission_full_screen_intent_description">Allows apps to show full-screen notifications that take over your screen when the device is locked or in use. Commonly used for alarms, calls, and other time-sensitive events.</string>
+    <string name="permission_interact_across_profiles_label">Connected Work and Personal Apps</string>
+    <string name="permission_interact_across_profiles_description">Allows apps to communicate between your work and personal profiles, sharing data and functionality across profile boundaries.</string>
+    <string name="permission_loader_usage_stats_label">Loader Usage Stats</string>
+    <string name="permission_loader_usage_stats_description">Allows apps to collect statistics about data loader usage on the device.</string>
     <string name="permission_premium_sms_services_label">Premium SMS Access</string>
     <string name="permission_premium_sms_services_description">Allows apps to use premium text message services. This will cost you money.</string>
     <string name="permission_unlimited_data_access_label">Unlimited Data Access</string>


### PR DESCRIPTION
## Summary
- Add 6 new permissions to `SPECIAL_PERMISSIONS` list for accurate grant status detection via AppOpsManager
- Sort `SPECIAL_PERMISSIONS` by API level for maintainability  
- Add full definitions (icon, label, description) for all new SpecialAccess permissions

## New Permissions Added
| Permission | AppOps | Min API |
|------------|--------|---------|
| INTERACT_ACROSS_PROFILES | `android:interact_across_profiles` | R (30) |
| MANAGE_MEDIA | `android:manage_media` | S (31) |
| ACCESS_NOTIFICATIONS | `android:access_notifications` | 21 |
| USE_FULL_SCREEN_INTENT | `android:use_full_screen_intent` | S (31) |
| LOADER_USAGE_STATS | `android:loader_usage_stats` | R (30) |
| TURN_SCREEN_ON | `android:turn_screen_on` | O (26) |

## Test plan
- [x] Build: `./gradlew assembleDebug`
- [x] Run tests: `./gradlew testFossDebugUnitTest`
- [x] Manual: Toggle permissions in Settings > Apps > Special app access and verify correct state display

Closes #133