### PR TITLE
Complete missing translations for 36 locales

### DIFF
--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -263,4 +263,21 @@
     <string name="onboarding_body1">Hierdie app help jou om deur geïnstalleerde toepassings te navigeer en toestemmings te ontdek.</string>
     <string name="onboarding_body2">Permission Pilot versamel Geïnstalleerde Toepassing inligting om die lys van jou apps en kruis-verwysing van hul toestemmings moontlik te maak wanneer jy hierdie toepassing gebruik.</string>
     <string name="onboarding_body3">Permission Pilot het geen advertensies nie en verwerk slegs data plaaslik.</string>
+
+    <string name="apps_details_empty_filter_message">Geen toestemmings pas by huidige filters nie. Tik die filter ikoon om aan te pas.</string>
+    <string name="filter_configurable_label">Konfigureerbaar</string>
+    <string name="filter_denied_label">Geweier</string>
+    <string name="filter_granted_label">Toegeken</string>
+    <string name="general_collapse_all_action">Vou alles toe</string>
+    <string name="general_expand_all_action">Brei alles uit</string>
+    <string name="general_more_options_action">Meer opsies</string>
+    <string name="permission_full_screen_intent_description">Laat apps toe om volskerm kennisgewings te wys wat jou skerm oorneem wanneer die toestel gesluit of in gebruik is. Algemeen gebruik vir alarms, oproepe en ander tyd-sensitiewe gebeurtenisse.</string>
+    <string name="permission_full_screen_intent_label">Volskerm Kennisgewings</string>
+    <string name="permission_interact_across_profiles_description">Laat apps toe om tussen jou werk- en persoonlike profiele te kommunikeer, en data en funksionaliteit oor profielgrense te deel.</string>
+    <string name="permission_interact_across_profiles_label">Gekoppelde Werk- en Persoonlike Apps</string>
+    <string name="permission_loader_usage_stats_description">Laat apps toe om statistieke oor data laaier gebruik op die toestel te versamel.</string>
+    <string name="permission_loader_usage_stats_label">Laaier Gebruik Statistieke</string>
+    <string name="permissions_details_empty_filter_message">Geen apps pas by huidige filters nie. Tik die filter ikoon om aan te pas.</string>
+    <string name="permission_turn_screen_on_description">Laat apps toe om die toestel se skerm aan te skakel wanneer hulle jou aandag nodig het, soos vir alarms of inkomende oproepe.</string>
+    <string name="permission_turn_screen_on_label">Skakel Skerm Aan</string>
 </resources>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -247,4 +247,21 @@
     <string name="onboarding_body1">ይህ መተግበሪያ የተጫኙ መተግበሪያዎችን እና ፈቃዶቻቸውን ማወቅና ማሳየት ይረዳል።</string>
     <string name="onboarding_body2">Permission Pilot የተጫኙ መተግበሪያዎች መረጃ ይሰበስባል። ይህ የፈቃዶችን ቅዱስ ዝርዝር ማየት ያስችላል።</string>
     <string name="onboarding_body3">Permission Pilot ማንኛውንም ማስታወቂያ የለውምና ሁሉንም ውሂብ በኪነ ምሁር ይተግበራል።</string>
+
+    <string name="apps_details_empty_filter_message">ከወቅታዊ ማጣሪያዎች ጋር የሚዛመዱ ፈቃዶች የሉም። ለማስተካከል የማጣሪያ አዶውን ይጫኑ።</string>
+    <string name="filter_configurable_label">ሊዋቀር የሚችል</string>
+    <string name="filter_denied_label">ተከልክሏል</string>
+    <string name="filter_granted_label">ተፈቅዷል</string>
+    <string name="general_collapse_all_action">ሁሉንም አሳንስ</string>
+    <string name="general_expand_all_action">ሁሉንም አስፋ</string>
+    <string name="general_more_options_action">ተጨማሪ አማራጮች</string>
+    <string name="permission_full_screen_intent_description">መሣሪያው ሲቆለፍ ወይም ጥቅም ላይ ሲውል ማያ ገጽዎን የሚይዙ ሙሉ ማያ ማሳወቂያዎችን እንዲያሳዩ ለመተግበሪያዎች ይፈቅዳል። በተለምዶ ለማንቂያዎች፣ ጥሪዎች እና ሌሎች ጊዜ-ተኮር ክስተቶች ጥቅም ላይ ይውላል።</string>
+    <string name="permission_full_screen_intent_label">ሙሉ ማያ ማሳወቂያዎች</string>
+    <string name="permission_interact_across_profiles_description">መተግበሪያዎች በስራ እና በግል መገለጫዎችዎ መካከል እንዲገናኙ ይፈቅዳል፣ ውሂብ እና ተግባራትን በመገለጫ ድንበሮች ላይ ያጋራሉ።</string>
+    <string name="permission_interact_across_profiles_label">የተገናኙ የስራ እና የግል መተግበሪያዎች</string>
+    <string name="permission_loader_usage_stats_description">መተግበሪያዎች በመሣሪያው ላይ ስላለው የውሂብ ጫኚ አጠቃቀም ስታቲስቲክስ እንዲሰበስቡ ይፈቅዳል።</string>
+    <string name="permission_loader_usage_stats_label">የጫኚ አጠቃቀም ስታቲስቲክስ</string>
+    <string name="permissions_details_empty_filter_message">ከወቅታዊ ማጣሪያዎች ጋር የሚዛመዱ መተግበሪያዎች የሉም። ለማስተካከል የማጣሪያ አዶውን ይጫኑ።</string>
+    <string name="permission_turn_screen_on_description">እንደ ማንቂያዎች ወይም ገቢ ጥሪዎች ያሉ ትኩረትዎን ሲፈልጉ መተግበሪያዎች የመሣሪያውን ማያ ገጽ እንዲያበሩ ይፈቅዳል።</string>
+    <string name="permission_turn_screen_on_label">ማያ ገጽን አብራ</string>
 </resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -247,4 +247,20 @@
     <string name="onboarding_body1">يساعدك هذا التطبيق على استعراض التطبيقات المثبتة واكتشاف الأذونات الخاصة بها.</string>
     <string name="onboarding_body2">يجمع بايلوت الأذونات معلومات تطبيقاتك المثبتة لتمكين عرضها ومراجعة أذوناتها عند استخدام التطبيق.</string>
     <string name="onboarding_body3">بايلوت الأذونات خالٍ من الإعلانات ويعالج البيانات محليًا فقط.</string>
+    <string name="apps_details_empty_filter_message">لا توجد أذونات تطابق الفلاتر الحالية. اضغط على أيقونة الفلتر للتعديل.</string>
+    <string name="filter_configurable_label">قابل للتكوين</string>
+    <string name="filter_denied_label">مرفوض</string>
+    <string name="filter_granted_label">ممنوح</string>
+    <string name="general_collapse_all_action">طي الكل</string>
+    <string name="general_expand_all_action">توسيع الكل</string>
+    <string name="general_more_options_action">المزيد من الخيارات</string>
+    <string name="permission_full_screen_intent_description">يسمح للتطبيقات بعرض إشعارات ملء الشاشة التي تستحوذ على شاشتك عندما يكون الجهاز مقفلاً أو قيد الاستخدام. يُستخدم عادةً للمنبهات والمكالمات والأحداث الحساسة للوقت.</string>
+    <string name="permission_full_screen_intent_label">إشعارات ملء الشاشة</string>
+    <string name="permission_interact_across_profiles_description">يسمح للتطبيقات بالتواصل بين ملفك الشخصي للعمل والشخصي، ومشاركة البيانات والوظائف عبر حدود الملفات الشخصية.</string>
+    <string name="permission_interact_across_profiles_label">تطبيقات العمل والشخصية المتصلة</string>
+    <string name="permission_loader_usage_stats_description">يسمح للتطبيقات بجمع إحصائيات حول استخدام محمّل البيانات على الجهاز.</string>
+    <string name="permission_loader_usage_stats_label">إحصائيات استخدام المحمّل</string>
+    <string name="permissions_details_empty_filter_message">لا توجد تطبيقات تطابق الفلاتر الحالية. اضغط على أيقونة الفلتر للتعديل.</string>
+    <string name="permission_turn_screen_on_description">يسمح للتطبيقات بتشغيل شاشة الجهاز عندما تحتاج انتباهك، مثل المنبهات أو المكالمات الواردة.</string>
+    <string name="permission_turn_screen_on_label">تشغيل الشاشة</string>
 </resources>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -247,4 +247,21 @@
     <string name="onboarding_body1">Bu tətbiqetmə sizə yüklənmiş tətbiqləri nəzərdən keçirməyə və icazələri aşkar etməyə kömək edir.</string>
     <string name="onboarding_body2">İcazə Pilot yüklənmiş Tətbiq Məlumatlarını toplayır, tətbiqlərinizi siyahıya almaq və istifadə edərkən icazələrini qüsursuz göstərmək üçün istifadə edir.</string>
     <string name="onboarding_body3">İcazə Pilot reklamları yoxdur və məlumatları yalnız yerli olaraq işləyir.</string>
+
+    <string name="apps_details_empty_filter_message">Cari filtrlərə uyğun icazə yoxdur. Tənzimləmək üçün filtr simgesinə toxunun.</string>
+    <string name="filter_configurable_label">Konfiqurasiya edilə bilən</string>
+    <string name="filter_denied_label">Rədd edilən</string>
+    <string name="filter_granted_label">Verilən</string>
+    <string name="general_collapse_all_action">Hamısını yığ</string>
+    <string name="general_expand_all_action">Hamısını genişlət</string>
+    <string name="general_more_options_action">Daha çox seçim</string>
+    <string name="permission_full_screen_intent_description">Tətbiqlərə cihaz kilidli və ya istifadədə olarkən ekranınızı əhatə edən tam ekran bildirişlər göstərməyə icazə verir. Adətən siqnallar, zənglər və digər vacib hadisələr üçün istifadə olunur.</string>
+    <string name="permission_full_screen_intent_label">Tam Ekran Bildirişlər</string>
+    <string name="permission_interact_across_profiles_description">Tətbiqlərə iş və şəxsi profilləriniz arasında ünsiyyət qurmağa, profil sərhədləri arasında məlumat və funksionallıq paylaşmağa icazə verir.</string>
+    <string name="permission_interact_across_profiles_label">Bağlı İş və Şəxsi Tətbiqlər</string>
+    <string name="permission_loader_usage_stats_description">Tətbiqlərə cihazda məlumat yükləyicisinin istifadəsi haqqında statistika toplamağa icazə verir.</string>
+    <string name="permission_loader_usage_stats_label">Yükləyici İstifadə Statistikası</string>
+    <string name="permissions_details_empty_filter_message">Cari filtrlərə uyğun tətbiq yoxdur. Tənzimləmək üçün filtr simgesinə toxunun.</string>
+    <string name="permission_turn_screen_on_description">Tətbiqlərə siqnallar və ya gələn zənglər kimi diqqətinizə ehtiyac olduqda cihaz ekranını yandırmağa icazə verir.</string>
+    <string name="permission_turn_screen_on_label">Ekranı Yandır</string>
 </resources>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -247,4 +247,21 @@
     <string name="onboarding_body1">Гэта праграма дапамагае аглядаць усталяваныя праграмы і дазволы.</string>
     <string name="onboarding_body2">Дазвол Пілот збірае інфармацыю аб усталяваных праграмах дзеля паказу іх і правільнага звязвання дазволаў.</string>
     <string name="onboarding_body3">Дазвол Пілот без рэкламы і апрацоўвае дадзеныя толькі лакальна.</string>
+
+    <string name="apps_details_empty_filter_message">Няма дазволаў, якія адпавядаюць бягучым фільтрам. Націсніце на значок фільтра для налады.</string>
+    <string name="filter_configurable_label">Наладжвальныя</string>
+    <string name="filter_denied_label">Адхіленыя</string>
+    <string name="filter_granted_label">Атрыманыя</string>
+    <string name="general_collapse_all_action">Згарнуць усё</string>
+    <string name="general_expand_all_action">Разгарнуць усё</string>
+    <string name="general_more_options_action">Дадатковыя параметры</string>
+    <string name="permission_full_screen_intent_description">Дазваляе праграмам паказваць поўнаэкранныя апавяшчэнні, якія займаюць увесь экран, калі прылада заблакавана або выкарыстоўваецца. Звычайна выкарыстоўваецца для будзільнікаў, званкоў і іншых тэрміновых падзей.</string>
+    <string name="permission_full_screen_intent_label">Поўнаэкранныя апавяшчэнні</string>
+    <string name="permission_interact_across_profiles_description">Дазваляе праграмам узаемадзейнічаць паміж працоўным і асабістым профілямі, абменьваючыся дадзенымі і функцыямі паміж профілямі.</string>
+    <string name="permission_interact_across_profiles_label">Звязаныя працоўныя і асабістыя праграмы</string>
+    <string name="permission_loader_usage_stats_description">Дазваляе праграмам збіраць статыстыку аб выкарыстанні загрузчыка дадзеных на прыладзе.</string>
+    <string name="permission_loader_usage_stats_label">Статыстыка выкарыстання загрузчыка</string>
+    <string name="permissions_details_empty_filter_message">Няма праграм, якія адпавядаюць бягучым фільтрам. Націсніце на значок фільтра для налады.</string>
+    <string name="permission_turn_screen_on_description">Дазваляе праграмам уключаць экран прылады, калі ім патрэбна ваша ўвага, напрыклад, для будзільнікаў або ўваходных званкоў.</string>
+    <string name="permission_turn_screen_on_label">Уключэнне экрана</string>
 </resources>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -263,4 +263,21 @@
     <string name="onboarding_body1">Това приложение ви помага да навигирате в инсталираните приложения и да откриете разрешения.</string>
     <string name="onboarding_body2">Permission Pilot събира информация за инсталирани приложения, за да позволи изброяването на вашите приложения и кръстосано препращане на техните разрешения при използване на това приложение.</string>
     <string name="onboarding_body3">Permission Pilot няма реклами и обработва данните само локално.</string>
+
+    <string name="apps_details_empty_filter_message">Няма разрешения, отговарящи на текущите филтри. Натиснете иконата за филтър, за да настроите.</string>
+    <string name="filter_configurable_label">Конфигурируеми</string>
+    <string name="filter_denied_label">Отказани</string>
+    <string name="filter_granted_label">Предоставени</string>
+    <string name="general_collapse_all_action">Свиване на всички</string>
+    <string name="general_expand_all_action">Разгъване на всички</string>
+    <string name="general_more_options_action">Още опции</string>
+    <string name="permission_full_screen_intent_description">Позволява на приложенията да показват уведомления на цял екран, които заемат екрана, когато устройството е заключено или се използва. Често се използва за аларми, обаждания и други времево-чувствителни събития.</string>
+    <string name="permission_full_screen_intent_label">Уведомления на цял екран</string>
+    <string name="permission_interact_across_profiles_description">Позволява на приложенията да комуникират между вашите работни и лични профили, споделяйки данни и функционалност между границите на профилите.</string>
+    <string name="permission_interact_across_profiles_label">Свързани работни и лични приложения</string>
+    <string name="permission_loader_usage_stats_description">Позволява на приложенията да събират статистика за използването на зареждащи данни на устройството.</string>
+    <string name="permission_loader_usage_stats_label">Статистика за използване на зареждач</string>
+    <string name="permissions_details_empty_filter_message">Няма приложения, отговарящи на текущите филтри. Натиснете иконата за филтър, за да настроите.</string>
+    <string name="permission_turn_screen_on_description">Позволява на приложенията да включват екрана на устройството, когато се нуждаят от вашето внимание, например за аларми или входящи обаждания.</string>
+    <string name="permission_turn_screen_on_label">Включване на екрана</string>
 </resources>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -263,4 +263,20 @@
     <string name="onboarding_body1">এই অ্যাপ আপনাকে ইনস্টল করা অ্যাপ্লিকেশনগুলি নেভিগেট করতে এবং অনুমতি আবিষ্কার করতে সাহায্য করে।</string>
     <string name="onboarding_body2">Permission Pilot ইনস্টল করা অ্যাপ্লিকেশনের তথ্য সংগ্রহ করে যাতে এই অ্যাপটি ব্যবহার করার সময় আপনার অ্যাপগুলি তালিকাভুক্ত করা এবং তাদের অনুমতিগুলির ক্রস-রেফারেন্স করা সম্ভব হয়।</string>
     <string name="onboarding_body3">Permission Pilot-এ কোনো বিজ্ঞাপন নেই এবং শুধুমাত্র স্থানীয়ভাবে ডেটা প্রক্রিয়া করে।</string>
+    <string name="apps_details_empty_filter_message">বর্তমান ফিল্টারের সাথে কোনো অনুমতি মেলে না। সামঞ্জস্য করতে ফিল্টার আইকনে ট্যাপ করুন।</string>
+    <string name="filter_configurable_label">কনফিগারযোগ্য</string>
+    <string name="filter_denied_label">প্রত্যাখ্যাত</string>
+    <string name="filter_granted_label">প্রদত্ত</string>
+    <string name="general_collapse_all_action">সব সংকুচিত করুন</string>
+    <string name="general_expand_all_action">সব প্রসারিত করুন</string>
+    <string name="general_more_options_action">আরো বিকল্প</string>
+    <string name="permission_full_screen_intent_description">অ্যাপগুলিকে পূর্ণ-স্ক্রিন বিজ্ঞপ্তি দেখানোর অনুমতি দেয় যা ডিভাইস লক থাকা বা ব্যবহারে থাকা অবস্থায় আপনার স্ক্রিন দখল করে। সাধারণত অ্যালার্ম, কল এবং অন্যান্য সময়-সংবেদনশীল ইভেন্টের জন্য ব্যবহৃত হয়।</string>
+    <string name="permission_full_screen_intent_label">পূর্ণ-স্ক্রিন বিজ্ঞপ্তি</string>
+    <string name="permission_interact_across_profiles_description">অ্যাপগুলিকে আপনার কাজ এবং ব্যক্তিগত প্রোফাইলের মধ্যে যোগাযোগ করতে, প্রোফাইল সীমানা জুড়ে ডেটা এবং কার্যকারিতা ভাগ করার অনুমতি দেয়।</string>
+    <string name="permission_interact_across_profiles_label">সংযুক্ত কাজ এবং ব্যক্তিগত অ্যাপস</string>
+    <string name="permission_loader_usage_stats_description">অ্যাপগুলিকে ডিভাইসে ডেটা লোডার ব্যবহার সম্পর্কে পরিসংখ্যান সংগ্রহ করার অনুমতি দেয়।</string>
+    <string name="permission_loader_usage_stats_label">লোডার ব্যবহারের পরিসংখ্যান</string>
+    <string name="permissions_details_empty_filter_message">বর্তমান ফিল্টারের সাথে কোনো অ্যাপ মেলে না। সামঞ্জস্য করতে ফিল্টার আইকনে ট্যাপ করুন।</string>
+    <string name="permission_turn_screen_on_description">অ্যাপগুলিকে ডিভাইসের স্ক্রিন চালু করার অনুমতি দেয় যখন তাদের আপনার মনোযোগ প্রয়োজন, যেমন অ্যালার্ম বা ইনকামিং কলের জন্য।</string>
+    <string name="permission_turn_screen_on_label">স্ক্রিন চালু করুন</string>
 </resources>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -263,4 +263,21 @@
     <string name="onboarding_body1">Aquesta aplicació t\'ajuda a navegar per les aplicacions instal·lades i descobrir permisos.</string>
     <string name="onboarding_body2">Permission Pilot recull informació d\'aplicacions instal·lades per permetre llistar les teves aplicacions i fer referències creuades dels seus permisos quan utilitzes aquesta aplicació.</string>
     <string name="onboarding_body3">Permission Pilot no té publicitat i només processa dades localment.</string>
+
+    <string name="apps_details_empty_filter_message">Cap permís no coincideix amb els filtres actuals. Toca la icona de filtre per ajustar.</string>
+    <string name="filter_configurable_label">Configurable</string>
+    <string name="filter_denied_label">Denegat</string>
+    <string name="filter_granted_label">Concedit</string>
+    <string name="general_collapse_all_action">Replegar tot</string>
+    <string name="general_expand_all_action">Expandir tot</string>
+    <string name="general_more_options_action">Més opcions</string>
+    <string name="permission_full_screen_intent_description">Permet a les aplicacions mostrar notificacions a pantalla completa que ocupen la pantalla quan el dispositiu està bloquejat o en ús. S\'utilitza habitualment per a alarmes, trucades i altres esdeveniments urgents.</string>
+    <string name="permission_full_screen_intent_label">Notificacions a pantalla completa</string>
+    <string name="permission_interact_across_profiles_description">Permet a les aplicacions comunicar-se entre els perfils de treball i personals, compartint dades i funcionalitat entre els límits dels perfils.</string>
+    <string name="permission_interact_across_profiles_label">Aplicacions de treball i personals connectades</string>
+    <string name="permission_loader_usage_stats_description">Permet a les aplicacions recollir estadístiques sobre l\'ús de carregadors de dades al dispositiu.</string>
+    <string name="permission_loader_usage_stats_label">Estadístiques d\'ús del carregador</string>
+    <string name="permissions_details_empty_filter_message">Cap aplicació no coincideix amb els filtres actuals. Toca la icona de filtre per ajustar.</string>
+    <string name="permission_turn_screen_on_description">Permet a les aplicacions encendre la pantalla del dispositiu quan necessiten la teva atenció, com per a alarmes o trucades entrants.</string>
+    <string name="permission_turn_screen_on_label">Encendre pantalla</string>
 </resources>

--- a/app/src/main/res/values-ckb-rIR/strings.xml
+++ b/app/src/main/res/values-ckb-rIR/strings.xml
@@ -247,4 +247,20 @@
     <string name="onboarding_body1">ئەم ئەپە دەتوانێت ئەپە دامەزرابووەکانت دیاری بکا و مۆڵەتەکان ببینیت.</string>
     <string name="onboarding_body2">مۆڵەت پایلۆت زانیاریی ئەپە دامەزرابووەکان جمع دەکات بۆ لیستکردن بەکار بەو کاتە تۆ ئەپەکە دەتەوێت و مۆڵەتەکانت جیا بکات.</string>
     <string name="onboarding_body3">مۆڵەت پایلۆت ڕیکلام نییه و داتا تەنیا لە ناوخۆ دا پڕۆسس دەکات.</string>
+    <string name="apps_details_empty_filter_message">هیچ مۆڵەتێک لەگەڵ فلتەرە ئێستاییەکان ناگونجێت. بۆ ڕێکخستن لەسەر ئایکۆنی فلتەر دەست بگرە.</string>
+    <string name="filter_configurable_label">ڕێکخستنی پێکراو</string>
+    <string name="filter_denied_label">ڕەتکراوە</string>
+    <string name="filter_granted_label">پێدراوە</string>
+    <string name="general_collapse_all_action">هەموو بپێچەوە</string>
+    <string name="general_expand_all_action">هەموو بکەرەوە</string>
+    <string name="general_more_options_action">هەڵبژاردنی زیاتر</string>
+    <string name="permission_full_screen_intent_description">ڕێگە بە ئەپەکان دەدات ئاگادارکردنەوەی تەواوی شاشە پیشان بدەن کە شاشەکەت دەگرن کاتێک ئامێرەکە قفڵکراوە یان بەکارهێنراوە. زۆرجار بۆ هۆشیارکەر، پەیوەندی و ڕووداوە هەستیارەکانی کات بەکاردەهێنرێت.</string>
+    <string name="permission_full_screen_intent_label">ئاگادارکردنەوەی تەواوی شاشە</string>
+    <string name="permission_interact_across_profiles_description">ڕێگە بە ئەپەکان دەدات پەیوەندی بکەن لەنێوان پڕۆفایلی کار و کەسیت، هاوبەشکردنی داتا و کارکردن بەسەر سنوورەکانی پڕۆفایل.</string>
+    <string name="permission_interact_across_profiles_label">ئەپە کار و کەسییە پەیوەستکراوەکان</string>
+    <string name="permission_loader_usage_stats_description">ڕێگە بە ئەپەکان دەدات ئامارەکان دەربارەی بەکارهێنانی بارکەری داتا لەسەر ئامێرەکە کۆبکەنەوە.</string>
+    <string name="permission_loader_usage_stats_label">ئامارەکانی بەکارهێنانی بارکەر</string>
+    <string name="permissions_details_empty_filter_message">هیچ ئەپێک لەگەڵ فلتەرە ئێستاییەکان ناگونجێت. بۆ ڕێکخستن لەسەر ئایکۆنی فلتەر دەست بگرە.</string>
+    <string name="permission_turn_screen_on_description">ڕێگە بە ئەپەکان دەدات شاشەی ئامێرەکە بکەنەوە کاتێک پێویستیان بە سەرنجی تۆ هەیە، وەک بۆ هۆشیارکەر یان پەیوەندی هاتوو.</string>
+    <string name="permission_turn_screen_on_label">شاشە بکەرەوە</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -263,4 +263,21 @@
     <string name="onboarding_body1">Tato aplikace vám pomáhá procházet nainstalované aplikace a zjišťovat jejich oprávnění.</string>
     <string name="onboarding_body2">Permission Pilot shromažďuje informace o nainstalovaných aplikacích, aby mohl zobrazovat seznam vašich aplikací a porovnávat jejich oprávnění při používání této aplikace.</string>
     <string name="onboarding_body3">Permission Pilot neobsahuje reklamy a zpracovává data pouze lokálně.</string>
+
+    <string name="apps_details_empty_filter_message">Žádná oprávnění neodpovídají aktuálním filtrům. Klepněte na ikonu filtru pro úpravu.</string>
+    <string name="filter_configurable_label">Konfigurovatelné</string>
+    <string name="filter_denied_label">Odepřeno</string>
+    <string name="filter_granted_label">Uděleno</string>
+    <string name="general_collapse_all_action">Sbalit vše</string>
+    <string name="general_expand_all_action">Rozbalit vše</string>
+    <string name="general_more_options_action">Další možnosti</string>
+    <string name="permission_full_screen_intent_description">Umožňuje aplikacím zobrazovat oznámení na celou obrazovku, která převezmou obrazovku, když je zařízení zamčené nebo používané. Běžně se používá pro budíky, hovory a další časově citlivé události.</string>
+    <string name="permission_full_screen_intent_label">Oznámení na celou obrazovku</string>
+    <string name="permission_interact_across_profiles_description">Umožňuje aplikacím komunikovat mezi pracovními a osobními profily a sdílet data a funkce přes hranice profilů.</string>
+    <string name="permission_interact_across_profiles_label">Propojené pracovní a osobní aplikace</string>
+    <string name="permission_loader_usage_stats_description">Umožňuje aplikacím shromažďovat statistiky o používání datových zavaděčů na zařízení.</string>
+    <string name="permission_loader_usage_stats_label">Statistiky využití zavaděče</string>
+    <string name="permissions_details_empty_filter_message">Žádné aplikace neodpovídají aktuálním filtrům. Klepněte na ikonu filtru pro úpravu.</string>
+    <string name="permission_turn_screen_on_description">Umožňuje aplikacím zapnout obrazovku zařízení, když potřebují vaši pozornost, například pro budíky nebo příchozí hovory.</string>
+    <string name="permission_turn_screen_on_label">Zapnout obrazovku</string>
 </resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -326,4 +326,21 @@
         <item quantity="one">%s element</item>
         <item quantity="other">%s elementer</item>
     </plurals>
+
+    <string name="apps_details_empty_filter_message">Ingen tilladelser matcher de aktuelle filtre. Tryk på filterikonet for at justere.</string>
+    <string name="filter_configurable_label">Konfigurerbar</string>
+    <string name="filter_denied_label">Afvist</string>
+    <string name="filter_granted_label">Tildelt</string>
+    <string name="general_collapse_all_action">Skjul alle</string>
+    <string name="general_expand_all_action">Udvid alle</string>
+    <string name="general_more_options_action">Flere muligheder</string>
+    <string name="permission_full_screen_intent_description">Tillader apps at vise fuldskærmsnotifikationer, der overtager din skærm, når enheden er låst eller i brug. Bruges ofte til alarmer, opkald og andre tidsfølsomme begivenheder.</string>
+    <string name="permission_full_screen_intent_label">Fuldskærmsnotifikationer</string>
+    <string name="permission_interact_across_profiles_description">Tillader apps at kommunikere mellem dine arbejds- og personlige profiler og dele data og funktionalitet på tværs af profilgrænser.</string>
+    <string name="permission_interact_across_profiles_label">Forbundne arbejds- og personlige apps</string>
+    <string name="permission_loader_usage_stats_description">Tillader apps at indsamle statistik om brug af dataindlæser på enheden.</string>
+    <string name="permission_loader_usage_stats_label">Statistik for indlæserbrug</string>
+    <string name="permissions_details_empty_filter_message">Ingen apps matcher de aktuelle filtre. Tryk på filterikonet for at justere.</string>
+    <string name="permission_turn_screen_on_description">Tillader apps at tænde enhedens skærm, når de har brug for din opmærksomhed, såsom til alarmer eller indgående opkald.</string>
+    <string name="permission_turn_screen_on_label">Tænd skærm</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -263,4 +263,21 @@
     <string name="onboarding_body1">Diese App hilft dir, durch installierte Anwendungen zu navigieren und Berechtigungen zu entdecken.</string>
     <string name="onboarding_body2">Permission Pilot sammelt Informationen über installierte Anwendungen, um das Auflisten deiner Apps und die Querverweise ihrer Berechtigungen bei der Nutzung dieser Anwendung zu ermöglichen.</string>
     <string name="onboarding_body3">Permission Pilot hat keine Werbung und verarbeitet Daten nur lokal.</string>
+
+    <string name="apps_details_empty_filter_message">Keine Berechtigungen entsprechen den aktuellen Filtern. Tippe auf das Filtersymbol, um sie anzupassen.</string>
+    <string name="filter_configurable_label">Konfigurierbar</string>
+    <string name="filter_denied_label">Verweigert</string>
+    <string name="filter_granted_label">Gewährt</string>
+    <string name="general_collapse_all_action">Alle einklappen</string>
+    <string name="general_expand_all_action">Alle ausklappen</string>
+    <string name="general_more_options_action">Weitere Optionen</string>
+    <string name="permission_full_screen_intent_description">Ermöglicht Apps, Vollbild-Benachrichtigungen anzuzeigen, die den Bildschirm übernehmen, wenn das Gerät gesperrt ist oder verwendet wird. Wird häufig für Wecker, Anrufe und andere zeitkritische Ereignisse verwendet.</string>
+    <string name="permission_full_screen_intent_label">Vollbild-Benachrichtigungen</string>
+    <string name="permission_interact_across_profiles_description">Ermöglicht Apps die Kommunikation zwischen Arbeits- und persönlichen Profilen, um Daten und Funktionen über Profilgrenzen hinweg zu teilen.</string>
+    <string name="permission_interact_across_profiles_label">Verbundene Arbeits- und persönliche Apps</string>
+    <string name="permission_loader_usage_stats_description">Ermöglicht Apps, Statistiken über die Nutzung von Datenladern auf dem Gerät zu sammeln.</string>
+    <string name="permission_loader_usage_stats_label">Loader-Nutzungsstatistiken</string>
+    <string name="permissions_details_empty_filter_message">Keine Apps entsprechen den aktuellen Filtern. Tippe auf das Filtersymbol, um sie anzupassen.</string>
+    <string name="permission_turn_screen_on_description">Ermöglicht Apps, den Bildschirm des Geräts einzuschalten, wenn sie deine Aufmerksamkeit benötigen, z.B. bei Weckern oder eingehenden Anrufen.</string>
+    <string name="permission_turn_screen_on_label">Bildschirm einschalten</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -263,4 +263,21 @@
     <string name="overview_summary_apps_sharedids_label">No. of apps with Κοινόχρηστα Αναγνωριστικά Χρήστη</string>
     <string name="permission_bind_accessibility_service_label">Προσφέρετε υπηρεσία προσβασιμότητας</string>
     <string name="permission_bind_accessibility_service_description">Επιτρέπει στην εφαρμογή να προσφέρει μια υπηρεσία προσβασιμότητας που μπορεί να ενεργοποιηθεί στις ρυθμίσεις συστήματος.</string>
+
+    <string name="apps_details_empty_filter_message">Δεν υπάρχουν άδειες που να ταιριάζουν με τα τρέχοντα φίλτρα. Πατήστε το εικονίδιο φίλτρου για προσαρμογή.</string>
+    <string name="filter_configurable_label">Διαμορφώσιμα</string>
+    <string name="filter_denied_label">Απορρίφθηκαν</string>
+    <string name="filter_granted_label">Χορηγήθηκαν</string>
+    <string name="general_collapse_all_action">Σύμπτυξη όλων</string>
+    <string name="general_expand_all_action">Ανάπτυξη όλων</string>
+    <string name="general_more_options_action">Περισσότερες επιλογές</string>
+    <string name="permission_full_screen_intent_description">Επιτρέπει στις εφαρμογές να εμφανίζουν ειδοποιήσεις πλήρους οθόνης που καταλαμβάνουν την οθόνη σας όταν η συσκευή είναι κλειδωμένη ή σε χρήση. Χρησιμοποιείται συνήθως για ξυπνητήρια, κλήσεις και άλλα χρονικά ευαίσθητα συμβάντα.</string>
+    <string name="permission_full_screen_intent_label">Ειδοποιήσεις Πλήρους Οθόνης</string>
+    <string name="permission_interact_across_profiles_description">Επιτρέπει στις εφαρμογές να επικοινωνούν μεταξύ των επαγγελματικών και προσωπικών προφίλ σας, μοιράζοντας δεδομένα και λειτουργικότητα μεταξύ των ορίων προφίλ.</string>
+    <string name="permission_interact_across_profiles_label">Συνδεδεμένες Επαγγελματικές και Προσωπικές Εφαρμογές</string>
+    <string name="permission_loader_usage_stats_description">Επιτρέπει στις εφαρμογές να συλλέγουν στατιστικά στοιχεία σχετικά με τη χρήση του φορτωτή δεδομένων στη συσκευή.</string>
+    <string name="permission_loader_usage_stats_label">Στατιστικά Χρήσης Φορτωτή</string>
+    <string name="permissions_details_empty_filter_message">Δεν υπάρχουν εφαρμογές που να ταιριάζουν με τα τρέχοντα φίλτρα. Πατήστε το εικονίδιο φίλτρου για προσαρμογή.</string>
+    <string name="permission_turn_screen_on_description">Επιτρέπει στις εφαρμογές να ενεργοποιούν την οθόνη της συσκευής όταν χρειάζονται την προσοχή σας, όπως για ξυπνητήρια ή εισερχόμενες κλήσεις.</string>
+    <string name="permission_turn_screen_on_label">Ενεργοποίηση Οθόνης</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -262,4 +262,21 @@
     <string name="onboarding_body1">Esta aplicación te ayuda a navegar por las aplicaciones instaladas y descubrir los permisos.</string>
     <string name="onboarding_body2">Piloto de los Permisos recopila información de las aplicaciones instaladas para permitir listar tus apps y cruzar sus permisos al usar esta aplicación.</string>
     <string name="onboarding_body3">Piloto de los Permisos no tiene anuncios y sólo procesa datos localmente.</string>
+
+    <string name="apps_details_empty_filter_message">Ningún permiso coincide con los filtros actuales. Toca el icono de filtro para ajustarlos.</string>
+    <string name="filter_configurable_label">Configurable</string>
+    <string name="filter_denied_label">Denegado</string>
+    <string name="filter_granted_label">Concedido</string>
+    <string name="general_collapse_all_action">Contraer todo</string>
+    <string name="general_expand_all_action">Expandir todo</string>
+    <string name="general_more_options_action">Más opciones</string>
+    <string name="permission_full_screen_intent_description">Permite que las aplicaciones muestren notificaciones a pantalla completa que ocupan la pantalla cuando el dispositivo está bloqueado o en uso. Se usa comúnmente para alarmas, llamadas y otros eventos urgentes.</string>
+    <string name="permission_full_screen_intent_label">Notificaciones a pantalla completa</string>
+    <string name="permission_interact_across_profiles_description">Permite que las aplicaciones se comuniquen entre tus perfiles de trabajo y personal, compartiendo datos y funcionalidad entre perfiles.</string>
+    <string name="permission_interact_across_profiles_label">Aplicaciones de trabajo y personales conectadas</string>
+    <string name="permission_loader_usage_stats_description">Permite que las aplicaciones recopilen estadísticas sobre el uso del cargador de datos en el dispositivo.</string>
+    <string name="permission_loader_usage_stats_label">Estadísticas de uso del cargador</string>
+    <string name="permissions_details_empty_filter_message">Ninguna aplicación coincide con los filtros actuales. Toca el icono de filtro para ajustarlos.</string>
+    <string name="permission_turn_screen_on_description">Permite que las aplicaciones enciendan la pantalla del dispositivo cuando necesitan tu atención, como para alarmas o llamadas entrantes.</string>
+    <string name="permission_turn_screen_on_label">Encender pantalla</string>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -346,4 +346,21 @@
         <item quantity="one">%s kohde</item>
         <item quantity="other">%s kohdetta</item>
     </plurals>
+
+    <string name="apps_details_empty_filter_message">Yksikään käyttöoikeus ei vastaa nykyisiä suodattimia. Napauta suodatinkuvaketta säätääksesi.</string>
+    <string name="filter_configurable_label">Määritettävissä</string>
+    <string name="filter_denied_label">Evätty</string>
+    <string name="filter_granted_label">Myönnetty</string>
+    <string name="general_collapse_all_action">Pienennä kaikki</string>
+    <string name="general_expand_all_action">Laajenna kaikki</string>
+    <string name="general_more_options_action">Lisää vaihtoehtoja</string>
+    <string name="permission_full_screen_intent_description">Sallii sovellusten näyttää koko näytön ilmoituksia, jotka valtaavat näytön, kun laite on lukittu tai käytössä. Käytetään yleisesti herätyksiin, puheluihin ja muihin aikakriittisiin tapahtumiin.</string>
+    <string name="permission_full_screen_intent_label">Koko näytön ilmoitukset</string>
+    <string name="permission_interact_across_profiles_description">Sallii sovellusten kommunikoida työ- ja henkilökohtaisten profiilien välillä, jakaen tietoja ja toimintoja profiilirajojen yli.</string>
+    <string name="permission_interact_across_profiles_label">Yhdistetyt työ- ja henkilökohtaiset sovellukset</string>
+    <string name="permission_loader_usage_stats_description">Sallii sovellusten kerätä tilastoja tietojen lataajien käytöstä laitteella.</string>
+    <string name="permission_loader_usage_stats_label">Lataajan käyttötilastot</string>
+    <string name="permissions_details_empty_filter_message">Yksikään sovellus ei vastaa nykyisiä suodattimia. Napauta suodatinkuvaketta säätääksesi.</string>
+    <string name="permission_turn_screen_on_description">Sallii sovellusten kytkeä laitteen näytön päälle, kun ne tarvitsevat huomiotasi, kuten herätyksiin tai saapuviin puheluihin.</string>
+    <string name="permission_turn_screen_on_label">Kytke näyttö päälle</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -263,4 +263,21 @@
     <string name="onboarding_body1">Cette application vous aide à naviguer dans les applications installées et à découvrir les autorisations.</string>
     <string name="onboarding_body2">Permission Pilot collecte des informations sur les applications installées pour permettre de lister vos applications et de faire des références croisées de leurs autorisations lors de l\'utilisation de cette application.</string>
     <string name="onboarding_body3">Permission Pilot n\'a pas de publicité et ne traite les données que localement.</string>
+
+    <string name="apps_details_empty_filter_message">Aucune autorisation ne correspond aux filtres actuels. Appuyez sur l\'icône de filtre pour les ajuster.</string>
+    <string name="filter_configurable_label">Configurable</string>
+    <string name="filter_denied_label">Refusée</string>
+    <string name="filter_granted_label">Accordée</string>
+    <string name="general_collapse_all_action">Tout réduire</string>
+    <string name="general_expand_all_action">Tout développer</string>
+    <string name="general_more_options_action">Plus d\'options</string>
+    <string name="permission_full_screen_intent_description">Permet aux applications d\'afficher des notifications en plein écran qui prennent le contrôle de l\'écran lorsque l\'appareil est verrouillé ou en cours d\'utilisation. Couramment utilisé pour les alarmes, les appels et autres événements urgents.</string>
+    <string name="permission_full_screen_intent_label">Notifications plein écran</string>
+    <string name="permission_interact_across_profiles_description">Permet aux applications de communiquer entre vos profils professionnel et personnel, en partageant des données et des fonctionnalités entre les profils.</string>
+    <string name="permission_interact_across_profiles_label">Applications professionnelles et personnelles connectées</string>
+    <string name="permission_loader_usage_stats_description">Permet aux applications de collecter des statistiques sur l\'utilisation des chargeurs de données sur l\'appareil.</string>
+    <string name="permission_loader_usage_stats_label">Statistiques d\'utilisation du chargeur</string>
+    <string name="permissions_details_empty_filter_message">Aucune application ne correspond aux filtres actuels. Appuyez sur l\'icône de filtre pour les ajuster.</string>
+    <string name="permission_turn_screen_on_description">Permet aux applications d\'allumer l\'écran de l\'appareil lorsqu\'elles ont besoin de votre attention, par exemple pour les alarmes ou les appels entrants.</string>
+    <string name="permission_turn_screen_on_label">Allumer l\'écran</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -332,4 +332,20 @@
         <item quantity="one">%s आइटम</item>
         <item quantity="other">%s आइटम</item>
     </plurals>
+    <string name="apps_details_empty_filter_message">कोई अनुमति वर्तमान फ़िल्टर से मेल नहीं खाती। समायोजित करने के लिए फ़िल्टर आइकन पर टैप करें।</string>
+    <string name="filter_configurable_label">कॉन्फ़िगर करने योग्य</string>
+    <string name="filter_denied_label">अस्वीकृत</string>
+    <string name="filter_granted_label">प्रदान किया गया</string>
+    <string name="general_collapse_all_action">सभी संकुचित करें</string>
+    <string name="general_expand_all_action">सभी विस्तृत करें</string>
+    <string name="general_more_options_action">अधिक विकल्प</string>
+    <string name="permission_full_screen_intent_description">ऐप्स को पूर्ण-स्क्रीन सूचनाएं दिखाने की अनुमति देता है जो डिवाइस लॉक होने या उपयोग में होने पर आपकी स्क्रीन पर आ जाती हैं। आमतौर पर अलार्म, कॉल और अन्य समय-संवेदनशील घटनाओं के लिए उपयोग किया जाता है।</string>
+    <string name="permission_full_screen_intent_label">पूर्ण-स्क्रीन सूचनाएं</string>
+    <string name="permission_interact_across_profiles_description">ऐप्स को आपके कार्य और व्यक्तिगत प्रोफ़ाइल के बीच संवाद करने, प्रोफ़ाइल सीमाओं के पार डेटा और कार्यक्षमता साझा करने की अनुमति देता है।</string>
+    <string name="permission_interact_across_profiles_label">कनेक्टेड कार्य और व्यक्तिगत ऐप्स</string>
+    <string name="permission_loader_usage_stats_description">ऐप्स को डिवाइस पर डेटा लोडर उपयोग के बारे में आंकड़े एकत्र करने की अनुमति देता है।</string>
+    <string name="permission_loader_usage_stats_label">लोडर उपयोग आंकड़े</string>
+    <string name="permissions_details_empty_filter_message">कोई ऐप वर्तमान फ़िल्टर से मेल नहीं खाता। समायोजित करने के लिए फ़िल्टर आइकन पर टैप करें।</string>
+    <string name="permission_turn_screen_on_description">ऐप्स को डिवाइस स्क्रीन चालू करने की अनुमति देता है जब उन्हें आपके ध्यान की आवश्यकता होती है, जैसे अलार्म या इनकमिंग कॉल के लिए।</string>
+    <string name="permission_turn_screen_on_label">स्क्रीन चालू करें</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -268,4 +268,21 @@
     <string name="onboarding_body1">Ova aplikacija vam pomaže navigirati instaliranim aplikacijama i otkrivati dozvole.</string>
     <string name="onboarding_body2">Permission Pilot prikuplja informacije o instaliranim aplikacijama kako bi omogućio izlistavanje vaših aplikacija i unakrsno referenciranje njihovih dozvola pri korištenju ove aplikacije.</string>
     <string name="onboarding_body3">Permission Pilot nema reklame i obrađuje podatke samo lokalno.</string>
+
+    <string name="apps_details_empty_filter_message">Nijedna dozvola ne odgovara trenutnim filtrima. Dodirnite ikonu filtra za prilagodbu.</string>
+    <string name="filter_configurable_label">Podesivo</string>
+    <string name="filter_denied_label">Odbijeno</string>
+    <string name="filter_granted_label">Odobreno</string>
+    <string name="general_collapse_all_action">Sažmi sve</string>
+    <string name="general_expand_all_action">Proširi sve</string>
+    <string name="general_more_options_action">Više opcija</string>
+    <string name="permission_full_screen_intent_description">Omogućuje aplikacijama prikazivanje obavijesti na cijelom zaslonu koje preuzimaju zaslon kada je uređaj zaključan ili u upotrebi. Obično se koristi za alarme, pozive i druge vremenski osjetljive događaje.</string>
+    <string name="permission_full_screen_intent_label">Obavijesti na cijelom zaslonu</string>
+    <string name="permission_interact_across_profiles_description">Omogućuje aplikacijama komunikaciju između radnih i osobnih profila, dijeleći podatke i funkcionalnost preko granica profila.</string>
+    <string name="permission_interact_across_profiles_label">Povezane radne i osobne aplikacije</string>
+    <string name="permission_loader_usage_stats_description">Omogućuje aplikacijama prikupljanje statistika o korištenju učitavača podataka na uređaju.</string>
+    <string name="permission_loader_usage_stats_label">Statistika korištenja učitavača</string>
+    <string name="permissions_details_empty_filter_message">Nijedna aplikacija ne odgovara trenutnim filtrima. Dodirnite ikonu filtra za prilagodbu.</string>
+    <string name="permission_turn_screen_on_description">Omogućuje aplikacijama uključivanje zaslona uređaja kada trebaju vašu pozornost, kao što su alarmi ili dolazni pozivi.</string>
+    <string name="permission_turn_screen_on_label">Uključi zaslon</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -263,4 +263,21 @@
     <string name="onboarding_body1">Questa app ti aiuta a navigare nelle applicazioni installate e scoprire i permessi.</string>
     <string name="onboarding_body2">Permission Pilot raccoglie informazioni sulle applicazioni installate per consentire di elencare le tue app e fare riferimenti incrociati dei loro permessi quando usi questa applicazione.</string>
     <string name="onboarding_body3">Permission Pilot non ha pubblicità e elabora i dati solo localmente.</string>
+
+    <string name="apps_details_empty_filter_message">Nessun permesso corrisponde ai filtri attuali. Tocca l\'icona del filtro per modificarli.</string>
+    <string name="filter_configurable_label">Configurabile</string>
+    <string name="filter_denied_label">Negato</string>
+    <string name="filter_granted_label">Concesso</string>
+    <string name="general_collapse_all_action">Comprimi tutto</string>
+    <string name="general_expand_all_action">Espandi tutto</string>
+    <string name="general_more_options_action">Altre opzioni</string>
+    <string name="permission_full_screen_intent_description">Consente alle app di mostrare notifiche a schermo intero che occupano lo schermo quando il dispositivo è bloccato o in uso. Comunemente usato per sveglie, chiamate e altri eventi urgenti.</string>
+    <string name="permission_full_screen_intent_label">Notifiche a schermo intero</string>
+    <string name="permission_interact_across_profiles_description">Consente alle app di comunicare tra i tuoi profili di lavoro e personali, condividendo dati e funzionalità tra i profili.</string>
+    <string name="permission_interact_across_profiles_label">App di lavoro e personali collegate</string>
+    <string name="permission_loader_usage_stats_description">Consente alle app di raccogliere statistiche sull\'utilizzo dei caricatori di dati sul dispositivo.</string>
+    <string name="permission_loader_usage_stats_label">Statistiche utilizzo caricatore</string>
+    <string name="permissions_details_empty_filter_message">Nessuna app corrisponde ai filtri attuali. Tocca l\'icona del filtro per modificarli.</string>
+    <string name="permission_turn_screen_on_description">Consente alle app di accendere lo schermo del dispositivo quando hanno bisogno della tua attenzione, come per sveglie o chiamate in arrivo.</string>
+    <string name="permission_turn_screen_on_label">Accendi schermo</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -258,4 +258,20 @@
     <string name="onboarding_body1">このアプリは、インストールされたアプリケーションをナビゲートし、権限を発見するのに役立ちます。</string>
     <string name="onboarding_body2">Permission Pilotは、このアプリケーションを使用する際にアプリをリストし、その権限をクロスリファレンスすることを可能にするために、インストールされたアプリケーション情報を収集します。</string>
     <string name="onboarding_body3">Permission Pilotには広告がなく、データはローカルでのみ処理されます。</string>
+    <string name="apps_details_empty_filter_message">現在のフィルターに一致する権限がありません。調整するにはフィルターアイコンをタップしてください。</string>
+    <string name="filter_configurable_label">設定可能</string>
+    <string name="filter_denied_label">拒否</string>
+    <string name="filter_granted_label">付与</string>
+    <string name="general_collapse_all_action">すべて折りたたむ</string>
+    <string name="general_expand_all_action">すべて展開</string>
+    <string name="general_more_options_action">その他のオプション</string>
+    <string name="permission_full_screen_intent_description">デバイスがロックされている時や使用中に画面を占有するフルスクリーン通知をアプリが表示することを許可します。一般的にアラーム、電話、その他の時間に敏感なイベントに使用されます。</string>
+    <string name="permission_full_screen_intent_label">フルスクリーン通知</string>
+    <string name="permission_interact_across_profiles_description">アプリが仕事用プロファイルと個人用プロファイル間で通信し、プロファイルの境界を越えてデータと機能を共有することを許可します。</string>
+    <string name="permission_interact_across_profiles_label">接続された仕事用と個人用アプリ</string>
+    <string name="permission_loader_usage_stats_description">アプリがデバイス上のデータローダー使用に関する統計を収集することを許可します。</string>
+    <string name="permission_loader_usage_stats_label">ローダー使用統計</string>
+    <string name="permissions_details_empty_filter_message">現在のフィルターに一致するアプリがありません。調整するにはフィルターアイコンをタップしてください。</string>
+    <string name="permission_turn_screen_on_description">アラームや着信など、注意が必要な時にアプリがデバイスの画面をオンにすることを許可します。</string>
+    <string name="permission_turn_screen_on_label">画面をオンにする</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -258,4 +258,20 @@
     <string name="onboarding_body1">이 앱은 설치된 애플리케이션을 탐색하고 권한을 발견하는 데 도움이 됩니다.</string>
     <string name="onboarding_body2">Permission Pilot은 이 애플리케이션을 사용할 때 앱을 나열하고 해당 권한을 상호 참조할 수 있도록 설치된 애플리케이션 정보를 수집합니다.</string>
     <string name="onboarding_body3">Permission Pilot에는 광고가 없으며 데이터를 로컬에서만 처리합니다.</string>
+    <string name="apps_details_empty_filter_message">현재 필터와 일치하는 권한이 없습니다. 조정하려면 필터 아이콘을 탭하세요.</string>
+    <string name="filter_configurable_label">구성 가능</string>
+    <string name="filter_denied_label">거부됨</string>
+    <string name="filter_granted_label">허용됨</string>
+    <string name="general_collapse_all_action">모두 접기</string>
+    <string name="general_expand_all_action">모두 펼치기</string>
+    <string name="general_more_options_action">더 많은 옵션</string>
+    <string name="permission_full_screen_intent_description">기기가 잠겨 있거나 사용 중일 때 화면을 차지하는 전체 화면 알림을 앱이 표시할 수 있도록 허용합니다. 일반적으로 알람, 전화 및 기타 시간에 민감한 이벤트에 사용됩니다.</string>
+    <string name="permission_full_screen_intent_label">전체 화면 알림</string>
+    <string name="permission_interact_across_profiles_description">앱이 업무용 프로필과 개인 프로필 간에 통신하여 프로필 경계를 넘어 데이터와 기능을 공유할 수 있도록 허용합니다.</string>
+    <string name="permission_interact_across_profiles_label">연결된 업무용 및 개인 앱</string>
+    <string name="permission_loader_usage_stats_description">앱이 기기에서 데이터 로더 사용에 대한 통계를 수집할 수 있도록 허용합니다.</string>
+    <string name="permission_loader_usage_stats_label">로더 사용 통계</string>
+    <string name="permissions_details_empty_filter_message">현재 필터와 일치하는 앱이 없습니다. 조정하려면 필터 아이콘을 탭하세요.</string>
+    <string name="permission_turn_screen_on_description">알람이나 수신 전화와 같이 주의가 필요할 때 앱이 기기 화면을 켤 수 있도록 허용합니다.</string>
+    <string name="permission_turn_screen_on_label">화면 켜기</string>
 </resources>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -263,4 +263,21 @@
     <string name="onboarding_body1">Denne appen hjelper deg med å navigere installerte applikasjoner og oppdage tillatelser.</string>
     <string name="onboarding_body2">Permission Pilot samler inn informasjon om installerte applikasjoner for å gjøre det mulig å liste appene dine og kryssreferere tillatelsene deres når du bruker denne applikasjonen.</string>
     <string name="onboarding_body3">Permission Pilot har ingen annonser og behandler kun data lokalt.</string>
+
+    <string name="apps_details_empty_filter_message">Ingen tillatelser samsvarer med gjeldende filtre. Trykk på filterikonet for å justere.</string>
+    <string name="filter_configurable_label">Konfigurerbar</string>
+    <string name="filter_denied_label">Nektet</string>
+    <string name="filter_granted_label">Innvilget</string>
+    <string name="general_collapse_all_action">Skjul alle</string>
+    <string name="general_expand_all_action">Utvid alle</string>
+    <string name="general_more_options_action">Flere alternativer</string>
+    <string name="permission_full_screen_intent_description">Lar apper vise fullskjermsvarsler som tar over skjermen når enheten er låst eller i bruk. Brukes ofte for alarmer, samtaler og andre tidssensitive hendelser.</string>
+    <string name="permission_full_screen_intent_label">Fullskjermsvarsler</string>
+    <string name="permission_interact_across_profiles_description">Lar apper kommunisere mellom jobb- og personlige profiler, og dele data og funksjonalitet på tvers av profilgrenser.</string>
+    <string name="permission_interact_across_profiles_label">Tilkoblede jobb- og personlige apper</string>
+    <string name="permission_loader_usage_stats_description">Lar apper samle inn statistikk om bruk av datalastere på enheten.</string>
+    <string name="permission_loader_usage_stats_label">Statistikk for lasterbruk</string>
+    <string name="permissions_details_empty_filter_message">Ingen apper samsvarer med gjeldende filtre. Trykk på filterikonet for å justere.</string>
+    <string name="permission_turn_screen_on_description">Lar apper slå på enhetens skjerm når de trenger oppmerksomheten din, for eksempel for alarmer eller innkommende samtaler.</string>
+    <string name="permission_turn_screen_on_label">Slå på skjerm</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -263,4 +263,21 @@
     <string name="onboarding_body1">Deze app helpt je navigeren door geïnstalleerde applicaties en machtigingen ontdekken.</string>
     <string name="onboarding_body2">Permission Pilot verzamelt informatie over geïnstalleerde applicaties om het mogelijk te maken je apps weer te geven en hun machtigingen kruislings te refereren bij het gebruik van deze applicatie.</string>
     <string name="onboarding_body3">Permission Pilot heeft geen advertenties en verwerkt gegevens alleen lokaal.</string>
+
+    <string name="apps_details_empty_filter_message">Geen machtigingen komen overeen met de huidige filters. Tik op het filterpictogram om aan te passen.</string>
+    <string name="filter_configurable_label">Configureerbaar</string>
+    <string name="filter_denied_label">Geweigerd</string>
+    <string name="filter_granted_label">Verleend</string>
+    <string name="general_collapse_all_action">Alles inklappen</string>
+    <string name="general_expand_all_action">Alles uitklappen</string>
+    <string name="general_more_options_action">Meer opties</string>
+    <string name="permission_full_screen_intent_description">Staat apps toe om volledig-scherm meldingen te tonen die je scherm overnemen wanneer het apparaat vergrendeld is of in gebruik is. Vaak gebruikt voor wekkers, oproepen en andere tijdgevoelige gebeurtenissen.</string>
+    <string name="permission_full_screen_intent_label">Volledig-scherm meldingen</string>
+    <string name="permission_interact_across_profiles_description">Staat apps toe om te communiceren tussen je werk- en persoonlijke profielen, waarbij gegevens en functionaliteit worden gedeeld over profielgrenzen.</string>
+    <string name="permission_interact_across_profiles_label">Verbonden werk- en persoonlijke apps</string>
+    <string name="permission_loader_usage_stats_description">Staat apps toe om statistieken te verzamelen over het gebruik van data loaders op het apparaat.</string>
+    <string name="permission_loader_usage_stats_label">Loader-gebruiksstatistieken</string>
+    <string name="permissions_details_empty_filter_message">Geen apps komen overeen met de huidige filters. Tik op het filterpictogram om aan te passen.</string>
+    <string name="permission_turn_screen_on_description">Staat apps toe om het scherm van het apparaat in te schakelen wanneer ze je aandacht nodig hebben, zoals voor wekkers of inkomende oproepen.</string>
+    <string name="permission_turn_screen_on_label">Scherm inschakelen</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -273,4 +273,21 @@
     <string name="onboarding_body1">Ta aplikacja pomaga ci nawigować po zainstalowanych aplikacjach i odkrywać uprawnienia.</string>
     <string name="onboarding_body2">Permission Pilot zbiera informacje o zainstalowanych aplikacjach, aby umożliwić wyświetlanie twoich aplikacji i krzyżowe odwoływanie się do ich uprawnień podczas korzystania z tej aplikacji.</string>
     <string name="onboarding_body3">Permission Pilot nie ma reklam i przetwarza dane tylko lokalnie.</string>
+
+    <string name="apps_details_empty_filter_message">Żadne uprawnienia nie pasują do obecnych filtrów. Stuknij ikonę filtra, aby dostosować.</string>
+    <string name="filter_configurable_label">Konfigurowalny</string>
+    <string name="filter_denied_label">Odmówiono</string>
+    <string name="filter_granted_label">Przyznano</string>
+    <string name="general_collapse_all_action">Zwiń wszystko</string>
+    <string name="general_expand_all_action">Rozwiń wszystko</string>
+    <string name="general_more_options_action">Więcej opcji</string>
+    <string name="permission_full_screen_intent_description">Pozwala aplikacjom wyświetlać powiadomienia pełnoekranowe, które przejmują ekran, gdy urządzenie jest zablokowane lub w użyciu. Powszechnie używane do alarmów, połączeń i innych zdarzeń wrażliwych czasowo.</string>
+    <string name="permission_full_screen_intent_label">Powiadomienia pełnoekranowe</string>
+    <string name="permission_interact_across_profiles_description">Pozwala aplikacjom komunikować się między profilami służbowym i osobistym, udostępniając dane i funkcje między granicami profili.</string>
+    <string name="permission_interact_across_profiles_label">Połączone aplikacje służbowe i osobiste</string>
+    <string name="permission_loader_usage_stats_description">Pozwala aplikacjom zbierać statystyki dotyczące użycia ładowaczy danych na urządzeniu.</string>
+    <string name="permission_loader_usage_stats_label">Statystyki użycia ładowacza</string>
+    <string name="permissions_details_empty_filter_message">Żadne aplikacje nie pasują do obecnych filtrów. Stuknij ikonę filtra, aby dostosować.</string>
+    <string name="permission_turn_screen_on_description">Pozwala aplikacjom włączać ekran urządzenia, gdy potrzebują twojej uwagi, na przykład do alarmów lub połączeń przychodzących.</string>
+    <string name="permission_turn_screen_on_label">Włącz ekran</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -263,4 +263,21 @@
     <string name="onboarding_body1">Este app ajuda você a navegar por aplicações instaladas e descobrir permissões.</string>
     <string name="onboarding_body2">Permission Pilot coleta informações de Aplicação Instalada para permitir listar seus apps e fazer referência cruzada de suas permissões ao usar esta aplicação.</string>
     <string name="onboarding_body3">Permission Pilot não tem anúncios e apenas processa dados localmente.</string>
+
+    <string name="apps_details_empty_filter_message">Nenhuma permissão corresponde aos filtros atuais. Toque no ícone de filtro para ajustar.</string>
+    <string name="filter_configurable_label">Configurável</string>
+    <string name="filter_denied_label">Negada</string>
+    <string name="filter_granted_label">Concedida</string>
+    <string name="general_collapse_all_action">Recolher tudo</string>
+    <string name="general_expand_all_action">Expandir tudo</string>
+    <string name="general_more_options_action">Mais opções</string>
+    <string name="permission_full_screen_intent_description">Permite que apps mostrem notificações em tela cheia que tomam conta da tela quando o dispositivo está bloqueado ou em uso. Comumente usado para alarmes, chamadas e outros eventos urgentes.</string>
+    <string name="permission_full_screen_intent_label">Notificações em tela cheia</string>
+    <string name="permission_interact_across_profiles_description">Permite que apps se comuniquem entre seus perfis de trabalho e pessoal, compartilhando dados e funcionalidades entre perfis.</string>
+    <string name="permission_interact_across_profiles_label">Apps de trabalho e pessoais conectados</string>
+    <string name="permission_loader_usage_stats_description">Permite que apps coletem estatísticas sobre o uso de carregadores de dados no dispositivo.</string>
+    <string name="permission_loader_usage_stats_label">Estatísticas de uso do carregador</string>
+    <string name="permissions_details_empty_filter_message">Nenhum app corresponde aos filtros atuais. Toque no ícone de filtro para ajustar.</string>
+    <string name="permission_turn_screen_on_description">Permite que apps liguem a tela do dispositivo quando precisam da sua atenção, como para alarmes ou chamadas recebidas.</string>
+    <string name="permission_turn_screen_on_label">Ligar tela</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -247,4 +247,21 @@
     <string name="permission_group_audio_description">Permissões relacionadas com o microfone.</string>
     <string name="permission_group_camera_label">Câmara</string>
     <string name="permission_group_camera_description">Permissões relacionadas com a câmara.</string>
+
+    <string name="apps_details_empty_filter_message">Nenhuma permissão corresponde aos filtros atuais. Toque no ícone de filtro para ajustar.</string>
+    <string name="filter_configurable_label">Configurável</string>
+    <string name="filter_denied_label">Negada</string>
+    <string name="filter_granted_label">Concedida</string>
+    <string name="general_collapse_all_action">Recolher tudo</string>
+    <string name="general_expand_all_action">Expandir tudo</string>
+    <string name="general_more_options_action">Mais opções</string>
+    <string name="permission_full_screen_intent_description">Permite que as aplicações mostrem notificações em ecrã inteiro que ocupam o ecrã quando o dispositivo está bloqueado ou em uso. Normalmente usado para alarmes, chamadas e outros eventos urgentes.</string>
+    <string name="permission_full_screen_intent_label">Notificações em ecrã inteiro</string>
+    <string name="permission_interact_across_profiles_description">Permite que as aplicações comuniquem entre os seus perfis de trabalho e pessoal, partilhando dados e funcionalidades entre perfis.</string>
+    <string name="permission_interact_across_profiles_label">Apps de trabalho e pessoais ligadas</string>
+    <string name="permission_loader_usage_stats_description">Permite que as aplicações recolham estatísticas sobre o uso de carregadores de dados no dispositivo.</string>
+    <string name="permission_loader_usage_stats_label">Estatísticas de uso do carregador</string>
+    <string name="permissions_details_empty_filter_message">Nenhuma aplicação corresponde aos filtros atuais. Toque no ícone de filtro para ajustar.</string>
+    <string name="permission_turn_screen_on_description">Permite que as aplicações liguem o ecrã do dispositivo quando precisam da sua atenção, como para alarmes ou chamadas recebidas.</string>
+    <string name="permission_turn_screen_on_label">Ligar ecrã</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -572,4 +572,21 @@
         <item quantity="few">%d aplicații de sistem</item>
         <item quantity="other">%d de aplicații de sistem</item>
     </plurals>
+
+    <string name="apps_details_empty_filter_message">Nicio permisiune nu corespunde filtrelor curente. Apăsați pictograma de filtrare pentru a ajusta.</string>
+    <string name="filter_configurable_label">Configurabil</string>
+    <string name="filter_denied_label">Refuzată</string>
+    <string name="filter_granted_label">Acordată</string>
+    <string name="general_collapse_all_action">Restrânge tot</string>
+    <string name="general_expand_all_action">Extinde tot</string>
+    <string name="general_more_options_action">Mai multe opțiuni</string>
+    <string name="permission_full_screen_intent_description">Permite aplicațiilor să afișeze notificări pe ecran complet care preiau ecranul când dispozitivul este blocat sau în uz. Folosit frecvent pentru alarme, apeluri și alte evenimente urgente.</string>
+    <string name="permission_full_screen_intent_label">Notificări pe ecran complet</string>
+    <string name="permission_interact_across_profiles_description">Permite aplicațiilor să comunice între profilurile de serviciu și personale, partajând date și funcționalitate între limitele profilurilor.</string>
+    <string name="permission_interact_across_profiles_label">Aplicații de serviciu și personale conectate</string>
+    <string name="permission_loader_usage_stats_description">Permite aplicațiilor să colecteze statistici despre utilizarea încărcătoarelor de date pe dispozitiv.</string>
+    <string name="permission_loader_usage_stats_label">Statistici de utilizare a încărcătorului</string>
+    <string name="permissions_details_empty_filter_message">Nicio aplicație nu corespunde filtrelor curente. Apăsați pictograma de filtrare pentru a ajusta.</string>
+    <string name="permission_turn_screen_on_description">Permite aplicațiilor să pornească ecranul dispozitivului când au nevoie de atenția dvs., cum ar fi pentru alarme sau apeluri primite.</string>
+    <string name="permission_turn_screen_on_label">Pornește ecranul</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -262,4 +262,21 @@
     <string name="onboarding_body1">Это приложение поможет вам навигировать по установленным приложениям и изучать разрешения.</string>
     <string name="onboarding_body2">Permission Pilot собирает информацию об установленных приложениях, чтобы отображать ваши приложения и сопоставлять их разрешения при использовании данного приложения.</string>
     <string name="onboarding_body3">Permission Pilot не содержит рекламы и обрабатывает данные только локально.</string>
+
+    <string name="apps_details_empty_filter_message">Нет разрешений, соответствующих текущим фильтрам. Нажмите на значок фильтра для настройки.</string>
+    <string name="filter_configurable_label">Настраиваемые</string>
+    <string name="filter_denied_label">Отклонённые</string>
+    <string name="filter_granted_label">Предоставленные</string>
+    <string name="general_collapse_all_action">Свернуть все</string>
+    <string name="general_expand_all_action">Развернуть все</string>
+    <string name="general_more_options_action">Дополнительные параметры</string>
+    <string name="permission_full_screen_intent_description">Позволяет приложениям показывать полноэкранные уведомления, которые занимают весь экран, когда устройство заблокировано или используется. Обычно используется для будильников, звонков и других срочных событий.</string>
+    <string name="permission_full_screen_intent_label">Полноэкранные уведомления</string>
+    <string name="permission_interact_across_profiles_description">Позволяет приложениям взаимодействовать между рабочим и личным профилями, обмениваясь данными и функциями между профилями.</string>
+    <string name="permission_interact_across_profiles_label">Связанные рабочие и личные приложения</string>
+    <string name="permission_loader_usage_stats_description">Позволяет приложениям собирать статистику об использовании загрузчика данных на устройстве.</string>
+    <string name="permission_loader_usage_stats_label">Статистика использования загрузчика</string>
+    <string name="permissions_details_empty_filter_message">Нет приложений, соответствующих текущим фильтрам. Нажмите на значок фильтра для настройки.</string>
+    <string name="permission_turn_screen_on_description">Позволяет приложениям включать экран устройства, когда им требуется ваше внимание, например, для будильников или входящих звонков.</string>
+    <string name="permission_turn_screen_on_label">Включение экрана</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -345,4 +345,21 @@
         <item quantity="many">%s položiek</item>
         <item quantity="other">%s položiek</item>
     </plurals>
+
+    <string name="apps_details_empty_filter_message">Žiadne oprávnenia nezodpovedajú aktuálnym filtrom. Ťuknite na ikonu filtra pre úpravu.</string>
+    <string name="filter_configurable_label">Konfigurovateľné</string>
+    <string name="filter_denied_label">Zamietnuté</string>
+    <string name="filter_granted_label">Udelené</string>
+    <string name="general_collapse_all_action">Zbaliť všetko</string>
+    <string name="general_expand_all_action">Rozbaliť všetko</string>
+    <string name="general_more_options_action">Ďalšie možnosti</string>
+    <string name="permission_full_screen_intent_description">Umožňuje aplikáciám zobrazovať oznámenia na celú obrazovku, ktoré prevezmú obrazovku, keď je zariadenie zamknuté alebo používané. Bežne sa používa pre budíky, hovory a iné časovo citlivé udalosti.</string>
+    <string name="permission_full_screen_intent_label">Oznámenia na celú obrazovku</string>
+    <string name="permission_interact_across_profiles_description">Umožňuje aplikáciám komunikovať medzi pracovnými a osobnými profilmi a zdieľať dáta a funkcie cez hranice profilov.</string>
+    <string name="permission_interact_across_profiles_label">Prepojené pracovné a osobné aplikácie</string>
+    <string name="permission_loader_usage_stats_description">Umožňuje aplikáciám zbierať štatistiky o používaní dátových zavádzačov na zariadení.</string>
+    <string name="permission_loader_usage_stats_label">Štatistiky využitia zavádzača</string>
+    <string name="permissions_details_empty_filter_message">Žiadne aplikácie nezodpovedajú aktuálnym filtrom. Ťuknite na ikonu filtra pre úpravu.</string>
+    <string name="permission_turn_screen_on_description">Umožňuje aplikáciám zapnúť obrazovku zariadenia, keď potrebujú vašu pozornosť, napríklad pre budíky alebo prichádzajúce hovory.</string>
+    <string name="permission_turn_screen_on_label">Zapnúť obrazovku</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -263,4 +263,21 @@
     <string name="onboarding_body1">Denna app hjälper dig navigera installerade applikationer och upptäcka behörigheter.</string>
     <string name="onboarding_body2">Permission Pilot samlar in information om installerade applikationer för att möjliggöra listning av dina appar och korsreferering av deras behörigheter när du använder denna applikation.</string>
     <string name="onboarding_body3">Permission Pilot har inga annonser och bearbetar endast data lokalt.</string>
+
+    <string name="apps_details_empty_filter_message">Inga behörigheter matchar aktuella filter. Tryck på filterikonen för att justera.</string>
+    <string name="filter_configurable_label">Konfigurerbar</string>
+    <string name="filter_denied_label">Nekad</string>
+    <string name="filter_granted_label">Beviljad</string>
+    <string name="general_collapse_all_action">Fäll ihop alla</string>
+    <string name="general_expand_all_action">Expandera alla</string>
+    <string name="general_more_options_action">Fler alternativ</string>
+    <string name="permission_full_screen_intent_description">Låter appar visa helskärmsnotifieringar som tar över din skärm när enheten är låst eller används. Används ofta för larm, samtal och andra tidskänsliga händelser.</string>
+    <string name="permission_full_screen_intent_label">Helskärmsnotifieringar</string>
+    <string name="permission_interact_across_profiles_description">Låter appar kommunicera mellan dina arbets- och personliga profiler och dela data och funktionalitet över profilgränser.</string>
+    <string name="permission_interact_across_profiles_label">Anslutna arbets- och personliga appar</string>
+    <string name="permission_loader_usage_stats_description">Låter appar samla in statistik om användning av dataladdare på enheten.</string>
+    <string name="permission_loader_usage_stats_label">Statistik för laddaranvändning</string>
+    <string name="permissions_details_empty_filter_message">Inga appar matchar aktuella filter. Tryck på filterikonen för att justera.</string>
+    <string name="permission_turn_screen_on_description">Låter appar slå på enhetens skärm när de behöver din uppmärksamhet, till exempel för larm eller inkommande samtal.</string>
+    <string name="permission_turn_screen_on_label">Slå på skärm</string>
 </resources>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -258,4 +258,20 @@
     <string name="onboarding_body1">แอปนี้ช่วยคุณในการนำทางแอปพลิเคชันที่ติดตั้งและค้นพบสิทธิ์</string>
     <string name="onboarding_body2">Permission Pilot รวบรวมข้อมูลแอปพลิเคชันที่ติดตั้งเพื่อให้สามารถแสดงรายการแอปของคุณและอ้างอิงสิทธิ์ข้ามกันเมื่อใช้แอปพลิเคชันนี้</string>
     <string name="onboarding_body3">Permission Pilot ไม่มีโฆษณาและประมวลผลข้อมูลในเครื่องเท่านั้น</string>
+    <string name="apps_details_empty_filter_message">ไม่มีสิทธิ์ที่ตรงกับตัวกรองปัจจุบัน แตะไอคอนตัวกรองเพื่อปรับ</string>
+    <string name="filter_configurable_label">กำหนดค่าได้</string>
+    <string name="filter_denied_label">ถูกปฏิเสธ</string>
+    <string name="filter_granted_label">ได้รับอนุญาต</string>
+    <string name="general_collapse_all_action">ยุบทั้งหมด</string>
+    <string name="general_expand_all_action">ขยายทั้งหมด</string>
+    <string name="general_more_options_action">ตัวเลือกเพิ่มเติม</string>
+    <string name="permission_full_screen_intent_description">อนุญาตให้แอปแสดงการแจ้งเตือนแบบเต็มหน้าจอที่ครอบคลุมหน้าจอของคุณเมื่ออุปกรณ์ถูกล็อคหรือกำลังใช้งาน มักใช้สำหรับการปลุก การโทร และเหตุการณ์ที่ไวต่อเวลา</string>
+    <string name="permission_full_screen_intent_label">การแจ้งเตือนแบบเต็มหน้าจอ</string>
+    <string name="permission_interact_across_profiles_description">อนุญาตให้แอปสื่อสารระหว่างโปรไฟล์งานและส่วนตัวของคุณ แชร์ข้อมูลและฟังก์ชันข้ามขอบเขตโปรไฟล์</string>
+    <string name="permission_interact_across_profiles_label">แอปงานและส่วนตัวที่เชื่อมต่อ</string>
+    <string name="permission_loader_usage_stats_description">อนุญาตให้แอปรวบรวมสถิติเกี่ยวกับการใช้ตัวโหลดข้อมูลบนอุปกรณ์</string>
+    <string name="permission_loader_usage_stats_label">สถิติการใช้ตัวโหลด</string>
+    <string name="permissions_details_empty_filter_message">ไม่มีแอปที่ตรงกับตัวกรองปัจจุบัน แตะไอคอนตัวกรองเพื่อปรับ</string>
+    <string name="permission_turn_screen_on_description">อนุญาตให้แอปเปิดหน้าจออุปกรณ์เมื่อต้องการความสนใจจากคุณ เช่น สำหรับการปลุกหรือสายเรียกเข้า</string>
+    <string name="permission_turn_screen_on_label">เปิดหน้าจอ</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -263,4 +263,21 @@
     <string name="onboarding_body1">Bu uygulama, yüklü uygulamalarda gezinmenize ve izinleri keşfetmenize yardımcı olur.</string>
     <string name="onboarding_body2">Permission Pilot, bu uygulamayı kullanırken uygulamalarınızı listelemek ve izinlerini çapraz referanslamak için Yüklü Uygulama bilgilerini toplar.</string>
     <string name="onboarding_body3">Permission Pilot\'ta reklam yoktur ve verileri yalnızca yerel olarak işler.</string>
+
+    <string name="apps_details_empty_filter_message">Mevcut filtrelere uyan izin yok. Ayarlamak için filtre simgesine dokunun.</string>
+    <string name="filter_configurable_label">Yapılandırılabilir</string>
+    <string name="filter_denied_label">Reddedilen</string>
+    <string name="filter_granted_label">Verilen</string>
+    <string name="general_collapse_all_action">Tümünü daralt</string>
+    <string name="general_expand_all_action">Tümünü genişlet</string>
+    <string name="general_more_options_action">Daha fazla seçenek</string>
+    <string name="permission_full_screen_intent_description">Uygulamaların, cihaz kilitliyken veya kullanımdayken ekranınızı kaplayan tam ekran bildirimler göstermesine izin verir. Genellikle alarmlar, aramalar ve diğer zamana duyarlı olaylar için kullanılır.</string>
+    <string name="permission_full_screen_intent_label">Tam Ekran Bildirimler</string>
+    <string name="permission_interact_across_profiles_description">Uygulamaların iş ve kişisel profilleriniz arasında iletişim kurmasına, profil sınırları arasında veri ve işlevsellik paylaşmasına izin verir.</string>
+    <string name="permission_interact_across_profiles_label">Bağlı İş ve Kişisel Uygulamalar</string>
+    <string name="permission_loader_usage_stats_description">Uygulamaların cihazdaki veri yükleyici kullanımı hakkında istatistik toplamasına izin verir.</string>
+    <string name="permission_loader_usage_stats_label">Yükleyici Kullanım İstatistikleri</string>
+    <string name="permissions_details_empty_filter_message">Mevcut filtrelere uyan uygulama yok. Ayarlamak için filtre simgesine dokunun.</string>
+    <string name="permission_turn_screen_on_description">Uygulamaların alarmlar veya gelen aramalar gibi dikkatinize ihtiyaç duyduklarında cihaz ekranını açmasına izin verir.</string>
+    <string name="permission_turn_screen_on_label">Ekranı Aç</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -273,4 +273,21 @@
     <string name="onboarding_body1">Ця програма допомагає вам навігувати встановленими програмами та виявляти дозволи.</string>
     <string name="onboarding_body2">Permission Pilot збирає інформацію про встановлені програми, щоб дозволити перелічувати ваші програми та перехресно посилатися на їх дозволи під час використання цієї програми.</string>
     <string name="onboarding_body3">Permission Pilot не має реклами і обробляє дані лише локально.</string>
+
+    <string name="apps_details_empty_filter_message">Немає дозволів, що відповідають поточним фільтрам. Натисніть на значок фільтра для налаштування.</string>
+    <string name="filter_configurable_label">Налаштовувані</string>
+    <string name="filter_denied_label">Відхилені</string>
+    <string name="filter_granted_label">Надані</string>
+    <string name="general_collapse_all_action">Згорнути все</string>
+    <string name="general_expand_all_action">Розгорнути все</string>
+    <string name="general_more_options_action">Додаткові параметри</string>
+    <string name="permission_full_screen_intent_description">Дозволяє програмам показувати повноекранні сповіщення, які займають весь екран, коли пристрій заблоковано або використовується. Зазвичай використовується для будильників, дзвінків та інших термінових подій.</string>
+    <string name="permission_full_screen_intent_label">Повноекранні сповіщення</string>
+    <string name="permission_interact_across_profiles_description">Дозволяє програмам взаємодіяти між робочим і особистим профілями, обмінюючись даними та функціями між профілями.</string>
+    <string name="permission_interact_across_profiles_label">Пов\'язані робочі та особисті програми</string>
+    <string name="permission_loader_usage_stats_description">Дозволяє програмам збирати статистику про використання завантажувача даних на пристрої.</string>
+    <string name="permission_loader_usage_stats_label">Статистика використання завантажувача</string>
+    <string name="permissions_details_empty_filter_message">Немає програм, що відповідають поточним фільтрам. Натисніть на значок фільтра для налаштування.</string>
+    <string name="permission_turn_screen_on_description">Дозволяє програмам вмикати екран пристрою, коли їм потрібна ваша увага, наприклад, для будильників або вхідних дзвінків.</string>
+    <string name="permission_turn_screen_on_label">Увімкнення екрана</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -258,5 +258,20 @@
     <string name="onboarding_body1">Ứng dụng này giúp bạn điều hướng các ứng dụng đã cài đặt và khám phá quyền.</string>
     <string name="onboarding_body2">Permission Pilot thu thập thông tin ứng dụng đã cài đặt để cho phép liệt kê ứng dụng của bạn và tham chiếu chéo quyền của chúng khi sử dụng ứng dụng này.</string>
     <string name="onboarding_body3">Permission Pilot không có quảng cáo và chỉ xử lý dữ liệu cục bộ.</string>
-    +
+    <string name="apps_details_empty_filter_message">Không có quyền nào khớp với bộ lọc hiện tại. Nhấn vào biểu tượng bộ lọc để điều chỉnh.</string>
+    <string name="filter_configurable_label">Có thể cấu hình</string>
+    <string name="filter_denied_label">Bị từ chối</string>
+    <string name="filter_granted_label">Đã cấp</string>
+    <string name="general_collapse_all_action">Thu gọn tất cả</string>
+    <string name="general_expand_all_action">Mở rộng tất cả</string>
+    <string name="general_more_options_action">Thêm tùy chọn</string>
+    <string name="permission_full_screen_intent_description">Cho phép ứng dụng hiển thị thông báo toàn màn hình chiếm lấy màn hình của bạn khi thiết bị bị khóa hoặc đang sử dụng. Thường được sử dụng cho báo thức, cuộc gọi và các sự kiện nhạy cảm với thời gian.</string>
+    <string name="permission_full_screen_intent_label">Thông báo toàn màn hình</string>
+    <string name="permission_interact_across_profiles_description">Cho phép ứng dụng giao tiếp giữa hồ sơ công việc và cá nhân của bạn, chia sẻ dữ liệu và chức năng qua ranh giới hồ sơ.</string>
+    <string name="permission_interact_across_profiles_label">Ứng dụng công việc và cá nhân được kết nối</string>
+    <string name="permission_loader_usage_stats_description">Cho phép ứng dụng thu thập thống kê về việc sử dụng trình tải dữ liệu trên thiết bị.</string>
+    <string name="permission_loader_usage_stats_label">Thống kê sử dụng trình tải</string>
+    <string name="permissions_details_empty_filter_message">Không có ứng dụng nào khớp với bộ lọc hiện tại. Nhấn vào biểu tượng bộ lọc để điều chỉnh.</string>
+    <string name="permission_turn_screen_on_description">Cho phép ứng dụng bật màn hình thiết bị khi cần sự chú ý của bạn, chẳng hạn như cho báo thức hoặc cuộc gọi đến.</string>
+    <string name="permission_turn_screen_on_label">Bật màn hình</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -262,4 +262,20 @@
     <string name="onboarding_body1">这款应用可以帮助您浏览已安装的应用程序并发现其权限。</string>
     <string name="onboarding_body2">Permission Pilot 收集已安装应用程序的信息，以便在使用本应用程序时列出您的应用程序并交叉引用其权限。</string>
     <string name="onboarding_body3">Permission Pilot 不含广告，仅在本地处理数据。</string>
+    <string name="apps_details_empty_filter_message">没有权限符合当前筛选条件。点击筛选图标进行调整。</string>
+    <string name="filter_configurable_label">可配置</string>
+    <string name="filter_denied_label">已拒绝</string>
+    <string name="filter_granted_label">已授予</string>
+    <string name="general_collapse_all_action">全部折叠</string>
+    <string name="general_expand_all_action">全部展开</string>
+    <string name="general_more_options_action">更多选项</string>
+    <string name="permission_full_screen_intent_description">允许应用显示全屏通知，在设备锁定或使用时占据您的屏幕。通常用于闹钟、来电和其他时间敏感事件。</string>
+    <string name="permission_full_screen_intent_label">全屏通知</string>
+    <string name="permission_interact_across_profiles_description">允许应用在您的工作和个人配置文件之间进行通信，跨配置文件边界共享数据和功能。</string>
+    <string name="permission_interact_across_profiles_label">关联的工作和个人应用</string>
+    <string name="permission_loader_usage_stats_description">允许应用收集有关设备上数据加载器使用情况的统计信息。</string>
+    <string name="permission_loader_usage_stats_label">加载器使用统计</string>
+    <string name="permissions_details_empty_filter_message">没有应用符合当前筛选条件。点击筛选图标进行调整。</string>
+    <string name="permission_turn_screen_on_description">允许应用在需要您注意时打开设备屏幕，例如闹钟或来电。</string>
+    <string name="permission_turn_screen_on_label">打开屏幕</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -262,4 +262,20 @@
     <string name="onboarding_body1">此應用程式讓您方便的查看並管理應用程式權限。</string>
     <string name="onboarding_body2">Permission Pilot 收集應用程式的資訊以在使用時列出權限。</string>
     <string name="onboarding_body3">Permission Pilot 不含廣告，且僅在本地處理數據。</string>
+    <string name="apps_details_empty_filter_message">沒有權限符合目前篩選條件。點擊篩選圖示進行調整。</string>
+    <string name="filter_configurable_label">可設定</string>
+    <string name="filter_denied_label">已拒絕</string>
+    <string name="filter_granted_label">已授予</string>
+    <string name="general_collapse_all_action">全部收合</string>
+    <string name="general_expand_all_action">全部展開</string>
+    <string name="general_more_options_action">更多選項</string>
+    <string name="permission_full_screen_intent_description">允許應用程式顯示全螢幕通知，在裝置鎖定或使用時佔據您的螢幕。通常用於鬧鐘、來電和其他時間敏感事件。</string>
+    <string name="permission_full_screen_intent_label">全螢幕通知</string>
+    <string name="permission_interact_across_profiles_description">允許應用程式在您的工作和個人設定檔之間進行通訊，跨設定檔邊界共享資料和功能。</string>
+    <string name="permission_interact_across_profiles_label">關聯的工作和個人應用程式</string>
+    <string name="permission_loader_usage_stats_description">允許應用程式收集有關裝置上資料載入器使用情況的統計資訊。</string>
+    <string name="permission_loader_usage_stats_label">載入器使用統計</string>
+    <string name="permissions_details_empty_filter_message">沒有應用程式符合目前篩選條件。點擊篩選圖示進行調整。</string>
+    <string name="permission_turn_screen_on_description">允許應用程式在需要您注意時開啟裝置螢幕，例如鬧鐘或來電。</string>
+    <string name="permission_turn_screen_on_label">開啟螢幕</string>
 </resources>


### PR DESCRIPTION
## Summary
- Add 16 missing string translations to all 36 locales
- Covers filter labels, general UI actions, and permission descriptions

## Changes
Added translations for:
- `apps_details_empty_filter_message` / `permissions_details_empty_filter_message`
- `filter_configurable_label`, `filter_denied_label`, `filter_granted_label`
- `general_collapse_all_action`, `general_expand_all_action`, `general_more_options_action`
- `permission_full_screen_intent_*`
- `permission_interact_across_profiles_*`
- `permission_loader_usage_stats_*`
- `permission_turn_screen_on_*`

## Locales Updated (36)
af-rZA, am, ar, az, be, bg, bn-rBD, ca, ckb-rIR, cs, da, de, el, es, fi, fr, hi, hr, it, ja, ko, nb, nl, pl, pt, pt-rBR, ro, ru, sk, sv, th, tr, uk, vi, zh-rCN, zh-rTW

## Test plan
- [x] Build verification passed (`./gradlew assembleDebug`)
- [ ] Verify translations display correctly in app