### PR TITLE
Apps: Show which apps other apps can discover via queries tag

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -210,6 +210,8 @@ dependencies {
 
     implementation("com.squareup.okio:okio:3.1.0")
 
+    implementation("net.dongliu:apk-parser:2.6.10")
+
     implementation("io.coil-kt:coil:2.4.0")
 
     "gplayImplementation"("com.android.billingclient:billing:8.0.0")

--- a/app/src/main/java/eu/darken/myperm/apps/core/features/QueriesInfo.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/features/QueriesInfo.kt
@@ -1,0 +1,19 @@
+package eu.darken.myperm.apps.core.features
+
+data class QueriesInfo(
+    val packageQueries: List<String> = emptyList(),
+    val intentQueries: List<IntentQuery> = emptyList(),
+    val providerQueries: List<String> = emptyList(),
+) {
+    val totalCount: Int
+        get() = packageQueries.size + intentQueries.size + providerQueries.size
+
+    val isEmpty: Boolean
+        get() = totalCount == 0
+
+    data class IntentQuery(
+        val actions: List<String> = emptyList(),
+        val dataSpecs: List<String> = emptyList(),
+        val categories: List<String> = emptyList(),
+    )
+}

--- a/app/src/main/java/eu/darken/myperm/apps/core/queries/ApkParserManifestParser.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/queries/ApkParserManifestParser.kt
@@ -1,0 +1,134 @@
+package eu.darken.myperm.apps.core.queries
+
+import eu.darken.myperm.apps.core.features.QueriesInfo
+import eu.darken.myperm.common.debug.logging.Logging.Priority.WARN
+import eu.darken.myperm.common.debug.logging.log
+import eu.darken.myperm.common.debug.logging.logTag
+import net.dongliu.apk.parser.ApkFile
+import org.xmlpull.v1.XmlPullParser
+import org.xmlpull.v1.XmlPullParserFactory
+import java.io.File
+import java.io.StringReader
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ApkParserManifestParser @Inject constructor() : ManifestParser {
+
+    override fun parseQueries(apkPath: String): ManifestParser.QueriesResult {
+        val apkFile = File(apkPath)
+        if (!apkFile.exists() || !apkFile.canRead()) {
+            return ManifestParser.QueriesResult.Unavailable("APK not accessible: $apkPath")
+        }
+
+        return try {
+            val manifestXml = ApkFile(apkFile).use { it.manifestXml }
+            val queriesInfo = parseQueriesFromXml(manifestXml)
+            ManifestParser.QueriesResult.Success(queriesInfo)
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Failed to parse manifest from $apkPath: $e" }
+            ManifestParser.QueriesResult.ParseError(e)
+        }
+    }
+
+    private fun parseQueriesFromXml(xml: String): QueriesInfo {
+        val packageQueries = mutableListOf<String>()
+        val intentQueries = mutableListOf<QueriesInfo.IntentQuery>()
+        val providerQueries = mutableListOf<String>()
+
+        val factory = XmlPullParserFactory.newInstance()
+        val parser = factory.newPullParser()
+        parser.setInput(StringReader(xml))
+
+        var insideQueries = false
+        var insideIntent = false
+        var currentActions = mutableListOf<String>()
+        var currentDataSpecs = mutableListOf<String>()
+        var currentCategories = mutableListOf<String>()
+
+        var eventType = parser.eventType
+        while (eventType != XmlPullParser.END_DOCUMENT) {
+            when (eventType) {
+                XmlPullParser.START_TAG -> {
+                    when (parser.name) {
+                        "queries" -> insideQueries = true
+                        "package" -> if (insideQueries) {
+                            val name = parser.getAndroidAttr("name")
+                            if (name != null) packageQueries.add(name)
+                        }
+                        "provider" -> if (insideQueries) {
+                            val authorities = parser.getAndroidAttr("authorities")
+                            if (authorities != null) providerQueries.add(authorities)
+                        }
+                        "intent" -> if (insideQueries) {
+                            insideIntent = true
+                            currentActions = mutableListOf()
+                            currentDataSpecs = mutableListOf()
+                            currentCategories = mutableListOf()
+                        }
+                        "action" -> if (insideQueries && insideIntent) {
+                            parser.getAndroidAttr("name")?.let { currentActions.add(it) }
+                        }
+                        "data" -> if (insideQueries && insideIntent) {
+                            currentDataSpecs.add(buildDataString(parser))
+                        }
+                        "category" -> if (insideQueries && insideIntent) {
+                            parser.getAndroidAttr("name")?.let { currentCategories.add(it) }
+                        }
+                    }
+                }
+
+                XmlPullParser.END_TAG -> {
+                    when (parser.name) {
+                        "queries" -> insideQueries = false
+                        "intent" -> if (insideQueries && insideIntent) {
+                            intentQueries.add(
+                                QueriesInfo.IntentQuery(
+                                    actions = currentActions,
+                                    dataSpecs = currentDataSpecs,
+                                    categories = currentCategories,
+                                )
+                            )
+                            insideIntent = false
+                        }
+                    }
+                }
+            }
+            eventType = parser.next()
+        }
+
+        return QueriesInfo(
+            packageQueries = packageQueries,
+            intentQueries = intentQueries,
+            providerQueries = providerQueries,
+        )
+    }
+
+    private fun XmlPullParser.getAndroidAttr(name: String): String? {
+        return getAttributeValue(ANDROID_NS, name)
+            ?: getAttributeValue(null, "android:$name")
+    }
+
+    private fun buildDataString(parser: XmlPullParser): String {
+        val scheme = parser.getAndroidAttr("scheme")
+        val host = parser.getAndroidAttr("host")
+        val mimeType = parser.getAndroidAttr("mimeType")
+
+        return buildString {
+            if (scheme != null) {
+                append(scheme)
+                if (host != null) append("://$host")
+            }
+            if (mimeType != null) {
+                if (isNotEmpty()) append(" ")
+                append("($mimeType)")
+            }
+            if (isEmpty()) append("*")
+        }
+    }
+
+    companion object {
+        private const val ANDROID_NS = "http://schemas.android.com/apk/res/android"
+        private val TAG = logTag("Apps", "Queries", "ManifestParser")
+    }
+}

--- a/app/src/main/java/eu/darken/myperm/apps/core/queries/ManifestParser.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/queries/ManifestParser.kt
@@ -1,0 +1,13 @@
+package eu.darken.myperm.apps.core.queries
+
+import eu.darken.myperm.apps.core.features.QueriesInfo
+
+interface ManifestParser {
+    fun parseQueries(apkPath: String): QueriesResult
+
+    sealed class QueriesResult {
+        data class Success(val queriesInfo: QueriesInfo) : QueriesResult()
+        data class Unavailable(val reason: String) : QueriesResult()
+        data class ParseError(val error: Throwable) : QueriesResult()
+    }
+}

--- a/app/src/main/java/eu/darken/myperm/apps/core/queries/QueriesModule.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/queries/QueriesModule.kt
@@ -1,0 +1,14 @@
+package eu.darken.myperm.apps.core.queries
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@InstallIn(SingletonComponent::class)
+@Module
+abstract class QueriesModule {
+
+    @Binds
+    abstract fun manifestParser(impl: ApkParserManifestParser): ManifestParser
+}

--- a/app/src/main/java/eu/darken/myperm/apps/core/queries/QueriesRepo.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/queries/QueriesRepo.kt
@@ -1,0 +1,115 @@
+package eu.darken.myperm.apps.core.queries
+
+import eu.darken.myperm.apps.core.Pkg
+import eu.darken.myperm.apps.core.container.BasePkg
+import eu.darken.myperm.apps.core.features.QueriesInfo
+import eu.darken.myperm.apps.core.features.ReadableApk
+import eu.darken.myperm.common.coroutine.DispatcherProvider
+import eu.darken.myperm.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.myperm.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.myperm.common.debug.logging.log
+import eu.darken.myperm.common.debug.logging.logTag
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.sync.withPermit
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class QueriesRepo @Inject constructor(
+    private val manifestParser: ManifestParser,
+    private val dispatcherProvider: DispatcherProvider,
+) {
+
+    private val ioLimiter = Semaphore(3)
+    private val cacheMutex = Mutex()
+    private val cache = mutableMapOf<CacheKey, ManifestParser.QueriesResult>()
+
+    private data class CacheKey(
+        val pkgId: Pkg.Id,
+        val versionCode: Long,
+        val lastUpdateTime: Long,
+    )
+
+    suspend fun getQueries(pkg: BasePkg): ManifestParser.QueriesResult {
+        val readableApk = pkg as? ReadableApk
+            ?: return ManifestParser.QueriesResult.Unavailable("Not a readable APK")
+
+        val key = CacheKey(
+            pkgId = pkg.id,
+            versionCode = readableApk.versionCode,
+            lastUpdateTime = readableApk.packageInfo.lastUpdateTime,
+        )
+
+        cacheMutex.withLock { cache[key] }?.let { return it }
+
+        val result = ioLimiter.withPermit {
+            withContext(dispatcherProvider.IO) {
+                parseFromApk(readableApk)
+            }
+        }
+
+        cacheMutex.withLock {
+            // Double-check: another coroutine may have cached this key while we were parsing
+            cache.getOrPut(key) { result }
+        }
+
+        return result
+    }
+
+    private fun parseFromApk(pkg: ReadableApk): ManifestParser.QueriesResult {
+        val sourceDir = pkg.applicationInfo?.sourceDir
+            ?: return ManifestParser.QueriesResult.Unavailable("No sourceDir for ${pkg.packageName}")
+
+        log(TAG, VERBOSE) { "Parsing queries for ${pkg.packageName} from $sourceDir" }
+
+        val result = manifestParser.parseQueries(sourceDir)
+
+        val finalResult = if (result is ManifestParser.QueriesResult.Success) {
+            val splitDirs = pkg.applicationInfo?.splitSourceDirs
+            if (!splitDirs.isNullOrEmpty()) {
+                log(TAG, VERBOSE) { "${pkg.packageName} has ${splitDirs.size} split APKs, checking for queries" }
+                var mergedInfo = result.queriesInfo
+                for (splitDir in splitDirs) {
+                    val splitResult = manifestParser.parseQueries(splitDir)
+                    if (splitResult is ManifestParser.QueriesResult.Success && !splitResult.queriesInfo.isEmpty) {
+                        mergedInfo = QueriesInfo(
+                            packageQueries = mergedInfo.packageQueries + splitResult.queriesInfo.packageQueries,
+                            intentQueries = mergedInfo.intentQueries + splitResult.queriesInfo.intentQueries,
+                            providerQueries = mergedInfo.providerQueries + splitResult.queriesInfo.providerQueries,
+                        )
+                    }
+                }
+                ManifestParser.QueriesResult.Success(mergedInfo)
+            } else {
+                result
+            }
+        } else {
+            result
+        }
+
+        when (finalResult) {
+            is ManifestParser.QueriesResult.Success -> {
+                log(TAG) { "${pkg.packageName}: ${finalResult.queriesInfo.totalCount} queries found" }
+            }
+            is ManifestParser.QueriesResult.Unavailable -> {
+                log(TAG) { "${pkg.packageName}: queries unavailable - ${finalResult.reason}" }
+            }
+            is ManifestParser.QueriesResult.ParseError -> {
+                log(TAG, ERROR) { "${pkg.packageName}: parse error - ${finalResult.error}" }
+            }
+        }
+
+        return finalResult
+    }
+
+    suspend fun clearCache() {
+        cacheMutex.withLock { cache.clear() }
+    }
+
+    companion object {
+        private val TAG = logTag("Apps", "Queries", "Repo")
+    }
+}

--- a/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsAdapter.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsAdapter.kt
@@ -28,6 +28,7 @@ class AppDetailsAdapter @Inject constructor() :
         modules.add(TypedVHCreatorMod({ data[it] is AppOverviewVH.Item }) { AppOverviewVH(it) })
         modules.add(TypedVHCreatorMod({ data[it] is AppTwinsVH.Item }) { AppTwinsVH(it) })
         modules.add(TypedVHCreatorMod({ data[it] is AppSiblingsVH.Item }) { AppSiblingsVH(it) })
+        modules.add(TypedVHCreatorMod({ data[it] is AppQueriesVH.Item }) { AppQueriesVH(it) })
         modules.add(TypedVHCreatorMod({ data[it] is UsesPermissionVH.Item }) { UsesPermissionVH(it) })
         modules.add(TypedVHCreatorMod({ data[it] is UnknownPermissionVH.Item }) { UnknownPermissionVH(it) })
     }

--- a/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsFragmentVM.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsFragmentVM.kt
@@ -12,7 +12,9 @@ import eu.darken.myperm.apps.core.Pkg
 import eu.darken.myperm.apps.core.apps
 import eu.darken.myperm.apps.core.features.ReadableApk
 import eu.darken.myperm.apps.core.features.UsesPermission
+import eu.darken.myperm.apps.core.queries.QueriesRepo
 import eu.darken.myperm.apps.ui.details.items.AppOverviewVH
+import eu.darken.myperm.apps.ui.details.items.AppQueriesVH
 import eu.darken.myperm.apps.ui.details.items.AppSiblingsVH
 import eu.darken.myperm.apps.ui.details.items.AppTwinsVH
 import eu.darken.myperm.apps.ui.details.items.UnknownPermissionVH
@@ -34,8 +36,12 @@ import eu.darken.myperm.permissions.core.features.RuntimeGrant
 import eu.darken.myperm.permissions.core.features.SpecialAccess
 import eu.darken.myperm.permissions.core.permissions
 import eu.darken.myperm.settings.core.GeneralSettings
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import javax.inject.Inject
@@ -51,6 +57,7 @@ class AppDetailsFragmentVM @Inject constructor(
     appRepo: AppRepo,
     permissionRepo: PermissionRepo,
     appStoreTool: AppStoreTool,
+    private val queriesRepo: QueriesRepo,
     private val generalSettings: GeneralSettings
 ) : ViewModel3(dispatcherProvider = dispatcherProvider) {
 
@@ -66,10 +73,23 @@ class AppDetailsFragmentVM @Inject constructor(
         val isEmptyDueToFilter: Boolean = false,
     )
 
+    private val appFlow = appRepo.apps.map { apps -> apps.single { it.id == navArgs.appId } }
+
+    private val queriesFlow: Flow<AppQueriesVH.State> = appFlow
+        .distinctUntilChangedBy { it.id }
+        .flatMapLatest { app ->
+            flow {
+                emit(AppQueriesVH.State.Loading)
+                val result = queriesRepo.getQueries(app)
+                emit(AppQueriesVH.State.from(result))
+            }
+        }
+
     val details: LiveData<Details> = combine(
-        appRepo.apps.map { apps -> apps.single { it.id == navArgs.appId } },
-        filterOptions
-    ) { app, filterOpts ->
+        appFlow,
+        filterOptions,
+        queriesFlow.onStart { emit(AppQueriesVH.State.Loading) }
+    ) { app, filterOpts, currentQueriesState ->
         val infoItems = mutableListOf<AppDetailsAdapter.Item>()
         val permissions = permissionRepo.permissions.first()
 
@@ -116,6 +136,8 @@ class AppDetailsFragmentVM @Inject constructor(
                 }
             ).run { infoItems.add(this) }
         }
+
+        AppQueriesVH.Item(state = currentQueriesState).run { infoItems.add(this) }
 
         val allPermissions = (app as? ReadableApk)?.requestedPermissions
             ?.map { usesPerm ->

--- a/app/src/main/java/eu/darken/myperm/apps/ui/details/items/AppQueriesVH.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/details/items/AppQueriesVH.kt
@@ -1,0 +1,107 @@
+package eu.darken.myperm.apps.ui.details.items
+
+import android.view.ViewGroup
+import androidx.core.view.isGone
+import androidx.core.view.isVisible
+import eu.darken.myperm.R
+import eu.darken.myperm.apps.core.features.QueriesInfo
+import eu.darken.myperm.apps.core.queries.ManifestParser
+import eu.darken.myperm.apps.ui.details.AppDetailsAdapter
+import eu.darken.myperm.common.DividerItemDecorator2
+import eu.darken.myperm.common.lists.BindableVH
+import eu.darken.myperm.databinding.AppsDetailsQueriesItemBinding
+
+class AppQueriesVH(parent: ViewGroup) : AppDetailsAdapter.BaseVH<AppQueriesVH.Item, AppsDetailsQueriesItemBinding>(
+    R.layout.apps_details_queries_item,
+    parent
+), BindableVH<AppQueriesVH.Item, AppsDetailsQueriesItemBinding>, DividerItemDecorator2.SkipDivider {
+
+    override val viewBinding = lazy { AppsDetailsQueriesItemBinding.bind(itemView) }
+
+    override val onBindData: AppsDetailsQueriesItemBinding.(
+        item: Item,
+        payloads: List<Any>
+    ) -> Unit = { item, _ ->
+        when (val state = item.state) {
+            is State.Loading -> {
+                loadingIndicator.isVisible = true
+                subtitle.text = getString(R.string.apps_details_queries_loading)
+                details.isGone = true
+            }
+
+            is State.Data -> {
+                loadingIndicator.isGone = true
+                val info = state.queriesInfo
+                if (info.isEmpty) {
+                    subtitle.text = getString(R.string.apps_details_queries_none)
+                    details.isGone = true
+                } else {
+                    subtitle.text = buildSummary(info)
+                    details.apply {
+                        text = buildDetails(info)
+                        isGone = text.isNullOrEmpty()
+                    }
+                }
+            }
+
+            is State.Unsupported -> {
+                loadingIndicator.isGone = true
+                subtitle.text = getString(R.string.apps_details_queries_unavailable)
+                details.isGone = true
+            }
+
+            is State.Error -> {
+                loadingIndicator.isGone = true
+                subtitle.text = getString(R.string.apps_details_queries_error)
+                details.isGone = true
+            }
+        }
+    }
+
+    private fun AppsDetailsQueriesItemBinding.buildSummary(info: QueriesInfo): String {
+        val parts = mutableListOf<String>()
+        if (info.packageQueries.isNotEmpty()) {
+            parts.add(getQuantityString(R.plurals.apps_details_queries_packages, info.packageQueries.size, info.packageQueries.size))
+        }
+        if (info.intentQueries.isNotEmpty()) {
+            parts.add(getQuantityString(R.plurals.apps_details_queries_intents, info.intentQueries.size, info.intentQueries.size))
+        }
+        if (info.providerQueries.isNotEmpty()) {
+            parts.add(getQuantityString(R.plurals.apps_details_queries_providers, info.providerQueries.size, info.providerQueries.size))
+        }
+        return parts.joinToString(", ")
+    }
+
+    private fun AppsDetailsQueriesItemBinding.buildDetails(info: QueriesInfo): String {
+        val lines = mutableListOf<String>()
+        info.packageQueries.forEach { lines.add(it) }
+        info.intentQueries.forEach { query ->
+            val parts = (query.actions + query.dataSpecs + query.categories).joinToString(" | ")
+            lines.add(parts.ifEmpty { getString(R.string.apps_details_queries_intent_fallback) })
+        }
+        info.providerQueries.forEach { lines.add(getString(R.string.apps_details_queries_provider_prefix, it)) }
+        return lines.joinToString("\n")
+    }
+
+    sealed class State {
+        data object Loading : State()
+        data class Data(val queriesInfo: QueriesInfo) : State()
+        data class Unsupported(val reason: String) : State()
+        data class Error(val error: Throwable) : State()
+
+        companion object {
+            fun from(result: ManifestParser.QueriesResult): State = when (result) {
+                is ManifestParser.QueriesResult.Success -> Data(result.queriesInfo)
+                is ManifestParser.QueriesResult.Unavailable -> Unsupported(result.reason)
+                is ManifestParser.QueriesResult.ParseError -> Error(result.error)
+            }
+        }
+    }
+
+    data class Item(
+        val state: State,
+    ) : AppDetailsAdapter.Item {
+        override val stableId: Long
+            get() = Item::class.hashCode().toLong()
+    }
+}

--- a/app/src/main/res/layout/apps_details_queries_item.xml
+++ b/app/src/main/res/layout/apps_details_queries_item.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/DetailsCardItem"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <ImageView
+            android:id="@+id/icon"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
+            android:layout_marginStart="16dp"
+            android:src="@drawable/ic_query_all_packages_24"
+            app:layout_constraintBottom_toBottomOf="@id/subtitle"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/title" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/title"
+            style="@style/TextAppearance.Material3.LabelSmall"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="16dp"
+            android:text="@string/apps_details_queries_label"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/icon"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/subtitle"
+            style="@style/TextAppearance.Material3.BodySmall"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            app:layout_constraintBottom_toTopOf="@id/details"
+            app:layout_constraintEnd_toStartOf="@id/loading_indicator"
+            app:layout_constraintStart_toStartOf="@id/title"
+            app:layout_constraintTop_toBottomOf="@id/title"
+            app:layout_constraintVertical_bias="0"
+            app:layout_goneMarginBottom="16dp"
+            tools:text="Queries 5 packages, 2 intents, 1 provider" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/details"
+            style="@style/TextAppearance.Material3.BodySmall"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:textColor="?android:attr/textColorSecondary"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/title"
+            app:layout_constraintStart_toStartOf="@id/title"
+            app:layout_constraintTop_toBottomOf="@id/subtitle"
+            tools:text="com.whatsapp, com.facebook.orca"
+            tools:visibility="visible" />
+
+        <ProgressBar
+            android:id="@+id/loading_indicator"
+            style="?android:attr/progressBarStyleSmall"
+            android:layout_width="16dp"
+            android:layout_height="16dp"
+            android:layout_marginEnd="16dp"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="@id/subtitle"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/title"
+            tools:visibility="visible" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -297,6 +297,26 @@
     <string name="permission_bind_accessibility_service_description">Allows the app to offer an accessibility service that can be enabled in the system settings.</string>
     <string name="debug_debuglog_sensitive_information_message">This file contains sensitive information (e.g. your installed applications). Only share it with trusted parties.</string>
     <string name="settings_debuglog_explanation">This feature records everything the app is doing into a shareable file. The generated file contains sensitive information (e.g. your installed applications). Only share it with trusted parties (e.g. the app developer if you are troubleshooting an issue together).</string>
+    <string name="apps_details_queries_label">Manifest Queries</string>
+    <string name="apps_details_queries_loading">Analyzing manifest…</string>
+    <string name="apps_details_queries_none">No queries declared</string>
+    <string name="apps_details_queries_unavailable">Manifest not accessible</string>
+    <string name="apps_details_queries_error">Failed to parse manifest</string>
+    <plurals name="apps_details_queries_packages">
+        <item quantity="one">%d package</item>
+        <item quantity="other">%d packages</item>
+    </plurals>
+    <plurals name="apps_details_queries_intents">
+        <item quantity="one">%d intent</item>
+        <item quantity="other">%d intents</item>
+    </plurals>
+    <plurals name="apps_details_queries_providers">
+        <item quantity="one">%d provider</item>
+        <item quantity="other">%d providers</item>
+    </plurals>
+    <string name="apps_details_queries_intent_fallback">intent</string>
+    <string name="apps_details_queries_provider_prefix">provider: %s</string>
+
     <string name="onboarding_body1">This app helps you navigate installed applications and discover permissions.</string>
     <string name="onboarding_body2">Permission Pilot collects Installed Application information to enable listing your apps and cross-referencing their permissions when using this application.</string>
     <string name="onboarding_body3">Permission Pilot has no ads and only processes data locally.</string>


### PR DESCRIPTION
## Summary
- Parse the `<queries>` manifest tag from APKs to detect which apps/intents/providers each app can discover
- Show a dedicated card on the app details screen with loading, data, unsupported, and error states
- Uses `apk-parser` library for binary AXML manifest parsing, with split APK support
- Separate `QueriesRepo` with semaphore-limited I/O and mutex-guarded caching to avoid impacting main app data loading

Closes #220

## Test plan
- [ ] Open app details for apps known to use `<queries>` (e.g., social media, messaging apps)
- [ ] Verify the queries card shows package counts, intent counts, and provider counts
- [ ] Verify details expand to show specific queried packages/intents/providers
- [ ] Verify apps without `<queries>` show "No queries declared"
- [ ] Verify loading state appears briefly before results
- [ ] Verify split APK apps are handled correctly
- [ ] Verify inaccessible APKs show "unavailable" state gracefully
