### PR TITLE
Permissions: Redesign permission details with typed pills and help dialogs

### DIFF
--- a/app/src/main/java/eu/darken/myperm/permissions/ui/details/PermissionDetailsScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/details/PermissionDetailsScreen.kt
@@ -1,9 +1,12 @@
 package eu.darken.myperm.permissions.ui.details
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -13,20 +16,25 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Cancel
-import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.automirrored.filled.HelpOutline
 import androidx.compose.material.icons.filled.FilterList
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -36,6 +44,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -43,12 +53,22 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import androidx.hilt.navigation.compose.hiltViewModel
 import eu.darken.myperm.R
+import eu.darken.myperm.apps.core.features.UsesPermission
 import eu.darken.myperm.common.compose.LabeledOption
 import eu.darken.myperm.common.compose.MultiChoiceFilterDialog
 import eu.darken.myperm.common.compose.waitForState
 import eu.darken.myperm.common.error.ErrorEventHandler
 import eu.darken.myperm.common.navigation.Nav
 import eu.darken.myperm.common.navigation.NavigationEventHandler
+import eu.darken.myperm.permissions.core.ProtectionFlag
+import eu.darken.myperm.permissions.core.ProtectionType
+import eu.darken.myperm.permissions.core.features.Highlighted
+import eu.darken.myperm.permissions.core.features.InstallTimeGrant
+import eu.darken.myperm.permissions.core.features.ManifestDoc
+import eu.darken.myperm.permissions.core.features.NotNormalPerm
+import eu.darken.myperm.permissions.core.features.PermissionTag
+import eu.darken.myperm.permissions.core.features.RuntimeGrant
+import eu.darken.myperm.permissions.core.features.SpecialAccess
 
 @Composable
 fun PermissionDetailsScreenHost(
@@ -63,6 +83,8 @@ fun PermissionDetailsScreenHost(
     val state by waitForState(vm.state)
 
     var showFilterDialog by rememberSaveable { mutableStateOf(false) }
+    var showPermissionHelpDialog by rememberSaveable { mutableStateOf(false) }
+    var showStatusHelpDialog by rememberSaveable { mutableStateOf(false) }
 
     state?.let {
         PermissionDetailsScreen(
@@ -70,7 +92,17 @@ fun PermissionDetailsScreenHost(
             onBack = { vm.navUp() },
             onAppClicked = { pkgName, userHandle -> vm.onAppClicked(pkgName, userHandle) },
             onFilterClicked = { showFilterDialog = true },
+            onPermissionHelpClicked = { showPermissionHelpDialog = true },
+            onStatusHelpClicked = { showStatusHelpDialog = true },
         )
+    }
+
+    if (showPermissionHelpDialog) {
+        PermissionInfoHelpDialog(onDismiss = { showPermissionHelpDialog = false })
+    }
+
+    if (showStatusHelpDialog) {
+        GrantStatusHelpDialog(onDismiss = { showStatusHelpDialog = false })
     }
 
     if (showFilterDialog && state != null) {
@@ -87,13 +119,15 @@ fun PermissionDetailsScreenHost(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun PermissionDetailsScreen(
     state: PermissionDetailsViewModel.State,
     onBack: () -> Unit,
     onAppClicked: (String, Int) -> Unit,
     onFilterClicked: () -> Unit,
+    onPermissionHelpClicked: () -> Unit,
+    onStatusHelpClicked: () -> Unit,
 ) {
     Scaffold(
         topBar = {
@@ -135,9 +169,16 @@ fun PermissionDetailsScreen(
                 modifier = Modifier.fillMaxSize().padding(innerPadding),
             ) {
                 // Overview card
-                item {
-                    Card(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
-                        Column(modifier = Modifier.padding(16.dp)) {
+                item(key = "overview") {
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 8.dp),
+                    ) {
+                        Column(
+                            modifier = Modifier.padding(16.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
                             Row(
                                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                                 verticalAlignment = Alignment.CenterVertically,
@@ -149,61 +190,79 @@ fun PermissionDetailsScreen(
                                         modifier = Modifier.size(48.dp),
                                     )
                                 }
-                                Column {
-                                    state.description?.let {
-                                        Text(text = it, style = MaterialTheme.typography.titleMedium)
-                                    }
+                                Column(modifier = Modifier.weight(1f)) {
+                                    Text(
+                                        text = state.description ?: state.label,
+                                        style = MaterialTheme.typography.titleMedium,
+                                    )
                                     Text(
                                         text = state.permissionId,
-                                        style = MaterialTheme.typography.bodyMedium,
+                                        style = MaterialTheme.typography.bodySmall,
                                         color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                    )
+                                }
+                                IconButton(
+                                    onClick = onPermissionHelpClicked,
+                                    modifier = Modifier.size(32.dp),
+                                ) {
+                                    Icon(
+                                        Icons.AutoMirrored.Filled.HelpOutline,
+                                        contentDescription = stringResource(R.string.label_help),
+                                        modifier = Modifier.size(18.dp),
+                                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
                                     )
                                 }
                             }
+
+                            if (state.protectionType != null || state.protectionFlags.isNotEmpty() || state.tags.isNotEmpty()) {
+                                FlowRow(
+                                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                                ) {
+                                    state.protectionType?.let { ProtectionTypePill(it) }
+                                    state.protectionFlags.forEach { ProtectionFlagPill(it) }
+                                    if (state.protectionFlagOverflow > 0) {
+                                        Pill(
+                                            text = stringResource(R.string.permissions_details_flags_more_label, state.protectionFlagOverflow),
+                                            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                                            contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        )
+                                    }
+                                    state.tags.forEach { PermissionTagPill(it) }
+                                }
+                            }
+
                             state.fullDescription?.let {
-                                Spacer(modifier = Modifier.height(8.dp))
                                 Text(
                                     text = it,
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
                             }
-                            state.protectionLevel?.let {
-                                Spacer(modifier = Modifier.height(4.dp))
-                                Text(
-                                    text = stringResource(R.string.permissions_details_protection_label),
-                                    style = MaterialTheme.typography.labelMedium,
-                                )
-                                Text(
-                                    text = it,
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+
+                            if (state.totalUserCount > 0) {
+                                GrantRatioRow(
+                                    label = pluralStringResource(
+                                        R.plurals.generic_x_apps_user_label,
+                                        state.totalUserCount,
+                                        state.totalUserCount,
+                                    ),
+                                    granted = state.grantedUserCount,
+                                    total = state.totalUserCount,
                                 )
                             }
-                            if (state.totalUserCount > 0 || state.totalSystemCount > 0) {
-                                Spacer(modifier = Modifier.height(4.dp))
-                                if (state.totalUserCount > 0) {
-                                    Text(
-                                        text = pluralStringResource(
-                                            R.plurals.permissions_details_count_user_apps,
-                                            state.totalUserCount,
-                                            state.grantedUserCount,
-                                            state.totalUserCount,
-                                        ),
-                                        style = MaterialTheme.typography.bodySmall,
-                                    )
-                                }
-                                if (state.totalSystemCount > 0) {
-                                    Text(
-                                        text = pluralStringResource(
-                                            R.plurals.permissions_details_count_system_apps,
-                                            state.totalSystemCount,
-                                            state.grantedSystemCount,
-                                            state.totalSystemCount,
-                                        ),
-                                        style = MaterialTheme.typography.bodySmall,
-                                    )
-                                }
+                            if (state.totalSystemCount > 0) {
+                                GrantRatioRow(
+                                    label = pluralStringResource(
+                                        R.plurals.generic_x_apps_system_label,
+                                        state.totalSystemCount,
+                                        state.totalSystemCount,
+                                    ),
+                                    granted = state.grantedSystemCount,
+                                    total = state.totalSystemCount,
+                                )
                             }
                         }
                     }
@@ -211,20 +270,19 @@ fun PermissionDetailsScreen(
 
                 // Declaring apps
                 if (state.declaringApps.isNotEmpty()) {
-                    item {
+                    item(key = "decl_header") {
                         Text(
                             text = stringResource(R.string.permissions_details_declaring_apps_label),
                             style = MaterialTheme.typography.titleSmall,
                             modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                         )
                     }
-                    items(state.declaringApps) { app ->
+                    items(state.declaringApps, key = { "decl:${it.pkgName}:${it.userHandle}" }) { app ->
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .clickable { onAppClicked(app.pkgName, app.userHandle) }
-                                .padding(horizontal = 16.dp, vertical = 10.dp),
-                            verticalAlignment = Alignment.CenterVertically,
+                                .padding(horizontal = 16.dp, vertical = 8.dp),
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                         ) {
                             AsyncImage(
@@ -232,20 +290,28 @@ fun PermissionDetailsScreen(
                                 contentDescription = app.label,
                                 modifier = Modifier.size(32.dp),
                             )
-                            Column {
-                                Text(
-                                    text = app.label ?: app.pkgName,
-                                    style = MaterialTheme.typography.bodyMedium,
-                                )
+                            Column(modifier = Modifier.weight(1f)) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                ) {
+                                    Text(
+                                        text = app.label ?: app.pkgName,
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                        modifier = Modifier.weight(1f, fill = false),
+                                    )
+                                    if (app.isSystemApp) {
+                                        SystemBadge()
+                                    }
+                                }
                                 Text(
                                     text = app.pkgName,
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
-                                Text(
-                                    text = stringResource(R.string.permissions_app_type_declaring_description),
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
                                 )
                             }
                         }
@@ -255,20 +321,38 @@ fun PermissionDetailsScreen(
 
                 // Requesting apps
                 if (state.requestingApps.isNotEmpty()) {
-                    item {
-                        Text(
-                            text = stringResource(R.string.permissions_details_requesting_apps_label),
-                            style = MaterialTheme.typography.titleSmall,
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                        )
+                    item(key = "req_header") {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 12.dp, vertical = 6.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            Text(
+                                text = stringResource(R.string.permissions_details_requesting_apps_label),
+                                style = MaterialTheme.typography.titleSmall,
+                            )
+                            Spacer(modifier = Modifier.weight(1f))
+                            IconButton(
+                                onClick = onStatusHelpClicked,
+                                modifier = Modifier.size(32.dp),
+                            ) {
+                                Icon(
+                                    Icons.AutoMirrored.Filled.HelpOutline,
+                                    contentDescription = stringResource(R.string.label_help),
+                                    modifier = Modifier.size(18.dp),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
                     }
-                    items(state.requestingApps) { app ->
+                    items(state.requestingApps, key = { "req:${it.pkgName}:${it.userHandle}" }) { app ->
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .clickable { onAppClicked(app.pkgName, app.userHandle) }
-                                .padding(horizontal = 16.dp, vertical = 10.dp),
-                            verticalAlignment = Alignment.CenterVertically,
+                                .padding(horizontal = 16.dp, vertical = 8.dp),
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                         ) {
                             AsyncImage(
@@ -277,29 +361,28 @@ fun PermissionDetailsScreen(
                                 modifier = Modifier.size(32.dp),
                             )
                             Column(modifier = Modifier.weight(1f)) {
-                                Text(
-                                    text = app.label ?: app.pkgName,
-                                    style = MaterialTheme.typography.bodyMedium,
-                                )
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                ) {
+                                    Text(
+                                        text = app.label ?: app.pkgName,
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                        modifier = Modifier.weight(1f, fill = false),
+                                    )
+                                    if (app.isSystemApp) {
+                                        SystemBadge()
+                                    }
+                                    GrantStatusBadge(app.status)
+                                }
                                 Text(
                                     text = app.pkgName,
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
-                            }
-                            if (app.isGranted) {
-                                Icon(
-                                    imageVector = Icons.Filled.CheckCircle,
-                                    contentDescription = stringResource(R.string.filter_granted_label),
-                                    tint = MaterialTheme.colorScheme.primary,
-                                    modifier = Modifier.size(20.dp),
-                                )
-                            } else {
-                                Icon(
-                                    imageVector = Icons.Filled.Cancel,
-                                    contentDescription = stringResource(R.string.filter_denied_label),
-                                    tint = MaterialTheme.colorScheme.error,
-                                    modifier = Modifier.size(20.dp),
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
                                 )
                             }
                         }
@@ -308,5 +391,304 @@ fun PermissionDetailsScreen(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun Pill(
+    text: String,
+    containerColor: Color,
+    contentColor: Color,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelSmall,
+        color = contentColor,
+        modifier = modifier
+            .background(containerColor, RoundedCornerShape(4.dp))
+            .padding(horizontal = 6.dp, vertical = 2.dp),
+    )
+}
+
+@Composable
+private fun GrantRatioRow(label: String, granted: Int, total: Int) {
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text("$granted / $total", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+        LinearProgressIndicator(
+            progress = { if (total > 0) granted.toFloat() / total else 0f },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(6.dp)
+                .clip(RoundedCornerShape(3.dp)),
+            color = MaterialTheme.colorScheme.primary,
+            trackColor = MaterialTheme.colorScheme.surfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun ProtectionTypePill(type: ProtectionType) {
+    val colors = when (type) {
+        ProtectionType.DANGEROUS -> MaterialTheme.colorScheme.errorContainer to MaterialTheme.colorScheme.onErrorContainer
+        ProtectionType.SIGNATURE,
+        ProtectionType.SIGNATURE_OR_SYSTEM,
+        ProtectionType.INTERNAL -> MaterialTheme.colorScheme.tertiaryContainer to MaterialTheme.colorScheme.onTertiaryContainer
+        ProtectionType.NORMAL -> MaterialTheme.colorScheme.primaryContainer to MaterialTheme.colorScheme.onPrimaryContainer
+        ProtectionType.UNKNOWN -> MaterialTheme.colorScheme.surfaceVariant to MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    Pill(
+        text = stringResource(type.labelRes),
+        containerColor = colors.first,
+        contentColor = colors.second,
+    )
+}
+
+@Composable
+private fun ProtectionFlagPill(flag: ProtectionFlag) {
+    Pill(
+        text = flag.name,
+        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+@Composable
+private fun PermissionTagPill(tag: PermissionTag) {
+    val (text, containerColor, contentColor) = when (tag) {
+        is RuntimeGrant -> Triple(
+            stringResource(R.string.permissions_tag_runtime_label),
+            MaterialTheme.colorScheme.secondaryContainer,
+            MaterialTheme.colorScheme.onSecondaryContainer,
+        )
+        is SpecialAccess -> Triple(
+            stringResource(R.string.permissions_tag_special_access_label),
+            MaterialTheme.colorScheme.tertiaryContainer,
+            MaterialTheme.colorScheme.onTertiaryContainer,
+        )
+        is InstallTimeGrant -> Triple(
+            stringResource(R.string.permissions_tag_install_time_label),
+            MaterialTheme.colorScheme.primaryContainer,
+            MaterialTheme.colorScheme.onPrimaryContainer,
+        )
+        is ManifestDoc -> Triple(
+            stringResource(R.string.permissions_tag_documented_label),
+            MaterialTheme.colorScheme.surfaceVariant,
+            MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        is Highlighted -> Triple(
+            stringResource(R.string.permissions_tag_notable_label),
+            MaterialTheme.colorScheme.surfaceVariant,
+            MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        is NotNormalPerm -> Triple(
+            stringResource(R.string.permissions_tag_non_standard_label),
+            MaterialTheme.colorScheme.surfaceVariant,
+            MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+    Pill(text = text, containerColor = containerColor, contentColor = contentColor)
+}
+
+@Composable
+private fun SystemBadge() {
+    Pill(
+        text = stringResource(R.string.permissions_details_system_badge_label),
+        containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+        contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+    )
+}
+
+@Composable
+private fun GrantStatusBadge(status: UsesPermission.Status) {
+    val (text, containerColor, contentColor) = when (status) {
+        UsesPermission.Status.GRANTED -> Triple(
+            stringResource(R.string.filter_granted_label),
+            MaterialTheme.colorScheme.primaryContainer,
+            MaterialTheme.colorScheme.onPrimaryContainer,
+        )
+        UsesPermission.Status.GRANTED_IN_USE -> Triple(
+            stringResource(R.string.permissions_status_granted_in_use_label),
+            MaterialTheme.colorScheme.secondaryContainer,
+            MaterialTheme.colorScheme.onSecondaryContainer,
+        )
+        UsesPermission.Status.DENIED -> Triple(
+            stringResource(R.string.filter_denied_label),
+            MaterialTheme.colorScheme.errorContainer,
+            MaterialTheme.colorScheme.onErrorContainer,
+        )
+        UsesPermission.Status.UNKNOWN -> Triple(
+            stringResource(R.string.permissions_status_unknown_label),
+            MaterialTheme.colorScheme.surfaceVariant,
+            MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+    Pill(text = text, containerColor = containerColor, contentColor = contentColor)
+}
+
+@Composable
+private fun PermissionInfoHelpDialog(onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.permissions_details_help_title)) },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                // Protection type section
+                HelpSectionHeader(stringResource(R.string.permissions_details_help_section_protection))
+                HelpRow(
+                    pill = stringResource(R.string.permissions_protection_type_dangerous_label),
+                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                    contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                    description = stringResource(R.string.permissions_details_help_dangerous),
+                )
+                HelpRow(
+                    pill = stringResource(R.string.permissions_protection_type_normal_label),
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    description = stringResource(R.string.permissions_details_help_normal),
+                )
+                HelpRow(
+                    pill = stringResource(R.string.permissions_protection_type_signature_label),
+                    containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                    description = stringResource(R.string.permissions_details_help_signature),
+                )
+                HelpRow(
+                    pill = stringResource(R.string.permissions_protection_type_internal_label),
+                    containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                    description = stringResource(R.string.permissions_details_help_internal),
+                )
+
+                // Tags section
+                HelpSectionHeader(stringResource(R.string.permissions_details_help_section_tags))
+                HelpRow(
+                    pill = stringResource(R.string.permissions_tag_runtime_label),
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                    description = stringResource(R.string.permissions_details_help_tag_runtime),
+                )
+                HelpRow(
+                    pill = stringResource(R.string.permissions_tag_install_time_label),
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    description = stringResource(R.string.permissions_details_help_tag_install_time),
+                )
+                HelpRow(
+                    pill = stringResource(R.string.permissions_tag_special_access_label),
+                    containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                    description = stringResource(R.string.permissions_details_help_tag_special_access),
+                )
+                HelpRow(
+                    pill = stringResource(R.string.permissions_tag_documented_label),
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    description = stringResource(R.string.permissions_details_help_tag_documented),
+                )
+                HelpRow(
+                    pill = stringResource(R.string.permissions_tag_notable_label),
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    description = stringResource(R.string.permissions_details_help_tag_notable),
+                )
+                HelpRow(
+                    pill = stringResource(R.string.permissions_tag_non_standard_label),
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    description = stringResource(R.string.permissions_details_help_tag_non_standard),
+                )
+
+                // Badges section
+                HelpSectionHeader(stringResource(R.string.permissions_details_help_section_badges))
+                HelpRow(
+                    pill = stringResource(R.string.permissions_details_system_badge_label),
+                    containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                    description = stringResource(R.string.permissions_details_help_system_badge),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.general_done_action))
+            }
+        },
+    )
+}
+
+@Composable
+private fun GrantStatusHelpDialog(onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.permissions_details_status_help_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                HelpRow(
+                    pill = stringResource(R.string.filter_granted_label),
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    description = stringResource(R.string.permissions_details_help_status_granted),
+                )
+                HelpRow(
+                    pill = stringResource(R.string.permissions_status_granted_in_use_label),
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                    description = stringResource(R.string.permissions_details_help_status_in_use),
+                )
+                HelpRow(
+                    pill = stringResource(R.string.filter_denied_label),
+                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                    contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                    description = stringResource(R.string.permissions_details_help_status_denied),
+                )
+                HelpRow(
+                    pill = stringResource(R.string.permissions_status_unknown_label),
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    description = stringResource(R.string.permissions_details_help_status_unknown),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.general_done_action))
+            }
+        },
+    )
+}
+
+@Composable
+private fun HelpSectionHeader(title: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(top = 4.dp),
+    )
+}
+
+@Composable
+private fun HelpRow(
+    pill: String,
+    containerColor: Color,
+    contentColor: Color,
+    description: String,
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.Top,
+    ) {
+        Pill(text = pill, containerColor = containerColor, contentColor = contentColor)
+        Text(text = description, style = MaterialTheme.typography.bodySmall)
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -205,6 +205,47 @@
     </plurals>
     <string name="permissions_details_description_restrictions_caveat_description">Apps installed in other user profiles are excluded from the computation above due to Android restrictions.</string>
     <string name="permissions_details_empty_filter_message">No apps match current filters. Tap the filter icon to adjust.</string>
+
+    <!-- Permission tag chip labels -->
+    <string name="permissions_tag_runtime_label">Runtime</string>
+    <string name="permissions_tag_install_time_label">Install-time</string>
+    <string name="permissions_tag_special_access_label">Special access</string>
+    <string name="permissions_tag_documented_label">Documented</string>
+    <string name="permissions_tag_notable_label">Notable</string>
+    <string name="permissions_tag_non_standard_label">Non-standard</string>
+
+    <!-- Grant status labels -->
+    <string name="permissions_status_granted_in_use_label">In use</string>
+    <string name="permissions_status_unknown_label">Unknown</string>
+
+    <!-- System badge -->
+    <string name="permissions_details_system_badge_label">System</string>
+
+    <!-- Flag overflow -->
+    <string name="permissions_details_flags_more_label">+%d more</string>
+
+    <!-- Permission details help dialog -->
+    <string name="permissions_details_help_title">Permission indicators</string>
+    <string name="permissions_details_help_section_protection">Protection type</string>
+    <string name="permissions_details_help_dangerous">Dangerous — Requires explicit user approval at runtime. Can access sensitive data or device features.</string>
+    <string name="permissions_details_help_normal">Normal — Granted automatically at install. Poses minimal risk to other apps or the system.</string>
+    <string name="permissions_details_help_signature">Signature — Only granted to apps signed with the same certificate as the app that declared the permission.</string>
+    <string name="permissions_details_help_internal">Internal — Reserved for Android system internals. Not available to third-party apps.</string>
+    <string name="permissions_details_help_section_tags">Permission tags</string>
+    <string name="permissions_details_help_tag_runtime">Runtime — The app must ask you before using this permission.</string>
+    <string name="permissions_details_help_tag_install_time">Install-time — Granted automatically when the app is installed.</string>
+    <string name="permissions_details_help_tag_special_access">Special access — Requires toggling a switch in system settings.</string>
+    <string name="permissions_details_help_tag_documented">Documented — Listed in the official Android manifest documentation.</string>
+    <string name="permissions_details_help_tag_notable">Notable — Particularly noteworthy due to its impact on privacy or security.</string>
+    <string name="permissions_details_help_tag_non_standard">Non-standard — Not part of the standard Android permission set. Declared by a third-party app or OEM.</string>
+    <string name="permissions_details_status_help_title">Status indicators</string>
+    <string name="permissions_details_help_section_status">Grant status</string>
+    <string name="permissions_details_help_status_granted">Granted — The app has been given this permission.</string>
+    <string name="permissions_details_help_status_in_use">In use — Granted and currently being actively used by the app.</string>
+    <string name="permissions_details_help_status_denied">Denied — The app requested this permission but it was not granted.</string>
+    <string name="permissions_details_help_status_unknown">Unknown — The grant state cannot be determined, e.g. for apps in other user profiles.</string>
+    <string name="permissions_details_help_section_badges">Badges</string>
+    <string name="permissions_details_help_system_badge">System — The app is a pre-installed system app.</string>
     <string name="permission_nfc_label">NFC</string>
     <string name="permission_nfc_description">Allows apps to communicate with Near Field Communication (NFC) tags, cards and readers.</string>
     <string name="permission_manage_media_label">Manage Media</string>


### PR DESCRIPTION
## Summary

- Replace sparse overview card with compact stats grid: colored pills for protection type, protection flags (capped at 3 + overflow), and permission tags; linear progress bars for grant ratios
- Convert app rows to two-line compact format with system badges and colored grant status badges (4 states: Granted, In use, Denied, Unknown) replacing the old binary check/cancel icons
- Replace unstructured protection level text with typed `ProtectionType` + `ProtectionFlag` fields and sorted `PermissionTag` list in the ViewModel state
- Add two contextual help dialogs: permission info help (protection types, tags, system badge) triggered from the overview card, and grant status help (status badges) triggered from the requesting apps section header

## Test plan

- [ ] Navigate to a DANGEROUS permission (e.g. CAMERA) — verify colored pills, ratio bars, system badges render correctly
- [ ] Navigate to an unknown/undeclared permission — verify graceful empty state (no pills, no ratio bars)
- [ ] Toggle user/system filter — verify ratio bars and list update together
- [ ] Tap the help icon in the overview card — verify permission info dialog shows all protection types, tags, and system badge
- [ ] Tap the help icon in the requesting apps section header — verify grant status dialog shows all 4 statuses
- [ ] Verify tapping an app still navigates to app details
- [ ] Check for Compose duplicate-key warnings in logcat during scrolling
