### PR TITLE
Compose: Add preview functions to all leaf content screens

### DIFF
--- a/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsPreviewData.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsPreviewData.kt
@@ -1,0 +1,96 @@
+package eu.darken.myperm.apps.ui.details
+
+import eu.darken.myperm.apps.core.Pkg
+import eu.darken.myperm.apps.core.features.UsesPermission
+import eu.darken.myperm.permissions.core.Permission
+import java.time.Instant
+
+internal object AppDetailsPreviewData {
+
+    private fun permItem(
+        permName: String,
+        label: String? = null,
+        status: UsesPermission.Status = UsesPermission.Status.GRANTED,
+        isRuntime: Boolean = false,
+        isSpecialAccess: Boolean = false,
+        isDeclaredByApp: Boolean = false,
+    ) = AppDetailsViewModel.PermItem(
+        permId = Permission.Id(permName),
+        permLabel = label,
+        usesPermission = UsesPermission.WithState(Permission.Id(permName), flags = null, overrideStatus = status),
+        status = status,
+        type = "declared",
+        isRuntime = isRuntime,
+        isSpecialAccess = isSpecialAccess,
+        isDeclaredByApp = isDeclaredByApp,
+    )
+
+    fun loadedState() = AppDetailsViewModel.State(
+        label = "Chrome",
+        packageName = "com.google.chrome",
+        pkg = Pkg.Container(Pkg.Id("com.google.chrome")),
+        isSystemApp = false,
+        versionName = "120.0.6099.43",
+        versionCode = 612009943,
+        grantedCount = 8,
+        totalPermCount = 12,
+        installedAt = Instant.ofEpochMilli(1700000000000),
+        updatedAt = Instant.ofEpochMilli(1705000000000),
+        apiTargetDesc = "Target: Android 14 (Upside Down Cake) [34]",
+        apiMinimumDesc = "Min: Android 10 (Q) [29]",
+        apiCompileDesc = "Compile: Android 14 (Upside Down Cake) [34]",
+        installerLabel = "Google Play Store",
+        installerSourceLabel = "Installed by:",
+        canOpen = true,
+        installerPkgNames = listOf("com.android.vending"),
+        installerAppName = "Google Play Store",
+        permissions = listOf(
+            permItem("android.permission.CAMERA", "Camera", UsesPermission.Status.GRANTED, isRuntime = true),
+            permItem("android.permission.ACCESS_FINE_LOCATION", "Fine location", UsesPermission.Status.DENIED, isRuntime = true),
+            permItem("android.permission.INTERNET", "Internet", UsesPermission.Status.GRANTED),
+            permItem("android.permission.READ_CONTACTS", "Read contacts", UsesPermission.Status.GRANTED, isRuntime = true),
+            permItem("android.permission.SYSTEM_ALERT_WINDOW", "Draw over other apps", UsesPermission.Status.DENIED, isSpecialAccess = true),
+            permItem("com.google.chrome.DYNAMIC_RECEIVER", null, UsesPermission.Status.UNKNOWN, isDeclaredByApp = true),
+        ),
+        twins = listOf(
+            AppDetailsViewModel.TwinItem(Pkg.Id("com.google.chrome"), "Chrome (Work)"),
+        ),
+        siblings = listOf(
+            AppDetailsViewModel.SiblingItem(Pkg.Id("com.google.android.webview"), "Android System WebView"),
+        ),
+        isLoading = false,
+    )
+
+    fun loadingState() = AppDetailsViewModel.State(
+        label = "Chrome",
+        isLoading = true,
+    )
+
+    fun systemAppState() = AppDetailsViewModel.State(
+        label = "System UI",
+        packageName = "com.android.systemui",
+        pkg = Pkg.Container(Pkg.Id("com.android.systemui")),
+        isSystemApp = true,
+        versionName = "14",
+        versionCode = 34,
+        grantedCount = 42,
+        totalPermCount = 42,
+        apiTargetDesc = "Target: Android 14 (Upside Down Cake) [34]",
+        canOpen = false,
+        permissions = listOf(
+            permItem("android.permission.INTERNET", "Internet", UsesPermission.Status.GRANTED),
+            permItem("android.permission.READ_PHONE_STATE", "Read phone state", UsesPermission.Status.GRANTED, isRuntime = true),
+        ),
+        isLoading = false,
+    )
+
+    fun emptyFilterState() = AppDetailsViewModel.State(
+        label = "Chrome",
+        packageName = "com.google.chrome",
+        pkg = Pkg.Container(Pkg.Id("com.google.chrome")),
+        grantedCount = 8,
+        totalPermCount = 12,
+        permissions = emptyList(),
+        isLoading = false,
+    )
+}

--- a/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsScreen.kt
@@ -65,6 +65,8 @@ import eu.darken.myperm.R
 import eu.darken.myperm.apps.core.features.UsesPermission
 import eu.darken.myperm.common.compose.LabeledOption
 import eu.darken.myperm.common.compose.MultiChoiceFilterDialog
+import eu.darken.myperm.common.compose.Preview2
+import eu.darken.myperm.common.compose.PreviewWrapper
 import eu.darken.myperm.common.compose.waitForState
 import eu.darken.myperm.common.error.ErrorEventHandler
 import eu.darken.myperm.common.navigation.Nav
@@ -778,4 +780,74 @@ private fun PermissionHelpDialog(onDismiss: () -> Unit) {
             }
         },
     )
+}
+
+@Preview2
+@Composable
+private fun AppDetailsScreenPreview() = PreviewWrapper {
+    AppDetailsScreen(
+        state = AppDetailsPreviewData.loadedState(),
+        onBack = {},
+        onPermClicked = {},
+        onTwinClicked = {},
+        onSiblingClicked = {},
+        onGoSettings = {},
+        onOpenApp = {},
+        onFilter = {},
+        onInstallerClicked = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun AppDetailsScreenLoadingPreview() = PreviewWrapper {
+    AppDetailsScreen(
+        state = AppDetailsPreviewData.loadingState(),
+        onBack = {},
+        onPermClicked = {},
+        onTwinClicked = {},
+        onSiblingClicked = {},
+        onGoSettings = {},
+        onOpenApp = {},
+        onFilter = {},
+        onInstallerClicked = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun AppDetailsScreenSystemAppPreview() = PreviewWrapper {
+    AppDetailsScreen(
+        state = AppDetailsPreviewData.systemAppState(),
+        onBack = {},
+        onPermClicked = {},
+        onTwinClicked = {},
+        onSiblingClicked = {},
+        onGoSettings = {},
+        onOpenApp = {},
+        onFilter = {},
+        onInstallerClicked = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun AppDetailsScreenEmptyFilterPreview() = PreviewWrapper {
+    AppDetailsScreen(
+        state = AppDetailsPreviewData.emptyFilterState(),
+        onBack = {},
+        onPermClicked = {},
+        onTwinClicked = {},
+        onSiblingClicked = {},
+        onGoSettings = {},
+        onOpenApp = {},
+        onFilter = {},
+        onInstallerClicked = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun PermissionHelpDialogPreview() = PreviewWrapper {
+    PermissionHelpDialog(onDismiss = {})
 }

--- a/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsPreviewData.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsPreviewData.kt
@@ -1,0 +1,46 @@
+package eu.darken.myperm.apps.ui.list
+
+import android.os.Process
+import eu.darken.myperm.apps.core.Pkg
+import eu.darken.myperm.apps.core.features.InstallerInfo
+
+internal object AppsPreviewData {
+
+    private fun appItem(
+        pkgName: String,
+        label: String?,
+        isSystemApp: Boolean = false,
+        grantedCount: Int = 0,
+        totalCount: Int = 0,
+        declaredCount: Int = 0,
+        tagIconRes: List<Int> = emptyList(),
+        hasInstaller: Boolean = false,
+    ) = AppsViewModel.AppItem(
+        id = Pkg.Id(pkgName),
+        pkg = Pkg.Container(Pkg.Id(pkgName)),
+        label = label,
+        packageName = pkgName,
+        isSystemApp = isSystemApp,
+        permissionCount = totalCount,
+        grantedCount = grantedCount,
+        totalCount = totalCount,
+        declaredCount = declaredCount,
+        tagIconRes = tagIconRes,
+        installerInfo = if (hasInstaller) InstallerInfo(installingPkg = Pkg.Container(Pkg.Id("com.android.vending"))) else null,
+        userHandle = Process.myUserHandle(),
+    )
+
+    fun readyState() = AppsViewModel.State.Ready(
+        items = listOf(
+            appItem("com.google.chrome", "Chrome", grantedCount = 8, totalCount = 12, hasInstaller = true),
+            appItem("org.mozilla.firefox", "Firefox", grantedCount = 5, totalCount = 9, hasInstaller = true),
+            appItem("com.android.systemui", "System UI", isSystemApp = true, grantedCount = 42, totalCount = 42, declaredCount = 3),
+        ),
+        itemCount = 3,
+    )
+
+    fun emptyReadyState() = AppsViewModel.State.Ready(
+        items = emptyList(),
+        itemCount = 0,
+    )
+}

--- a/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsScreen.kt
@@ -47,6 +47,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import eu.darken.myperm.R
 import eu.darken.myperm.common.compose.LabeledOption
 import eu.darken.myperm.common.compose.MultiChoiceFilterDialog
+import eu.darken.myperm.common.compose.Preview2
+import eu.darken.myperm.common.compose.PreviewWrapper
 import eu.darken.myperm.common.compose.SingleChoiceSortDialog
 import eu.darken.myperm.common.compose.waitForState
 import eu.darken.myperm.common.error.ErrorEventHandler
@@ -286,4 +288,46 @@ private fun AppListItem(
             )
         }
     }
+}
+
+@Preview2
+@Composable
+private fun AppsScreenReadyPreview() = PreviewWrapper {
+    AppsScreen(
+        state = AppsPreviewData.readyState(),
+        onSearchChanged = {},
+        onAppClicked = {},
+        onFilter = {},
+        onSort = {},
+        onRefresh = {},
+        onSettings = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun AppsScreenEmptyPreview() = PreviewWrapper {
+    AppsScreen(
+        state = AppsPreviewData.emptyReadyState(),
+        onSearchChanged = {},
+        onAppClicked = {},
+        onFilter = {},
+        onSort = {},
+        onRefresh = {},
+        onSettings = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun AppsScreenLoadingPreview() = PreviewWrapper {
+    AppsScreen(
+        state = AppsViewModel.State.Loading,
+        onSearchChanged = {},
+        onAppClicked = {},
+        onFilter = {},
+        onSort = {},
+        onRefresh = {},
+        onSettings = {},
+    )
 }

--- a/app/src/main/java/eu/darken/myperm/common/compose/FilterSortDialogs.kt
+++ b/app/src/main/java/eu/darken/myperm/common/compose/FilterSortDialogs.kt
@@ -22,6 +22,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import eu.darken.myperm.R
+import eu.darken.myperm.apps.ui.details.AppDetailsFilterOptions
+import eu.darken.myperm.apps.ui.list.AppsSortOptions
+import eu.darken.myperm.common.compose.Preview2
+import eu.darken.myperm.common.compose.PreviewWrapper
 
 data class LabeledOption<T>(
     val value: T,
@@ -124,5 +128,29 @@ fun <T> SingleChoiceSortDialog(
                 Text(stringResource(android.R.string.cancel))
             }
         },
+    )
+}
+
+@Preview2
+@Composable
+private fun MultiChoiceFilterDialogPreview() = PreviewWrapper {
+    MultiChoiceFilterDialog(
+        title = "Filter",
+        options = AppDetailsFilterOptions.Filter.entries.map { LabeledOption(it, it.labelRes) },
+        selected = setOf(AppDetailsFilterOptions.Filter.GRANTED),
+        onConfirm = {},
+        onDismiss = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun SingleChoiceSortDialogPreview() = PreviewWrapper {
+    SingleChoiceSortDialog(
+        title = "Sort",
+        options = AppsSortOptions.Sort.entries.map { LabeledOption(it, it.labelRes) },
+        selected = AppsSortOptions.Sort.UPDATED_AT,
+        onSelect = {},
+        onDismiss = {},
     )
 }

--- a/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewPreviewData.kt
+++ b/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewPreviewData.kt
@@ -1,0 +1,36 @@
+package eu.darken.myperm.main.ui.overview
+
+internal object OverviewPreviewData {
+
+    fun loadedState() = OverviewViewModel.State(
+        deviceInfo = OverviewViewModel.DeviceInfo(
+            deviceName = "oriole (Pixel 6)",
+            androidVersion = "Android 14 (Upside Down Cake) [34]",
+            patchLevel = "2024-01-05",
+        ),
+        summaryInfo = OverviewViewModel.SummaryInfo(
+            activeProfileUser = 87,
+            activeProfileSystem = 142,
+            otherProfileUser = 3,
+            otherProfileSystem = 0,
+            sideloaded = 5,
+            installerAppsUser = 2,
+            installerAppsSystem = 1,
+            systemAlertWindowUser = 4,
+            systemAlertWindowSystem = 3,
+            noInternetUser = 12,
+            noInternetSystem = 68,
+            clonesUser = 1,
+            clonesSystem = 0,
+            sharedIdsUser = 0,
+            sharedIdsSystem = 14,
+        ),
+        versionDesc = "v1.2.3 (42) ~ abc1234/foss/debug",
+        isLoading = false,
+    )
+
+    fun loadingState() = OverviewViewModel.State(
+        versionDesc = "v1.2.3 (42) ~ abc1234/foss/debug",
+        isLoading = true,
+    )
+}

--- a/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewScreen.kt
@@ -32,6 +32,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import eu.darken.myperm.R
+import eu.darken.myperm.common.compose.Preview2
+import eu.darken.myperm.common.compose.PreviewWrapper
 import eu.darken.myperm.common.compose.waitForState
 import eu.darken.myperm.common.error.ErrorEventHandler
 import eu.darken.myperm.common.navigation.NavigationEventHandler
@@ -178,4 +180,24 @@ private fun SummaryRow(label: String, userCount: Int, systemCount: Int) {
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
+}
+
+@Preview2
+@Composable
+private fun OverviewScreenPreview() = PreviewWrapper {
+    OverviewScreen(
+        state = OverviewPreviewData.loadedState(),
+        onRefresh = {},
+        onSettings = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun OverviewScreenLoadingPreview() = PreviewWrapper {
+    OverviewScreen(
+        state = OverviewPreviewData.loadingState(),
+        onRefresh = {},
+        onSettings = {},
+    )
 }

--- a/app/src/main/java/eu/darken/myperm/permissions/ui/details/PermissionDetailsPreviewData.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/details/PermissionDetailsPreviewData.kt
@@ -1,0 +1,67 @@
+package eu.darken.myperm.permissions.ui.details
+
+import eu.darken.myperm.apps.core.Pkg
+import eu.darken.myperm.apps.core.features.UsesPermission
+import eu.darken.myperm.permissions.core.ProtectionType
+import eu.darken.myperm.permissions.core.features.ManifestDoc
+import eu.darken.myperm.permissions.core.features.RuntimeGrant
+
+internal object PermissionDetailsPreviewData {
+
+    fun loadedState() = PermissionDetailsViewModel.State(
+        label = "CAMERA",
+        permissionId = "android.permission.CAMERA",
+        permission = null,
+        description = "Camera",
+        fullDescription = "Required to be able to access the camera device.",
+        protectionType = ProtectionType.DANGEROUS,
+        protectionFlags = emptyList(),
+        tags = listOf(RuntimeGrant, ManifestDoc),
+        grantedUserCount = 12,
+        totalUserCount = 45,
+        grantedSystemCount = 3,
+        totalSystemCount = 8,
+        declaringApps = listOf(
+            PermissionDetailsViewModel.DeclaringAppItem(
+                pkgName = "android",
+                pkg = Pkg.Container(Pkg.Id("android")),
+                label = "Android System",
+                isSystemApp = true,
+                userHandle = 0,
+            ),
+        ),
+        requestingApps = listOf(
+            PermissionDetailsViewModel.RequestingAppItem(
+                pkgName = "com.google.chrome",
+                pkg = Pkg.Container(Pkg.Id("com.google.chrome")),
+                label = "Chrome",
+                isSystemApp = false,
+                status = UsesPermission.Status.GRANTED,
+                userHandle = 0,
+            ),
+            PermissionDetailsViewModel.RequestingAppItem(
+                pkgName = "org.mozilla.firefox",
+                pkg = Pkg.Container(Pkg.Id("org.mozilla.firefox")),
+                label = "Firefox",
+                isSystemApp = false,
+                status = UsesPermission.Status.DENIED,
+                userHandle = 0,
+            ),
+            PermissionDetailsViewModel.RequestingAppItem(
+                pkgName = "com.android.camera",
+                pkg = Pkg.Container(Pkg.Id("com.android.camera")),
+                label = "Camera",
+                isSystemApp = true,
+                status = UsesPermission.Status.GRANTED,
+                userHandle = 0,
+            ),
+        ),
+        isLoading = false,
+    )
+
+    fun loadingState() = PermissionDetailsViewModel.State(
+        label = "CAMERA",
+        permissionId = "android.permission.CAMERA",
+        isLoading = true,
+    )
+}

--- a/app/src/main/java/eu/darken/myperm/permissions/ui/details/PermissionDetailsScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/details/PermissionDetailsScreen.kt
@@ -56,6 +56,8 @@ import eu.darken.myperm.R
 import eu.darken.myperm.apps.core.features.UsesPermission
 import eu.darken.myperm.common.compose.LabeledOption
 import eu.darken.myperm.common.compose.MultiChoiceFilterDialog
+import eu.darken.myperm.common.compose.Preview2
+import eu.darken.myperm.common.compose.PreviewWrapper
 import eu.darken.myperm.common.compose.waitForState
 import eu.darken.myperm.common.error.ErrorEventHandler
 import eu.darken.myperm.common.navigation.Nav
@@ -691,4 +693,30 @@ private fun HelpRow(
         Pill(text = pill, containerColor = containerColor, contentColor = contentColor)
         Text(text = description, style = MaterialTheme.typography.bodySmall)
     }
+}
+
+@Preview2
+@Composable
+private fun PermissionDetailsScreenPreview() = PreviewWrapper {
+    PermissionDetailsScreen(
+        state = PermissionDetailsPreviewData.loadedState(),
+        onBack = {},
+        onAppClicked = { _, _ -> },
+        onFilterClicked = {},
+        onPermissionHelpClicked = {},
+        onStatusHelpClicked = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun PermissionDetailsScreenLoadingPreview() = PreviewWrapper {
+    PermissionDetailsScreen(
+        state = PermissionDetailsPreviewData.loadingState(),
+        onBack = {},
+        onAppClicked = { _, _ -> },
+        onFilterClicked = {},
+        onPermissionHelpClicked = {},
+        onStatusHelpClicked = {},
+    )
 }

--- a/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsPreviewData.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsPreviewData.kt
@@ -1,0 +1,57 @@
+package eu.darken.myperm.permissions.ui.list
+
+import eu.darken.myperm.permissions.core.Permission
+import eu.darken.myperm.permissions.core.container.UnknownPermission
+import eu.darken.myperm.permissions.core.features.ManifestDoc
+import eu.darken.myperm.permissions.core.features.RuntimeGrant
+import eu.darken.myperm.permissions.core.known.APermGrp
+
+internal object PermissionsPreviewData {
+
+    private fun permItem(
+        permName: String,
+        label: String? = null,
+        type: String = "declared",
+        requestingCount: Int = 0,
+        grantedCount: Int = 0,
+    ) = PermissionsViewModel.PermItem(
+        id = Permission.Id(permName),
+        label = label,
+        type = type,
+        requestingCount = requestingCount,
+        grantedCount = grantedCount,
+        permission = UnknownPermission(
+            id = Permission.Id(permName),
+            tags = if (type == "declared") setOf(RuntimeGrant, ManifestDoc) else emptySet(),
+            groupIds = emptySet(),
+        ),
+    )
+
+    fun readyState() = PermissionsViewModel.State.Ready(
+        listData = listOf(
+            PermissionsViewModel.ListItem.Group(
+                PermissionsViewModel.GroupItem(group = APermGrp.Camera, permCount = 2, isExpanded = true)
+            ),
+            PermissionsViewModel.ListItem.Perm(
+                permItem("android.permission.CAMERA", "Camera", "declared", requestingCount = 45, grantedCount = 12)
+            ),
+            PermissionsViewModel.ListItem.Perm(
+                permItem("android.permission.RECORD_VIDEO", null, "extra", requestingCount = 8, grantedCount = 3)
+            ),
+            PermissionsViewModel.ListItem.Group(
+                PermissionsViewModel.GroupItem(group = APermGrp.Location, permCount = 3, isExpanded = false)
+            ),
+            PermissionsViewModel.ListItem.Group(
+                PermissionsViewModel.GroupItem(group = APermGrp.Contacts, permCount = 2, isExpanded = false)
+            ),
+        ),
+        countPermissions = 7,
+        countGroups = 3,
+    )
+
+    fun emptyReadyState() = PermissionsViewModel.State.Ready(
+        listData = emptyList(),
+        countPermissions = 0,
+        countGroups = 0,
+    )
+}

--- a/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsScreen.kt
@@ -57,11 +57,14 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import eu.darken.myperm.R
 import eu.darken.myperm.common.compose.LabeledOption
 import eu.darken.myperm.common.compose.MultiChoiceFilterDialog
+import eu.darken.myperm.common.compose.Preview2
+import eu.darken.myperm.common.compose.PreviewWrapper
 import eu.darken.myperm.common.compose.SingleChoiceSortDialog
 import eu.darken.myperm.common.compose.waitForState
 import eu.darken.myperm.common.error.ErrorEventHandler
 import eu.darken.myperm.common.navigation.NavigationEventHandler
 import eu.darken.myperm.permissions.core.PermissionGroup
+import eu.darken.myperm.permissions.core.known.APermGrp
 
 @Composable
 fun PermissionsScreenHost(vm: PermissionsViewModel = hiltViewModel()) {
@@ -348,4 +351,64 @@ private fun PermissionListItem(
             }
         }
     }
+}
+
+@Preview2
+@Composable
+private fun PermissionsScreenReadyPreview() = PreviewWrapper {
+    PermissionsScreen(
+        state = PermissionsPreviewData.readyState(),
+        onSearchChanged = {},
+        onGroupClicked = {},
+        onPermClicked = {},
+        onExpandAll = {},
+        onCollapseAll = {},
+        onRefresh = {},
+        onSettings = {},
+        onFilterClicked = {},
+        onSortClicked = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun PermissionsScreenEmptyPreview() = PreviewWrapper {
+    PermissionsScreen(
+        state = PermissionsPreviewData.emptyReadyState(),
+        onSearchChanged = {},
+        onGroupClicked = {},
+        onPermClicked = {},
+        onExpandAll = {},
+        onCollapseAll = {},
+        onRefresh = {},
+        onSettings = {},
+        onFilterClicked = {},
+        onSortClicked = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun PermissionsScreenLoadingPreview() = PreviewWrapper {
+    PermissionsScreen(
+        state = PermissionsViewModel.State.Loading,
+        onSearchChanged = {},
+        onGroupClicked = {},
+        onPermClicked = {},
+        onExpandAll = {},
+        onCollapseAll = {},
+        onRefresh = {},
+        onSettings = {},
+        onFilterClicked = {},
+        onSortClicked = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun PermissionGroupHeaderPreview() = PreviewWrapper {
+    PermissionGroupHeader(
+        item = PermissionsViewModel.GroupItem(group = APermGrp.Camera, permCount = 5, isExpanded = true),
+        onClick = {},
+    )
 }

--- a/app/src/main/java/eu/darken/myperm/settings/ui/acks/AcknowledgementsScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/settings/ui/acks/AcknowledgementsScreen.kt
@@ -19,6 +19,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import eu.darken.myperm.R
+import eu.darken.myperm.common.compose.Preview2
+import eu.darken.myperm.common.compose.PreviewWrapper
 import eu.darken.myperm.common.navigation.LocalNavigationController
 
 @Composable
@@ -61,4 +63,10 @@ fun AcknowledgementsScreen(
             )
         }
     }
+}
+
+@Preview2
+@Composable
+private fun AcknowledgementsScreenPreview() = PreviewWrapper {
+    AcknowledgementsScreen(onBack = {})
 }

--- a/app/src/main/java/eu/darken/myperm/settings/ui/general/GeneralSettingsScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/settings/ui/general/GeneralSettingsScreen.kt
@@ -19,6 +19,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import eu.darken.myperm.R
+import eu.darken.myperm.common.compose.Preview2
+import eu.darken.myperm.common.compose.PreviewWrapper
 import eu.darken.myperm.common.navigation.LocalNavigationController
 
 @Composable
@@ -61,4 +63,10 @@ fun GeneralSettingsScreen(
             )
         }
     }
+}
+
+@Preview2
+@Composable
+private fun GeneralSettingsScreenPreview() = PreviewWrapper {
+    GeneralSettingsScreen(onBack = {})
 }

--- a/app/src/main/java/eu/darken/myperm/settings/ui/index/SettingsIndexScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/settings/ui/index/SettingsIndexScreen.kt
@@ -24,6 +24,8 @@ import androidx.compose.ui.res.stringResource
 import eu.darken.myperm.R
 import eu.darken.myperm.common.BuildConfigWrap
 import eu.darken.myperm.common.PrivacyPolicy
+import eu.darken.myperm.common.compose.Preview2
+import eu.darken.myperm.common.compose.PreviewWrapper
 import eu.darken.myperm.common.navigation.LocalNavigationController
 import eu.darken.myperm.common.navigation.Nav
 import eu.darken.myperm.common.settings.SettingsBaseItem
@@ -100,4 +102,10 @@ fun SettingsIndexScreen(
             )
         }
     }
+}
+
+@Preview2
+@Composable
+private fun SettingsIndexScreenPreview() = PreviewWrapper {
+    SettingsIndexScreen(onBack = {}, onGeneral = {}, onSupport = {}, onAcknowledgements = {}, onPrivacyPolicy = null)
 }

--- a/app/src/main/java/eu/darken/myperm/settings/ui/support/SupportScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/settings/ui/support/SupportScreen.kt
@@ -19,6 +19,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import eu.darken.myperm.R
+import eu.darken.myperm.common.compose.Preview2
+import eu.darken.myperm.common.compose.PreviewWrapper
 import eu.darken.myperm.common.navigation.LocalNavigationController
 
 @Composable
@@ -61,4 +63,10 @@ fun SupportScreen(
             )
         }
     }
+}
+
+@Preview2
+@Composable
+private fun SupportScreenPreview() = PreviewWrapper {
+    SupportScreen(onBack = {})
 }


### PR DESCRIPTION
## Summary

- Add `@Preview2` (light + dark) composable previews to all leaf content screens that were missing them after the Compose migration
- Create 5 feature-local preview data files with mock `ViewModel.State` objects for stateful screens
- Cover 22 preview functions across 15 files: settings screens, dialogs, overview, apps list/details, permissions list/details

## Details

**New preview data files** provide realistic mock state without Android framework dependencies:
- `OverviewPreviewData` — device info + app summary
- `AppsPreviewData` — app list items with mixed properties
- `AppDetailsPreviewData` — 4 variants (loaded, loading, system app, empty filter)
- `PermissionsPreviewData` — grouped permission list with expanded Camera group
- `PermissionDetailsPreviewData` — declaring + requesting apps with mixed grant statuses

**Preview coverage added to:**
- Settings: GeneralSettingsScreen, AcknowledgementsScreen, SupportScreen, SettingsIndexScreen
- Dialogs: MultiChoiceFilterDialog, SingleChoiceSortDialog
- Overview: loaded + loading states
- Apps: ready + empty + loading states
- Permissions: ready + empty + loading + group header sub-component
- Permission details: loaded + loading states
- App details: loaded + loading + system app + empty filter + help dialog

All previews follow the existing pattern: `@Preview2 @Composable private fun XPreview() = PreviewWrapper { ... }`
