### PR TITLE
Settings: Implement index, support, and acknowledgements screens

### DIFF
--- a/app/src/debug/java/eu/darken/myperm/screenshots/ScreenshotContent.kt
+++ b/app/src/debug/java/eu/darken/myperm/screenshots/ScreenshotContent.kt
@@ -150,10 +150,10 @@ internal fun PermissionDetailsContent() = PreviewWrapper {
 internal fun SettingsIndexContent() = PreviewWrapper {
     SettingsIndexScreen(
         onBack = {},
-        onGeneral = {},
+        onChangelog = {},
         onSupport = {},
         onAcknowledgements = {},
-        onPrivacyPolicy = null,
+        onPrivacyPolicy = {},
         versionSubtitle = "v1.2.3",
     )
 }

--- a/app/src/main/java/eu/darken/myperm/settings/ui/acks/AcknowledgementsScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/settings/ui/acks/AcknowledgementsScreen.kt
@@ -8,27 +8,66 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import eu.darken.myperm.R
 import eu.darken.myperm.common.compose.Preview2
 import eu.darken.myperm.common.compose.PreviewWrapper
 import eu.darken.myperm.common.navigation.LocalNavigationController
+import eu.darken.myperm.common.settings.SettingsBaseItem
+import eu.darken.myperm.common.settings.SettingsCategoryHeader
+
+private data class AckEntry(val title: String, val subtitle: String, val url: String)
+
+private val LICENSE_ENTRIES = listOf(
+    AckEntry(
+        "Material Design Icons",
+        "materialdesignicons.com (SIL Open Font License 1.1 / Attribution 4.0 International)",
+        "https://github.com/Templarian/MaterialDesign",
+    ),
+    AckEntry(
+        "Lottie",
+        "Airbnb's Lottie for Android. (APACHE 2.0)",
+        "https://github.com/airbnb/lottie-android",
+    ),
+    AckEntry(
+        "Kotlin",
+        "The Kotlin Programming Language. (APACHE 2.0)",
+        "https://github.com/JetBrains/kotlin",
+    ),
+    AckEntry(
+        "Dagger",
+        "A fast dependency injector for Android and Java. (APACHE 2.0)",
+        "https://github.com/google/dagger",
+    ),
+    AckEntry(
+        "Android",
+        "Android Open Source Project (APACHE 2.0)",
+        "https://source.android.com/source/licenses.html",
+    ),
+    AckEntry(
+        "Android",
+        "The Android robot is reproduced or modified from work created and shared by Google and used according to terms described in the Creative Commons 3.0 Attribution License.",
+        "https://developer.android.com/distribute/tools/promote/brand.html",
+    ),
+)
 
 @Composable
 fun AcknowledgementsScreenHost() {
     val navCtrl = LocalNavigationController.current
+    val vm: AcknowledgementsViewModel = hiltViewModel()
 
     AcknowledgementsScreen(
         onBack = { navCtrl?.up() },
+        onOpenUrl = { vm.openUrl(it) },
     )
 }
 
@@ -36,11 +75,17 @@ fun AcknowledgementsScreenHost() {
 @Composable
 fun AcknowledgementsScreen(
     onBack: () -> Unit,
+    onOpenUrl: (String) -> Unit,
 ) {
+    val thankYouEntries = listOf(
+        AckEntry("Max Patchs", stringResource(R.string.acks_maxpatchs_desc), "https://twitter.com/maxpatchs"),
+        AckEntry("Crowdin", stringResource(R.string.acks_crowdin_desc), "https://crowdin.com/project/permission-pilot"),
+    )
+
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(text = stringResource(R.string.settings_licenses_label)) },
+                title = { Text(text = stringResource(R.string.settings_acknowledgements_label)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
@@ -53,14 +98,27 @@ fun AcknowledgementsScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding)
-                .verticalScroll(rememberScrollState())
-                .padding(vertical = 8.dp),
+                .verticalScroll(rememberScrollState()),
         ) {
-            Text(
-                text = "Open source licenses",
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.padding(16.dp),
-            )
+            SettingsCategoryHeader(text = stringResource(R.string.general_thank_you_label))
+            thankYouEntries.forEachIndexed { index, entry ->
+                SettingsBaseItem(
+                    title = entry.title,
+                    subtitle = entry.subtitle,
+                    onClick = { onOpenUrl(entry.url) },
+                )
+                if (index < thankYouEntries.lastIndex) HorizontalDivider()
+            }
+
+            SettingsCategoryHeader(text = stringResource(R.string.settings_licenses_label))
+            LICENSE_ENTRIES.forEachIndexed { index, entry ->
+                SettingsBaseItem(
+                    title = entry.title,
+                    subtitle = entry.subtitle,
+                    onClick = { onOpenUrl(entry.url) },
+                )
+                if (index < LICENSE_ENTRIES.lastIndex) HorizontalDivider()
+            }
         }
     }
 }
@@ -68,5 +126,5 @@ fun AcknowledgementsScreen(
 @Preview2
 @Composable
 private fun AcknowledgementsScreenPreview() = PreviewWrapper {
-    AcknowledgementsScreen(onBack = {})
+    AcknowledgementsScreen(onBack = {}, onOpenUrl = {})
 }

--- a/app/src/main/java/eu/darken/myperm/settings/ui/acks/AcknowledgementsViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/settings/ui/acks/AcknowledgementsViewModel.kt
@@ -1,0 +1,23 @@
+package eu.darken.myperm.settings.ui.acks
+
+import dagger.hilt.android.lifecycle.HiltViewModel
+import eu.darken.myperm.common.WebpageTool
+import eu.darken.myperm.common.coroutine.DispatcherProvider
+import eu.darken.myperm.common.debug.logging.logTag
+import eu.darken.myperm.common.uix.ViewModel4
+import javax.inject.Inject
+
+@HiltViewModel
+class AcknowledgementsViewModel @Inject constructor(
+    dispatcherProvider: DispatcherProvider,
+    private val webpageTool: WebpageTool,
+) : ViewModel4(dispatcherProvider) {
+
+    fun openUrl(url: String) {
+        webpageTool.open(url)
+    }
+
+    companion object {
+        private val TAG = logTag("Settings", "Acknowledgements", "VM")
+    }
+}

--- a/app/src/main/java/eu/darken/myperm/settings/ui/general/GeneralSettingsScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/settings/ui/general/GeneralSettingsScreen.kt
@@ -23,6 +23,7 @@ import eu.darken.myperm.common.compose.Preview2
 import eu.darken.myperm.common.compose.PreviewWrapper
 import eu.darken.myperm.common.navigation.LocalNavigationController
 
+// TODO: No UI entry point yet — reserved for future general settings
 @Composable
 fun GeneralSettingsScreenHost() {
     val navCtrl = LocalNavigationController.current

--- a/app/src/main/java/eu/darken/myperm/settings/ui/index/SettingsIndexScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/settings/ui/index/SettingsIndexScreen.kt
@@ -7,23 +7,22 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.twotone.FormatListNumbered
 import androidx.compose.material.icons.twotone.Favorite
+import androidx.compose.material.icons.automirrored.twotone.HelpOutline
 import androidx.compose.material.icons.twotone.Info
-import androidx.compose.material.icons.twotone.Policy
-import androidx.compose.material.icons.twotone.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.hilt.navigation.compose.hiltViewModel
 import eu.darken.myperm.R
 import eu.darken.myperm.common.BuildConfigWrap
-import eu.darken.myperm.common.PrivacyPolicy
 import eu.darken.myperm.common.compose.Preview2
 import eu.darken.myperm.common.compose.PreviewWrapper
 import eu.darken.myperm.common.navigation.LocalNavigationController
@@ -35,13 +34,14 @@ import eu.darken.myperm.common.settings.SettingsDivider
 @Composable
 fun SettingsIndexScreenHost() {
     val navCtrl = LocalNavigationController.current
+    val vm: SettingsIndexViewModel = hiltViewModel()
 
     SettingsIndexScreen(
         onBack = { navCtrl?.up() },
-        onGeneral = { navCtrl?.goTo(Nav.Settings.General) },
+        onChangelog = { vm.openChangelog() },
         onSupport = { navCtrl?.goTo(Nav.Settings.Support) },
         onAcknowledgements = { navCtrl?.goTo(Nav.Settings.Acknowledgements) },
-        onPrivacyPolicy = null, // Handled via WebpageTool — will be wired later
+        onPrivacyPolicy = { vm.openPrivacyPolicy() },
     )
 }
 
@@ -49,10 +49,10 @@ fun SettingsIndexScreenHost() {
 @Composable
 fun SettingsIndexScreen(
     onBack: () -> Unit,
-    onGeneral: () -> Unit,
+    onChangelog: () -> Unit,
     onSupport: () -> Unit,
     onAcknowledgements: () -> Unit,
-    onPrivacyPolicy: (() -> Unit)?,
+    onPrivacyPolicy: () -> Unit,
     versionSubtitle: String = BuildConfigWrap.VERSION_DESCRIPTION,
 ) {
     Scaffold(
@@ -73,33 +73,34 @@ fun SettingsIndexScreen(
                 .padding(innerPadding)
                 .verticalScroll(rememberScrollState()),
         ) {
-            SettingsBaseItem(
-                title = stringResource(R.string.general_settings_label),
-                subtitle = versionSubtitle,
-                icon = Icons.TwoTone.Settings,
-                onClick = onGeneral,
-            )
-            SettingsDivider()
-
             SettingsCategoryHeader(text = stringResource(R.string.settings_category_other_label))
 
             SettingsBaseItem(
-                title = stringResource(R.string.settings_privacy_policy_label),
-                subtitle = stringResource(R.string.settings_privacy_policy_desc),
-                icon = Icons.TwoTone.Policy,
-                onClick = { onPrivacyPolicy?.invoke() },
+                title = stringResource(R.string.changelog_label),
+                subtitle = versionSubtitle,
+                icon = Icons.TwoTone.FormatListNumbered,
+                onClick = onChangelog,
             )
             SettingsDivider()
             SettingsBaseItem(
                 title = stringResource(R.string.settings_support_label),
-                icon = Icons.TwoTone.Favorite,
+                subtitle = "\u00AF\\_(ツ)_/\u00AF",
+                icon = Icons.AutoMirrored.TwoTone.HelpOutline,
                 onClick = onSupport,
             )
             SettingsDivider()
             SettingsBaseItem(
-                title = stringResource(R.string.settings_licenses_label),
-                icon = Icons.TwoTone.Info,
+                title = stringResource(R.string.settings_acknowledgements_label),
+                subtitle = stringResource(R.string.general_thank_you_label),
+                icon = Icons.TwoTone.Favorite,
                 onClick = onAcknowledgements,
+            )
+            SettingsDivider()
+            SettingsBaseItem(
+                title = stringResource(R.string.settings_privacy_policy_label),
+                subtitle = stringResource(R.string.settings_privacy_policy_desc),
+                icon = Icons.TwoTone.Info,
+                onClick = onPrivacyPolicy,
             )
         }
     }
@@ -108,5 +109,5 @@ fun SettingsIndexScreen(
 @Preview2
 @Composable
 private fun SettingsIndexScreenPreview() = PreviewWrapper {
-    SettingsIndexScreen(onBack = {}, onGeneral = {}, onSupport = {}, onAcknowledgements = {}, onPrivacyPolicy = null)
+    SettingsIndexScreen(onBack = {}, onChangelog = {}, onSupport = {}, onAcknowledgements = {}, onPrivacyPolicy = {})
 }

--- a/app/src/main/java/eu/darken/myperm/settings/ui/index/SettingsIndexViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/settings/ui/index/SettingsIndexViewModel.kt
@@ -1,0 +1,28 @@
+package eu.darken.myperm.settings.ui.index
+
+import dagger.hilt.android.lifecycle.HiltViewModel
+import eu.darken.myperm.common.PrivacyPolicy
+import eu.darken.myperm.common.WebpageTool
+import eu.darken.myperm.common.coroutine.DispatcherProvider
+import eu.darken.myperm.common.debug.logging.logTag
+import eu.darken.myperm.common.uix.ViewModel4
+import javax.inject.Inject
+
+@HiltViewModel
+class SettingsIndexViewModel @Inject constructor(
+    dispatcherProvider: DispatcherProvider,
+    private val webpageTool: WebpageTool,
+) : ViewModel4(dispatcherProvider) {
+
+    fun openChangelog() {
+        webpageTool.open("https://github.com/d4rken-org/permission-pilot/releases")
+    }
+
+    fun openPrivacyPolicy() {
+        webpageTool.open(PrivacyPolicy.URL)
+    }
+
+    companion object {
+        private val TAG = logTag("Settings", "Index", "VM")
+    }
+}

--- a/app/src/main/java/eu/darken/myperm/settings/ui/support/SupportScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/settings/ui/support/SupportScreen.kt
@@ -7,28 +7,48 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.twotone.BugReport
+import androidx.compose.material.icons.twotone.ChatBubble
+import androidx.compose.material.icons.twotone.Description
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import eu.darken.myperm.R
 import eu.darken.myperm.common.compose.Preview2
 import eu.darken.myperm.common.compose.PreviewWrapper
+import eu.darken.myperm.common.debug.recording.core.RecorderModule
 import eu.darken.myperm.common.navigation.LocalNavigationController
+import eu.darken.myperm.common.settings.SettingsBaseItem
+import eu.darken.myperm.common.settings.SettingsCategoryHeader
+import eu.darken.myperm.common.settings.SettingsDivider
 
 @Composable
 fun SupportScreenHost() {
     val navCtrl = LocalNavigationController.current
+    val vm: SupportViewModel = hiltViewModel()
+    val recorderState by vm.recorderState.collectAsState(initial = RecorderModule.State(isAvailable = false))
 
     SupportScreen(
         onBack = { navCtrl?.up() },
+        onIssueTracker = { vm.openIssueTracker() },
+        onDiscord = { vm.openDiscord() },
+        isDebugLogAvailable = recorderState.isAvailable,
+        isRecording = recorderState.isRecording,
+        onStartDebugLog = { vm.startDebugLog() },
     )
 }
 
@@ -36,7 +56,14 @@ fun SupportScreenHost() {
 @Composable
 fun SupportScreen(
     onBack: () -> Unit,
+    onIssueTracker: () -> Unit,
+    onDiscord: () -> Unit,
+    isDebugLogAvailable: Boolean,
+    isRecording: Boolean,
+    onStartDebugLog: () -> Unit,
 ) {
+    var showDebugDialog by rememberSaveable { mutableStateOf(false) }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -53,20 +80,66 @@ fun SupportScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding)
-                .verticalScroll(rememberScrollState())
-                .padding(vertical = 8.dp),
+                .verticalScroll(rememberScrollState()),
         ) {
-            Text(
-                text = "Support information",
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.padding(16.dp),
+            SettingsBaseItem(
+                title = stringResource(R.string.issue_tracker_label),
+                subtitle = stringResource(R.string.issue_tracker_description),
+                icon = Icons.TwoTone.BugReport,
+                onClick = onIssueTracker,
             )
+            SettingsDivider()
+            SettingsBaseItem(
+                title = stringResource(R.string.discord_label),
+                subtitle = stringResource(R.string.discord_description),
+                icon = Icons.TwoTone.ChatBubble,
+                onClick = onDiscord,
+            )
+
+            if (isDebugLogAvailable) {
+                SettingsCategoryHeader(text = stringResource(R.string.settings_category_other_label))
+                SettingsBaseItem(
+                    title = stringResource(R.string.support_debuglog_label),
+                    subtitle = if (isRecording) "Recording..." else stringResource(R.string.support_debuglog_desc),
+                    icon = Icons.TwoTone.Description,
+                    enabled = !isRecording,
+                    onClick = { showDebugDialog = true },
+                )
+            }
         }
+    }
+
+    if (showDebugDialog) {
+        AlertDialog(
+            onDismissRequest = { showDebugDialog = false },
+            title = { Text(text = stringResource(R.string.support_debuglog_label)) },
+            text = { Text(text = stringResource(R.string.settings_debuglog_explanation)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    showDebugDialog = false
+                    onStartDebugLog()
+                }) {
+                    Text(text = stringResource(android.R.string.ok))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDebugDialog = false }) {
+                    Text(text = stringResource(android.R.string.cancel))
+                }
+            },
+        )
     }
 }
 
 @Preview2
 @Composable
 private fun SupportScreenPreview() = PreviewWrapper {
-    SupportScreen(onBack = {})
+    SupportScreen(
+        onBack = {},
+        onIssueTracker = {},
+        onDiscord = {},
+        isDebugLogAvailable = true,
+        isRecording = false,
+        onStartDebugLog = {},
+    )
 }

--- a/app/src/main/java/eu/darken/myperm/settings/ui/support/SupportViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/settings/ui/support/SupportViewModel.kt
@@ -1,0 +1,36 @@
+package eu.darken.myperm.settings.ui.support
+
+import dagger.hilt.android.lifecycle.HiltViewModel
+import eu.darken.myperm.common.WebpageTool
+import eu.darken.myperm.common.coroutine.DispatcherProvider
+import eu.darken.myperm.common.debug.logging.logTag
+import eu.darken.myperm.common.debug.recording.core.RecorderModule
+import eu.darken.myperm.common.uix.ViewModel4
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+@HiltViewModel
+class SupportViewModel @Inject constructor(
+    dispatcherProvider: DispatcherProvider,
+    private val webpageTool: WebpageTool,
+    private val recorderModule: RecorderModule,
+) : ViewModel4(dispatcherProvider) {
+
+    val recorderState: Flow<RecorderModule.State> = recorderModule.state
+
+    fun openIssueTracker() {
+        webpageTool.open("https://github.com/d4rken-org/permission-pilot/issues")
+    }
+
+    fun openDiscord() {
+        webpageTool.open("https://discord.gg/7gGWxfM5yv")
+    }
+
+    fun startDebugLog() = launch {
+        recorderModule.startRecorder()
+    }
+
+    companion object {
+        private val TAG = logTag("Settings", "Support", "VM")
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,6 +45,9 @@
     <string name="discord_description">A place to hang out in and ask questions.</string>
     <string name="issue_tracker_label">Issue tracker</string>
     <string name="issue_tracker_description">A public issue tracker for bug reports and feature requests.</string>
+
+    <string name="acks_maxpatchs_desc">Thanks for the lovely icons.</string>
+    <string name="acks_crowdin_desc">For supporting translation of open-source projects.</string>
     <string name="permissions_page_label">Permissions</string>
     <string name="apps_page_label">Apps</string>
     <string name="app_type_system_label">System App</string>


### PR DESCRIPTION
## Summary

- **Settings index**: Replace superfluous "General" entry with "Changelog" (opens GitHub releases), reorder entries to match old app layout (Changelog → Support → Acknowledgements → Privacy policy), wire privacy policy click handler via ViewModel
- **Support screen**: Replace empty stub with Issue tracker, Discord, and Debug log entries — includes two-tone icons, RecorderModule integration, and a confirmation dialog for debug log recording
- **Acknowledgements screen**: Replace empty stub with "Thank you" (Max Patchs, Crowdin) and "Licenses" (Material Design Icons, Lottie, Kotlin, Dagger, Android) sections with clickable entries that open URLs
- **ViewModels**: Create `SettingsIndexViewModel`, `SupportViewModel`, and `AcknowledgementsViewModel` extending `ViewModel4` for Compose-ready error handling and URL actions via `WebpageTool`
- **String resources**: Add `acks_maxpatchs_desc` and `acks_crowdin_desc` for localizable acknowledgement descriptions

All settings screens now match the old XML/Fragment-based app. Debug log section is hidden on gplay flavor (`NoopRecorderModule` returns `isAvailable = false`).
