### PR TITLE
Permissions: Redesign list with grant ratio bars and unified tag pills

### DIFF
--- a/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsScreen.kt
@@ -63,6 +63,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import eu.darken.myperm.R
 import eu.darken.myperm.apps.core.features.UsesPermission
 import eu.darken.myperm.common.compose.AppIcon
+import eu.darken.myperm.common.compose.Pill
 import eu.darken.myperm.common.compose.PermissionIcon
 import eu.darken.myperm.common.compose.LabeledOption
 import eu.darken.myperm.common.compose.MultiChoiceFilterDialog
@@ -592,17 +593,6 @@ private fun SectionHeader(title: String, count: Int? = null, onHelpClicked: (() 
     }
 }
 
-@Composable
-private fun PermTypeTag(text: String, containerColor: Color, contentColor: Color) {
-    Text(
-        text = text,
-        style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
-        color = contentColor,
-        modifier = Modifier
-            .background(containerColor, RoundedCornerShape(4.dp))
-            .padding(horizontal = 4.dp, vertical = 1.dp),
-    )
-}
 
 @Composable
 private fun StatusIcon(status: UsesPermission.Status) {
@@ -675,22 +665,25 @@ private fun PermissionRow(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 if (item.isRuntime) {
-                    PermTypeTag(
+                    Pill(
                         text = stringResource(R.string.apps_details_perm_tag_runtime),
-                        containerColor = MaterialTheme.colorScheme.primaryContainer,
-                        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                        compact = true,
                     )
                 } else if (item.isSpecialAccess) {
-                    PermTypeTag(
+                    Pill(
                         text = stringResource(R.string.apps_details_perm_tag_special),
-                        containerColor = MaterialTheme.colorScheme.errorContainer,
-                        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                        containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                        compact = true,
                     )
                 } else {
-                    PermTypeTag(
+                    Pill(
                         text = stringResource(R.string.apps_details_perm_tag_install),
                         containerColor = MaterialTheme.colorScheme.surfaceVariant,
                         contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        compact = true,
                     )
                 }
                 if (item.isDeclaredByApp) {
@@ -720,10 +713,11 @@ private fun PermissionHelpDialog(onDismiss: () -> Unit) {
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     verticalAlignment = Alignment.Top,
                 ) {
-                    PermTypeTag(
+                    Pill(
                         text = stringResource(R.string.apps_details_perm_tag_runtime),
-                        containerColor = MaterialTheme.colorScheme.primaryContainer,
-                        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                        compact = true,
                     )
                     Text(
                         text = stringResource(R.string.apps_details_perm_help_runtime),
@@ -734,10 +728,11 @@ private fun PermissionHelpDialog(onDismiss: () -> Unit) {
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     verticalAlignment = Alignment.Top,
                 ) {
-                    PermTypeTag(
+                    Pill(
                         text = stringResource(R.string.apps_details_perm_tag_special),
-                        containerColor = MaterialTheme.colorScheme.errorContainer,
-                        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                        containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                        compact = true,
                     )
                     Text(
                         text = stringResource(R.string.apps_details_perm_help_special),
@@ -748,10 +743,11 @@ private fun PermissionHelpDialog(onDismiss: () -> Unit) {
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     verticalAlignment = Alignment.Top,
                 ) {
-                    PermTypeTag(
+                    Pill(
                         text = stringResource(R.string.apps_details_perm_tag_install),
                         containerColor = MaterialTheme.colorScheme.surfaceVariant,
                         contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        compact = true,
                     )
                     Text(
                         text = stringResource(R.string.apps_details_perm_help_install),

--- a/app/src/main/java/eu/darken/myperm/common/compose/Pill.kt
+++ b/app/src/main/java/eu/darken/myperm/common/compose/Pill.kt
@@ -1,0 +1,87 @@
+package eu.darken.myperm.common.compose
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import eu.darken.myperm.R
+import eu.darken.myperm.permissions.core.features.Highlighted
+import eu.darken.myperm.permissions.core.features.InstallTimeGrant
+import eu.darken.myperm.permissions.core.features.ManifestDoc
+import eu.darken.myperm.permissions.core.features.NotNormalPerm
+import eu.darken.myperm.permissions.core.features.PermissionTag
+import eu.darken.myperm.permissions.core.features.RuntimeGrant
+import eu.darken.myperm.permissions.core.features.SpecialAccess
+
+@Composable
+fun Pill(
+    text: String,
+    containerColor: Color,
+    contentColor: Color,
+    modifier: Modifier = Modifier,
+    compact: Boolean = false,
+) {
+    if (compact) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
+            color = contentColor,
+            modifier = modifier
+                .background(containerColor, RoundedCornerShape(4.dp))
+                .padding(horizontal = 4.dp, vertical = 1.dp),
+        )
+    } else {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelSmall,
+            color = contentColor,
+            modifier = modifier
+                .background(containerColor, RoundedCornerShape(4.dp))
+                .padding(horizontal = 6.dp, vertical = 2.dp),
+        )
+    }
+}
+
+@Composable
+fun PermissionTagPill(tag: PermissionTag, compact: Boolean = false) {
+    val (text, containerColor, contentColor) = when (tag) {
+        is RuntimeGrant -> Triple(
+            stringResource(R.string.permissions_tag_runtime_label),
+            MaterialTheme.colorScheme.secondaryContainer,
+            MaterialTheme.colorScheme.onSecondaryContainer,
+        )
+        is SpecialAccess -> Triple(
+            stringResource(R.string.permissions_tag_special_access_label),
+            MaterialTheme.colorScheme.tertiaryContainer,
+            MaterialTheme.colorScheme.onTertiaryContainer,
+        )
+        is InstallTimeGrant -> Triple(
+            stringResource(R.string.permissions_tag_install_time_label),
+            MaterialTheme.colorScheme.primaryContainer,
+            MaterialTheme.colorScheme.onPrimaryContainer,
+        )
+        is ManifestDoc -> Triple(
+            stringResource(R.string.permissions_tag_documented_label),
+            MaterialTheme.colorScheme.surfaceVariant,
+            MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        is Highlighted -> Triple(
+            stringResource(R.string.permissions_tag_notable_label),
+            MaterialTheme.colorScheme.surfaceVariant,
+            MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        is NotNormalPerm -> Triple(
+            stringResource(R.string.permissions_tag_non_standard_label),
+            MaterialTheme.colorScheme.surfaceVariant,
+            MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+    Pill(text = text, containerColor = containerColor, contentColor = contentColor, compact = compact)
+}

--- a/app/src/main/java/eu/darken/myperm/permissions/ui/details/PermissionDetailsScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/details/PermissionDetailsScreen.kt
@@ -63,15 +63,10 @@ import eu.darken.myperm.common.compose.waitForState
 import eu.darken.myperm.common.error.ErrorEventHandler
 import eu.darken.myperm.common.navigation.Nav
 import eu.darken.myperm.common.navigation.NavigationEventHandler
+import eu.darken.myperm.common.compose.Pill
+import eu.darken.myperm.common.compose.PermissionTagPill
 import eu.darken.myperm.permissions.core.ProtectionFlag
 import eu.darken.myperm.permissions.core.ProtectionType
-import eu.darken.myperm.permissions.core.features.Highlighted
-import eu.darken.myperm.permissions.core.features.InstallTimeGrant
-import eu.darken.myperm.permissions.core.features.ManifestDoc
-import eu.darken.myperm.permissions.core.features.NotNormalPerm
-import eu.darken.myperm.permissions.core.features.PermissionTag
-import eu.darken.myperm.permissions.core.features.RuntimeGrant
-import eu.darken.myperm.permissions.core.features.SpecialAccess
 
 @Composable
 fun PermissionDetailsScreenHost(
@@ -396,23 +391,6 @@ fun PermissionDetailsScreen(
 }
 
 @Composable
-private fun Pill(
-    text: String,
-    containerColor: Color,
-    contentColor: Color,
-    modifier: Modifier = Modifier,
-) {
-    Text(
-        text = text,
-        style = MaterialTheme.typography.labelSmall,
-        color = contentColor,
-        modifier = modifier
-            .background(containerColor, RoundedCornerShape(4.dp))
-            .padding(horizontal = 6.dp, vertical = 2.dp),
-    )
-}
-
-@Composable
 private fun GrantRatioRow(label: String, granted: Int, total: Int) {
     Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
         Row(
@@ -458,43 +436,6 @@ private fun ProtectionFlagPill(flag: ProtectionFlag) {
         containerColor = MaterialTheme.colorScheme.surfaceVariant,
         contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
     )
-}
-
-@Composable
-private fun PermissionTagPill(tag: PermissionTag) {
-    val (text, containerColor, contentColor) = when (tag) {
-        is RuntimeGrant -> Triple(
-            stringResource(R.string.permissions_tag_runtime_label),
-            MaterialTheme.colorScheme.secondaryContainer,
-            MaterialTheme.colorScheme.onSecondaryContainer,
-        )
-        is SpecialAccess -> Triple(
-            stringResource(R.string.permissions_tag_special_access_label),
-            MaterialTheme.colorScheme.tertiaryContainer,
-            MaterialTheme.colorScheme.onTertiaryContainer,
-        )
-        is InstallTimeGrant -> Triple(
-            stringResource(R.string.permissions_tag_install_time_label),
-            MaterialTheme.colorScheme.primaryContainer,
-            MaterialTheme.colorScheme.onPrimaryContainer,
-        )
-        is ManifestDoc -> Triple(
-            stringResource(R.string.permissions_tag_documented_label),
-            MaterialTheme.colorScheme.surfaceVariant,
-            MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        is Highlighted -> Triple(
-            stringResource(R.string.permissions_tag_notable_label),
-            MaterialTheme.colorScheme.surfaceVariant,
-            MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        is NotNormalPerm -> Triple(
-            stringResource(R.string.permissions_tag_non_standard_label),
-            MaterialTheme.colorScheme.surfaceVariant,
-            MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-    }
-    Pill(text = text, containerColor = containerColor, contentColor = contentColor)
 }
 
 @Composable

--- a/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsPreviewData.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsPreviewData.kt
@@ -2,8 +2,11 @@ package eu.darken.myperm.permissions.ui.list
 
 import eu.darken.myperm.permissions.core.Permission
 import eu.darken.myperm.permissions.core.container.UnknownPermission
+import eu.darken.myperm.permissions.core.features.InstallTimeGrant
 import eu.darken.myperm.permissions.core.features.ManifestDoc
+import eu.darken.myperm.permissions.core.features.PermissionTag
 import eu.darken.myperm.permissions.core.features.RuntimeGrant
+import eu.darken.myperm.permissions.core.features.SpecialAccess
 import eu.darken.myperm.permissions.core.known.APermGrp
 
 internal object PermissionsPreviewData {
@@ -14,6 +17,7 @@ internal object PermissionsPreviewData {
         type: String = "declared",
         requestingCount: Int = 0,
         grantedCount: Int = 0,
+        tags: Set<PermissionTag> = emptySet(),
     ) = PermissionsViewModel.PermItem(
         id = Permission.Id(permName),
         label = label,
@@ -22,7 +26,7 @@ internal object PermissionsPreviewData {
         grantedCount = grantedCount,
         permission = UnknownPermission(
             id = Permission.Id(permName),
-            tags = if (type == "declared") setOf(RuntimeGrant, ManifestDoc) else emptySet(),
+            tags = tags,
             groupIds = emptySet(),
         ),
     )
@@ -39,10 +43,37 @@ internal object PermissionsPreviewData {
                 PermissionsViewModel.GroupItem(group = APermGrp.Calls, permCount = 8, isExpanded = false)
             ),
             PermissionsViewModel.ListItem.Group(
-                PermissionsViewModel.GroupItem(group = APermGrp.Camera, permCount = 1, isExpanded = true)
+                PermissionsViewModel.GroupItem(group = APermGrp.Camera, permCount = 3, isExpanded = true)
             ),
             PermissionsViewModel.ListItem.Perm(
-                permItem("android.permission.CAMERA", "take pictures and videos", "declared", requestingCount = 34, grantedCount = 15)
+                permItem(
+                    "android.permission.CAMERA",
+                    "Camera access",
+                    "declared",
+                    requestingCount = 45,
+                    grantedCount = 6,
+                    tags = setOf(RuntimeGrant, ManifestDoc),
+                )
+            ),
+            PermissionsViewModel.ListItem.Perm(
+                permItem(
+                    "android.permission.RECORD_VIDEO",
+                    null,
+                    "extra",
+                    requestingCount = 12,
+                    grantedCount = 3,
+                    tags = emptySet(),
+                )
+            ),
+            PermissionsViewModel.ListItem.Perm(
+                permItem(
+                    "android.permission.MANAGE_APP_OPS_MODES",
+                    "Special camera access",
+                    "declared",
+                    requestingCount = 8,
+                    grantedCount = 8,
+                    tags = setOf(SpecialAccess),
+                )
             ),
             PermissionsViewModel.ListItem.Group(
                 PermissionsViewModel.GroupItem(group = APermGrp.Connectivity, permCount = 3, isExpanded = false)
@@ -74,5 +105,13 @@ internal object PermissionsPreviewData {
         listData = emptyList(),
         countPermissions = 0,
         countGroups = 0,
+    )
+
+    fun activeFilterState() = PermissionsViewModel.State.Ready(
+        listData = emptyList(),
+        countPermissions = 0,
+        countGroups = 0,
+        filterOptions = PermsFilterOptions(keys = setOf(PermsFilterOptions.Filter.RUNTIME)),
+        sortOptions = PermsSortOptions(mainSort = PermsSortOptions.Sort.APPS_GRANTED),
     )
 }

--- a/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsScreen.kt
@@ -1,7 +1,9 @@
 package eu.darken.myperm.permissions.ui.list
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -15,29 +17,36 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.automirrored.filled.HelpOutline
 import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material.icons.filled.Sort
+import androidx.compose.material.icons.automirrored.filled.Sort
 import androidx.compose.material.icons.filled.UnfoldLess
 import androidx.compose.material.icons.filled.UnfoldMore
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -46,24 +55,34 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import eu.darken.myperm.R
-import eu.darken.myperm.common.compose.PermissionIcon
-import eu.darken.myperm.common.compose.icon
 import eu.darken.myperm.common.compose.LabeledOption
 import eu.darken.myperm.common.compose.MultiChoiceFilterDialog
+import eu.darken.myperm.common.compose.Pill
+import eu.darken.myperm.common.compose.PermissionIcon
+import eu.darken.myperm.common.compose.PermissionTagPill
 import eu.darken.myperm.common.compose.Preview2
 import eu.darken.myperm.common.compose.PreviewWrapper
 import eu.darken.myperm.common.compose.SingleChoiceSortDialog
+import eu.darken.myperm.common.compose.icon
 import eu.darken.myperm.common.compose.waitForState
 import eu.darken.myperm.common.error.ErrorEventHandler
 import eu.darken.myperm.common.navigation.NavigationEventHandler
 import eu.darken.myperm.permissions.core.PermissionGroup
+import eu.darken.myperm.permissions.core.features.InstallTimeGrant
+import eu.darken.myperm.permissions.core.features.PermissionTag
+import eu.darken.myperm.permissions.core.features.RuntimeGrant
+import eu.darken.myperm.permissions.core.features.SpecialAccess
 import eu.darken.myperm.permissions.core.known.APermGrp
 
 @Composable
@@ -137,6 +156,11 @@ fun PermissionsScreen(
     var searchQuery by rememberSaveable { mutableStateOf("") }
     var isSearchActive by rememberSaveable { mutableStateOf(false) }
     var showOverflowMenu by rememberSaveable { mutableStateOf(false) }
+    var showTagHelpDialog by rememberSaveable { mutableStateOf(false) }
+
+    if (showTagHelpDialog) {
+        PermissionTagHelpDialog(onDismiss = { showTagHelpDialog = false })
+    }
 
     Scaffold(
         topBar = {
@@ -145,9 +169,8 @@ fun PermissionsScreen(
                     Column {
                         Text(text = stringResource(R.string.permissions_page_label))
                         if (state is PermissionsViewModel.State.Ready) {
-                            val ready = state as PermissionsViewModel.State.Ready
                             Text(
-                                text = "${pluralStringResource(R.plurals.generic_x_groups_label, ready.countGroups, ready.countGroups)}, ${pluralStringResource(R.plurals.generic_x_items_label, ready.countPermissions, ready.countPermissions)}",
+                                text = "${pluralStringResource(R.plurals.generic_x_groups_label, state.countGroups, state.countGroups)}, ${pluralStringResource(R.plurals.generic_x_items_label, state.countPermissions, state.countPermissions)}",
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
@@ -155,13 +178,13 @@ fun PermissionsScreen(
                     }
                 },
                 actions = {
-                    IconButton(onClick = onFilterClicked) {
-                        Icon(Icons.Filled.FilterList, contentDescription = stringResource(R.string.general_filter_action))
-                    }
-                    IconButton(onClick = onSortClicked) {
-                        Icon(Icons.Filled.Sort, contentDescription = stringResource(R.string.general_sort_action))
-                    }
-                    IconButton(onClick = { isSearchActive = !isSearchActive }) {
+                    IconButton(onClick = {
+                        isSearchActive = !isSearchActive
+                        if (!isSearchActive) {
+                            searchQuery = ""
+                            onSearchChanged(null)
+                        }
+                    }) {
                         Icon(Icons.Filled.Search, contentDescription = stringResource(R.string.permissions_search_list_hint))
                     }
                     Box {
@@ -199,7 +222,46 @@ fun PermissionsScreen(
         }
     ) { innerPadding ->
         Column(modifier = Modifier.padding(innerPadding)) {
-            if (isSearchActive) {
+            // Filter/Sort chip row + help icon
+            if (state is PermissionsViewModel.State.Ready) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 12.dp, end = 4.dp, top = 4.dp, bottom = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .weight(1f)
+                            .horizontalScroll(rememberScrollState()),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        val hasActiveFilter = state.filterOptions.keys != PermsFilterOptions().keys
+                        FilterChip(
+                            selected = hasActiveFilter,
+                            onClick = onFilterClicked,
+                            label = { Text(stringResource(R.string.general_filter_action)) },
+                            leadingIcon = { Icon(Icons.Filled.FilterList, contentDescription = null, modifier = Modifier.size(18.dp)) },
+                        )
+                        FilterChip(
+                            selected = false,
+                            onClick = onSortClicked,
+                            label = { Text("${stringResource(R.string.general_sort_action)}: ${stringResource(state.sortOptions.mainSort.labelRes)}") },
+                            leadingIcon = { Icon(Icons.AutoMirrored.Filled.Sort, contentDescription = null, modifier = Modifier.size(18.dp)) },
+                        )
+                    }
+                    IconButton(onClick = { showTagHelpDialog = true }) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.HelpOutline,
+                            contentDescription = stringResource(R.string.label_help),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+
+            // Search bar
+            AnimatedVisibility(visible = isSearchActive) {
                 OutlinedTextField(
                     value = searchQuery,
                     onValueChange = {
@@ -225,20 +287,66 @@ fun PermissionsScreen(
                 }
 
                 is PermissionsViewModel.State.Ready -> {
-                    LazyColumn(modifier = Modifier.fillMaxSize()) {
-                        items(state.listData) { listItem ->
-                            when (listItem) {
-                                is PermissionsViewModel.ListItem.Group -> PermissionGroupHeader(
-                                    item = listItem.item,
-                                    onClick = { onGroupClicked(listItem.item.group.id) },
-                                )
+                    if (state.listData.isEmpty()) {
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Text(
+                                text = if (searchQuery.isNotBlank()) {
+                                    stringResource(R.string.permissions_list_empty_search_message)
+                                } else {
+                                    stringResource(R.string.permissions_list_empty_message)
+                                },
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(32.dp),
+                            )
+                        }
+                    } else {
+                        LazyColumn(modifier = Modifier.fillMaxSize()) {
+                            itemsIndexed(
+                                items = state.listData,
+                                key = { _, item ->
+                                    when (item) {
+                                        is PermissionsViewModel.ListItem.Group -> "group_${item.item.group.id.value}"
+                                        is PermissionsViewModel.ListItem.Perm -> "perm_${item.item.id.value}"
+                                    }
+                                }
+                            ) { index, listItem ->
+                                when (listItem) {
+                                    is PermissionsViewModel.ListItem.Group -> {
+                                        // Full-width divider between groups (not before first)
+                                        if (index > 0) {
+                                            val prevItem = state.listData[index - 1]
+                                            if (prevItem is PermissionsViewModel.ListItem.Group ||
+                                                prevItem is PermissionsViewModel.ListItem.Perm
+                                            ) {
+                                                HorizontalDivider()
+                                            }
+                                        }
+                                        PermissionGroupHeader(
+                                            item = listItem.item,
+                                            onClick = { onGroupClicked(listItem.item.group.id) },
+                                        )
+                                    }
 
-                                is PermissionsViewModel.ListItem.Perm -> PermissionListItem(
-                                    item = listItem.item,
-                                    onClick = { onPermClicked(listItem.item) },
-                                )
+                                    is PermissionsViewModel.ListItem.Perm -> {
+                                        // Inset divider between permission items
+                                        if (index > 0 && state.listData[index - 1] is PermissionsViewModel.ListItem.Perm) {
+                                            HorizontalDivider(
+                                                modifier = Modifier.padding(start = 48.dp),
+                                                thickness = 0.5.dp,
+                                                color = MaterialTheme.colorScheme.outlineVariant,
+                                            )
+                                        }
+                                        PermissionListItem(
+                                            item = listItem.item,
+                                            onClick = { onPermClicked(listItem.item) },
+                                        )
+                                    }
+                                }
                             }
-                            HorizontalDivider()
                         }
                     }
                 }
@@ -281,12 +389,28 @@ private fun PermissionGroupHeader(
                 tint = MaterialTheme.colorScheme.primary,
             )
             Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = stringResource(item.group.labelRes),
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.Medium,
-                    color = MaterialTheme.colorScheme.primary,
-                )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text(
+                        text = stringResource(item.group.labelRes),
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                    Text(
+                        text = item.permCount.toString(),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                        modifier = Modifier
+                            .background(
+                                MaterialTheme.colorScheme.secondaryContainer,
+                                RoundedCornerShape(10.dp),
+                            )
+                            .padding(horizontal = 8.dp, vertical = 2.dp),
+                    )
+                }
                 Text(
                     text = stringResource(item.group.descriptionRes),
                     style = MaterialTheme.typography.bodySmall,
@@ -294,15 +418,14 @@ private fun PermissionGroupHeader(
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
-                Text(
-                    text = pluralStringResource(R.plurals.generic_x_items_label, item.permCount, item.permCount),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
             }
             Icon(
                 imageVector = if (item.isExpanded) Icons.Filled.ExpandLess else Icons.Filled.ExpandMore,
-                contentDescription = null,
+                contentDescription = if (item.isExpanded) {
+                    stringResource(R.string.general_collapse_all_action)
+                } else {
+                    stringResource(R.string.general_expand_all_action)
+                },
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
@@ -317,39 +440,142 @@ private fun PermissionListItem(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .padding(start = 32.dp, end = 16.dp, top = 8.dp, bottom = 8.dp),
+            .height(IntrinsicSize.Min)
+            .clickable(onClick = onClick),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        PermissionIcon(
-            permissionId = item.permission.id,
-            modifier = Modifier.size(24.dp),
-            fallbackModel = item.permission,
+        // Left accent connector bar
+        Box(
+            modifier = Modifier
+                .width(4.dp)
+                .fillMaxHeight()
+                .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.15f))
         )
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = item.id.value,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
+        Row(
+            modifier = Modifier
+                .weight(1f)
+                .padding(start = 12.dp, end = 16.dp, top = 10.dp, bottom = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            PermissionIcon(
+                permissionId = item.permission.id,
+                modifier = Modifier.size(24.dp),
+                fallbackModel = item.permission,
             )
-            Text(
-                text = "Granted to ${item.grantedCount} out of ${item.requestingCount} apps.",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            val label = item.label
-            if (label != null && label.lowercase() != item.id.value.lowercase()) {
+            Column(modifier = Modifier.weight(1f)) {
+                // Label + type pill row
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    Text(
+                        text = item.label ?: item.id.value.substringAfterLast('.'),
+                        style = MaterialTheme.typography.bodyMedium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f),
+                    )
+                    val displayTag = pickDisplayTag(item.permission.tags)
+                    if (displayTag != null) {
+                        PermissionTagPill(tag = displayTag, compact = true)
+                    }
+                }
+                // Permission ID
                 Text(
-                    text = label,
-                    style = MaterialTheme.typography.bodyMedium,
+                    text = item.id.value,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
+                // Grant ratio row
+                val progress = if (item.requestingCount > 0) {
+                    (item.grantedCount.toFloat() / item.requestingCount).coerceIn(0f, 1f)
+                } else {
+                    0f
+                }
+                val ratioDescription = "${item.grantedCount} of ${item.requestingCount} granted"
+                Row(
+                    modifier = Modifier.semantics { contentDescription = ratioDescription },
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    LinearProgressIndicator(
+                        progress = { progress },
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(4.dp)
+                            .clip(RoundedCornerShape(2.dp)),
+                        color = MaterialTheme.colorScheme.primary,
+                        trackColor = MaterialTheme.colorScheme.surfaceVariant,
+                    )
+                    Text(
+                        text = "${item.grantedCount}/${item.requestingCount}",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
         }
+    }
+}
+
+private fun pickDisplayTag(tags: Collection<PermissionTag>): PermissionTag? = when {
+    tags.any { it is RuntimeGrant } -> RuntimeGrant
+    tags.any { it is SpecialAccess } -> SpecialAccess
+    tags.any { it is InstallTimeGrant } -> InstallTimeGrant
+    else -> null
+}
+
+@Composable
+private fun PermissionTagHelpDialog(onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.permissions_details_help_section_tags)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                TagHelpRow(
+                    pill = stringResource(R.string.permissions_tag_runtime_label),
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                    description = stringResource(R.string.permissions_details_help_tag_runtime),
+                )
+                TagHelpRow(
+                    pill = stringResource(R.string.permissions_tag_special_access_label),
+                    containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                    description = stringResource(R.string.permissions_details_help_tag_special_access),
+                )
+                TagHelpRow(
+                    pill = stringResource(R.string.permissions_tag_install_time_label),
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    description = stringResource(R.string.permissions_details_help_tag_install_time),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.general_done_action))
+            }
+        },
+    )
+}
+
+@Composable
+private fun TagHelpRow(
+    pill: String,
+    containerColor: Color,
+    contentColor: Color,
+    description: String,
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.Top,
+    ) {
+        Pill(text = pill, containerColor = containerColor, contentColor = contentColor)
+        Text(text = description, style = MaterialTheme.typography.bodySmall)
     }
 }
 
@@ -392,6 +618,23 @@ private fun PermissionsScreenEmptyPreview() = PreviewWrapper {
 private fun PermissionsScreenLoadingPreview() = PreviewWrapper {
     PermissionsScreen(
         state = PermissionsViewModel.State.Loading,
+        onSearchChanged = {},
+        onGroupClicked = {},
+        onPermClicked = {},
+        onExpandAll = {},
+        onCollapseAll = {},
+        onRefresh = {},
+        onSettings = {},
+        onFilterClicked = {},
+        onSortClicked = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun PermissionsScreenActiveFilterPreview() = PreviewWrapper {
+    PermissionsScreen(
+        state = PermissionsPreviewData.activeFilterState(),
         onSearchChanged = {},
         onGroupClicked = {},
         onPermClicked = {},

--- a/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsViewModel.kt
@@ -144,6 +144,7 @@ class PermissionsViewModel @Inject constructor(
                     GroupItem(group = APermGrp.Other, permCount = permItems.size, isExpanded = isExpanded)
                 )
             )
+            groupCount++
             permissionCount += permItems.size
             if (isExpanded) listItems.addAll(permItems.map { ListItem.Perm(it) })
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -330,6 +330,8 @@
     <string name="permission_group_camera_description">Camera related permissions.</string>
     <string name="permission_group_audio_label">Microphone</string>
     <string name="permission_group_audio_description">Microphone related permissions.</string>
+    <string name="permissions_list_empty_message">No permissions to show.</string>
+    <string name="permissions_list_empty_search_message">No permissions match your search.</string>
     <string name="permission_picture_in_picture_label">Picture in Picture</string>
     <string name="settings_page_label">Settings</string>
     <string name="overview_summary_title_label">Summary</string>


### PR DESCRIPTION
## Summary

- **Shared pill extraction**: New `common/compose/Pill.kt` with `Pill` and `PermissionTagPill` composables, replacing private duplicates in PermissionDetailsScreen and AppDetailsScreen. Unified color mapping across all screens (Runtime → secondaryContainer, Special → tertiaryContainer, Install-time → primaryContainer).
- **Permissions list redesign**: Label-first item layout with inline progress bars showing grant ratios, type tag pills pinned top-right, faded accent connector bars linking items to their parent group, and group count badge pills.
- **Toolbar simplification**: Replaced 4 action icons with a filter/sort chip row below the toolbar, plus a help icon explaining tag types. Search clears query on close.
- **Bug fix**: Other group was excluded from the subtitle group count in PermissionsViewModel.
- **Empty states**: Contextual messages for no-results vs no-search scenarios.

## Test plan

- [ ] Verify all previews render: PermissionsScreen (ready, empty, loading, active filter), PermissionDetailsScreen, AppDetailsScreen
- [ ] Check expanded group shows solid accent bar, child items show faded connector
- [ ] Check permission items show label → ID → ratio bar layout with tag pill top-right
- [ ] Tap filter chip opens filter dialog, sort chip opens sort dialog
- [ ] Tap help icon opens tag explanation dialog with 3 tag types
- [ ] Verify 0/0 ratio renders as empty progress bar, no tag shows no pill
- [ ] Verify Other group now counted in subtitle group count
- [ ] Check AppDetailsScreen pill colors match PermissionDetailsScreen (unified)
