### PR TITLE
General: Fix crash when resolving app labels on multi-user devices

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,6 @@
 	  "Bash(find:*)",
 	  "Bash(ls:*)",
 	  "Bash(grep:*)",
-	  "Bash(rg:*)",
 	  "Bash(git add:*)",
 	  "Bash(git log:*)",
 	  "Bash(git commit:*)",
@@ -15,5 +14,12 @@
 	  "WebSearch",
 	  "WebFetch(domain:developer.android.com)"
 	]
+  },
+  "enabledPlugins": {
+	"android-translation@claude-code-cafe": true,
+	"debugbadger@claude-code-cafe": true,
+	"jvm-tools@claude-code-cafe": true,
+	"frontend-design@claude-plugins-official": true,
+	"kotlin-lsp@claude-plugins-official": true
   }
 }

--- a/app/src/main/java/eu/darken/myperm/apps/core/container/PrimaryProfilePkg.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/container/PrimaryProfilePkg.kt
@@ -46,20 +46,35 @@ class PrimaryProfilePkg(
     override val id: Pkg.Id = Pkg.Id(packageInfo.packageName, userHandle)
 
     private var _label: String? = null
+    private var _resolvingLabel = false
     override fun getLabel(context: Context): String {
         _label?.let { return it }
-        val newLabel = context.packageManager.getLabel2(id)
-            ?: twins.firstNotNullOfOrNull { it.getLabel(context) }
-            ?: super.getLabel(context)
-            ?: id.pkgName
-        _label = newLabel
-        return newLabel
+        if (_resolvingLabel) return id.pkgName
+        _resolvingLabel = true
+        try {
+            val newLabel = context.packageManager.getLabel2(id)
+                ?: twins.firstNotNullOfOrNull { it.getLabel(context) }
+                ?: super.getLabel(context)
+                ?: id.pkgName
+            _label = newLabel
+            return newLabel
+        } finally {
+            _resolvingLabel = false
+        }
     }
 
-    override fun getIcon(context: Context): Drawable? =
-        context.packageManager.getIcon2(id)
-            ?: twins.firstNotNullOfOrNull { it.getIcon(context) }
-            ?: super.getIcon(context)
+    private var _resolvingIcon = false
+    override fun getIcon(context: Context): Drawable? {
+        if (_resolvingIcon) return null
+        _resolvingIcon = true
+        return try {
+            context.packageManager.getIcon2(id)
+                ?: twins.firstNotNullOfOrNull { it.getIcon(context) }
+                ?: super.getIcon(context)
+        } finally {
+            _resolvingIcon = false
+        }
+    }
 
     override val isSystemApp: Boolean = applicationInfo?.isSystemApp ?: true
 

--- a/app/src/main/java/eu/darken/myperm/apps/core/container/SecondaryProfilePkg.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/container/SecondaryProfilePkg.kt
@@ -43,36 +43,50 @@ class SecondaryProfilePkg(
 
 
     private var _label: String? = null
+    private var _resolvingLabel = false
     override fun getLabel(context: Context): String {
         _label?.let { return it }
-        val pm = context.packageManager
-        val newLabel = try {
-            val loadedLabel = launcherAppInfo.loadLabel(pm).toString()
-            pm.getUserBadgedLabel(loadedLabel, userHandle).toString()
-        } catch (_: Exception) {
-            null
-        }
-            ?: twins.firstNotNullOfOrNull { it.getLabel(context) }
-            ?: super.getLabel(context)
-            ?: id.pkgName
-        _label = newLabel
-        return newLabel
-    }
-
-    override fun getIcon(context: Context): Drawable? {
-        val pm = context.packageManager
-        return try {
-            val loadedIcon = launcherAppInfo.loadIcon(pm)
-            if (loadedIcon != null) {
-                pm.getUserBadgedIcon(loadedIcon, userHandle)
-            } else {
+        if (_resolvingLabel) return id.pkgName
+        _resolvingLabel = true
+        try {
+            val pm = context.packageManager
+            val newLabel = try {
+                val loadedLabel = launcherAppInfo.loadLabel(pm).toString()
+                pm.getUserBadgedLabel(loadedLabel, userHandle).toString()
+            } catch (_: Exception) {
                 null
             }
-        } catch (_: Exception) {
-            null
+                ?: twins.firstNotNullOfOrNull { it.getLabel(context) }
+                ?: super.getLabel(context)
+                ?: id.pkgName
+            _label = newLabel
+            return newLabel
+        } finally {
+            _resolvingLabel = false
         }
-            ?: twins.firstNotNullOfOrNull { it.getIcon(context) }
-            ?: super.getIcon(context)
+    }
+
+    private var _resolvingIcon = false
+    override fun getIcon(context: Context): Drawable? {
+        if (_resolvingIcon) return null
+        _resolvingIcon = true
+        return try {
+            val pm = context.packageManager
+            try {
+                val loadedIcon = launcherAppInfo.loadIcon(pm)
+                if (loadedIcon != null) {
+                    pm.getUserBadgedIcon(loadedIcon, userHandle)
+                } else {
+                    null
+                }
+            } catch (_: Exception) {
+                null
+            }
+                ?: twins.firstNotNullOfOrNull { it.getIcon(context) }
+                ?: super.getIcon(context)
+        } finally {
+            _resolvingIcon = false
+        }
     }
 
     override var siblings: Collection<Pkg> = emptyList()

--- a/app/src/main/java/eu/darken/myperm/apps/core/container/SecondaryUserPkg.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/container/SecondaryUserPkg.kt
@@ -39,20 +39,35 @@ class SecondaryUserPkg(
     override val id: Pkg.Id = Pkg.Id(packageInfo.packageName, userHandle)
 
     private var _label: String? = null
+    private var _resolvingLabel = false
     override fun getLabel(context: Context): String {
         _label?.let { return it }
-        val newLabel = context.packageManager.getLabel2(id)
-            ?: twins.firstNotNullOfOrNull { it.getLabel(context) }
-            ?: super.getLabel(context)
-            ?: id.pkgName
-        _label = newLabel
-        return newLabel
+        if (_resolvingLabel) return id.pkgName
+        _resolvingLabel = true
+        try {
+            val newLabel = context.packageManager.getLabel2(id)
+                ?: twins.firstNotNullOfOrNull { it.getLabel(context) }
+                ?: super.getLabel(context)
+                ?: id.pkgName
+            _label = newLabel
+            return newLabel
+        } finally {
+            _resolvingLabel = false
+        }
     }
 
-    override fun getIcon(context: Context): Drawable? =
-        context.packageManager.getIcon2(id)
-            ?: twins.firstNotNullOfOrNull { it.getIcon(context) }
-            ?: super.getIcon(context)
+    private var _resolvingIcon = false
+    override fun getIcon(context: Context): Drawable? {
+        if (_resolvingIcon) return null
+        _resolvingIcon = true
+        return try {
+            context.packageManager.getIcon2(id)
+                ?: twins.firstNotNullOfOrNull { it.getIcon(context) }
+                ?: super.getIcon(context)
+        } finally {
+            _resolvingIcon = false
+        }
+    }
 
     override var siblings: Collection<Pkg> = emptyList()
     override var twins: Collection<Installed> = emptyList()

--- a/app/src/main/java/eu/darken/myperm/apps/core/container/UninstalledDataPkg.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/container/UninstalledDataPkg.kt
@@ -28,20 +28,35 @@ class UninstalledDataPkg(
     override val id: Pkg.Id = Pkg.Id(packageInfo.packageName, userHandle)
 
     private var _label: String? = null
+    private var _resolvingLabel = false
     override fun getLabel(context: Context): String {
         _label?.let { return it }
-        val newLabel = context.packageManager.getLabel2(id)
-            ?: twins.firstNotNullOfOrNull { it.getLabel(context) }
-            ?: super.getLabel(context)
-            ?: id.pkgName
-        _label = newLabel
-        return newLabel
+        if (_resolvingLabel) return id.pkgName
+        _resolvingLabel = true
+        try {
+            val newLabel = context.packageManager.getLabel2(id)
+                ?: twins.firstNotNullOfOrNull { it.getLabel(context) }
+                ?: super.getLabel(context)
+                ?: id.pkgName
+            _label = newLabel
+            return newLabel
+        } finally {
+            _resolvingLabel = false
+        }
     }
 
-    override fun getIcon(context: Context): Drawable? =
-        context.packageManager.getIcon2(id)
-            ?: twins.firstNotNullOfOrNull { it.getIcon(context) }
-            ?: super.getIcon(context)
+    private var _resolvingIcon = false
+    override fun getIcon(context: Context): Drawable? {
+        if (_resolvingIcon) return null
+        _resolvingIcon = true
+        return try {
+            context.packageManager.getIcon2(id)
+                ?: twins.firstNotNullOfOrNull { it.getIcon(context) }
+                ?: super.getIcon(context)
+        } finally {
+            _resolvingIcon = false
+        }
+    }
 
     override var siblings: Collection<Pkg> = emptyList()
     override var twins: Collection<Installed> = emptyList()


### PR DESCRIPTION
## Summary

- Fix ANR/crash caused by infinite recursion between `getLabel()`/`getIcon()` in twin package containers
- When both the primary and secondary user package fail to resolve their label via PackageManager, they fall back to querying each other's twins, creating an infinite loop
- Add per-instance reentrancy guards to all four `BasePkg` subclasses (`PrimaryProfilePkg`, `SecondaryUserPkg`, `SecondaryProfilePkg`, `UninstalledDataPkg`)
- On re-entry, `getLabel()` returns the package name and `getIcon()` returns null instead of recursing
