### PR TITLE
General: Fix crash when checking special permissions on older devices

### DIFF
--- a/app/src/main/java/eu/darken/myperm/common/IPCFunnel.kt
+++ b/app/src/main/java/eu/darken/myperm/common/IPCFunnel.kt
@@ -146,7 +146,12 @@ class IPCFunnel @Inject constructor(
         }
 
         suspend fun checkOpNoThrow(op: String, uid: Int, packageName: String): Int = ipcFunnel.execute {
-            service.unsafeCheckOpNoThrow(op, uid, packageName)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                service.unsafeCheckOpNoThrow(op, uid, packageName)
+            } else {
+                @Suppress("DEPRECATION")
+                service.checkOpNoThrow(op, uid, packageName)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Fix NoSuchMethodError crash on devices running Android 10 (API 29) and below
- `AppOpsManager.unsafeCheckOpNoThrow()` requires API 30 but was called unconditionally
- Fall back to the deprecated `checkOpNoThrow()` on older devices (functionally identical)