### PR TITLE
Settings: Fix changelog link to point to website

### DIFF
--- a/app/src/main/java/eu/darken/myperm/settings/ui/index/SettingsIndexViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/settings/ui/index/SettingsIndexViewModel.kt
@@ -15,7 +15,7 @@ class SettingsIndexViewModel @Inject constructor(
 ) : ViewModel4(dispatcherProvider) {
 
     fun openChangelog() {
-        webpageTool.open("https://github.com/d4rken-org/permission-pilot/releases")
+        webpageTool.open("https://myperm.darken.eu/changelog")
     }
 
     fun openPrivacyPolicy() {


### PR DESCRIPTION
## Summary
- Changelog button in settings opened GitHub releases page instead of the project website changelog
- Updated URL from `github.com/.../releases` to `myperm.darken.eu/changelog`, matching the URL already used in fastlane store listings