### PR TITLE
Fix debug session manager bugs, add ViewModel nav scoping

### DIFF
--- a/app/src/main/java/eu/darken/myperm/common/debug/recording/core/DebugSessionManager.kt
+++ b/app/src/main/java/eu/darken/myperm/common/debug/recording/core/DebugSessionManager.kt
@@ -1,27 +1,34 @@
 package eu.darken.myperm.common.debug.recording.core
 
 import android.net.Uri
+import androidx.annotation.VisibleForTesting
 import eu.darken.myperm.common.coroutine.AppScope
 import eu.darken.myperm.common.coroutine.DispatcherProvider
 import eu.darken.myperm.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.myperm.common.debug.logging.Logging.Priority.INFO
 import eu.darken.myperm.common.debug.logging.Logging.Priority.WARN
 import eu.darken.myperm.common.debug.logging.log
 import eu.darken.myperm.common.debug.logging.logTag
 import eu.darken.myperm.common.flow.replayingShare
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.io.File
-import java.text.SimpleDateFormat
 import java.time.Instant
-import java.util.Locale
-import java.util.TimeZone
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -36,20 +43,63 @@ class DebugSessionManager @Inject constructor(
     private val fsMutex = Mutex()
     private val zippingIds = MutableStateFlow<Set<String>>(emptySet())
     private val failedZipIds = MutableStateFlow<Set<String>>(emptySet())
-    private val refreshTrigger = MutableStateFlow(0)
+    private val refreshTrigger = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    private val pendingAutoZips: MutableSet<String> = java.util.Collections.synchronizedSet(mutableSetOf())
 
-    val recorderState: Flow<RecorderModule.State> = recorderModule.state
+    val recorderState: Flow<RecorderModule.State> get() = recorderModule.state
 
     val sessions: Flow<List<DebugSession>> = combine(
         recorderModule.state,
         zippingIds,
         failedZipIds,
-        refreshTrigger,
+        refreshTrigger.onStart { emit(Unit) },
     ) { recorderState, zipping, failedZips, _ ->
         val activeDir = recorderModule.currentLogDir
         val scanned = scanSessions(recorderModule.getLogDirectories())
         applyOverlays(scanned, activeDir, recorderState, zipping, failedZips)
-    }.replayingShare(appScope + dispatcherProvider.IO)
+    }.replayingShare(appScope)
+
+    init {
+        sessions.onEach { allSessions ->
+            val orphans = findOrphans(allSessions, zippingIds.value)
+            for ((id, dir) in orphans) {
+                if (pendingAutoZips.add(id)) {
+                    log(TAG, INFO) { "Orphan session detected, auto-zipping: $id" }
+                    zipSessionAsync(id, dir)
+                }
+            }
+        }.launchIn(appScope)
+    }
+
+    private fun findOrphans(
+        sessions: List<DebugSession>,
+        zipping: Set<String>,
+    ): List<Pair<String, File>> {
+        return sessions.filterIsInstance<DebugSession.Ready>()
+            .filter { it.logDir != null && it.id !in zipping && it.id !in pendingAutoZips && it.id !in failedZipIds.value }
+            .filter { it.zipFile == null || it.compressedSize == 0L }
+            .map { it.id to it.logDir!! }
+    }
+
+    private fun zipSessionAsync(sessionId: String, logDir: File) {
+        zippingIds.update { it + sessionId }
+        appScope.launch(dispatcherProvider.IO) {
+            try {
+                fsMutex.withLock {
+                    debugLogZipper.zip(logDir)
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log(TAG, ERROR) { "Zipping failed for $sessionId: $e" }
+                failedZipIds.update { it + sessionId }
+            } finally {
+                pendingAutoZips.remove(sessionId)
+                zippingIds.update { it - sessionId }
+                refresh()
+            }
+        }
+    }
 
     private fun scanSessions(logDirs: List<File>): List<ScannedEntry> {
         return logDirs.flatMap { dir ->
@@ -58,7 +108,7 @@ class DebugSessionManager @Inject constructor(
             entries.mapNotNull { entry ->
                 when {
                     entry.isDirectory -> {
-                        val id = deriveSessionId(entry)
+                        val id = deriveId(entry)
                         val zipFile = File(entry.parentFile, "${entry.name}.zip")
                         ScannedEntry(
                             id = id,
@@ -72,7 +122,7 @@ class DebugSessionManager @Inject constructor(
                         val baseName = entry.nameWithoutExtension
                         val hasDir = File(entry.parentFile, baseName).isDirectory
                         if (hasDir) return@mapNotNull null // handled by dir entry
-                        val id = deriveSessionId(entry)
+                        val id = deriveId(entry)
                         ScannedEntry(
                             id = id,
                             displayName = baseName,
@@ -170,10 +220,9 @@ class DebugSessionManager @Inject constructor(
 
         // Dir exists
         if (logDir != null) {
-            val logFiles = logDir.listFiles()?.filter { it.isFile } ?: emptyList()
-            val hasContent = logFiles.any { it.extension == "log" && it.length() > 0 }
+            val coreLog = File(logDir, "core.log")
 
-            if (logFiles.isEmpty()) {
+            if (!coreLog.exists()) {
                 return DebugSession.Failed(
                     id = entry.id,
                     displayName = entry.displayName,
@@ -184,7 +233,7 @@ class DebugSessionManager @Inject constructor(
                 )
             }
 
-            if (!hasContent) {
+            if (coreLog.length() == 0L) {
                 return DebugSession.Failed(
                     id = entry.id,
                     displayName = entry.displayName,
@@ -202,7 +251,7 @@ class DebugSessionManager @Inject constructor(
                 diskSize = computeDiskSize(logDir, zipFile),
                 logDir = logDir,
                 zipFile = zipFile,
-                compressedSize = zipFile?.length() ?: -1L,
+                compressedSize = zipFile?.length() ?: 0L,
             )
         }
 
@@ -219,158 +268,185 @@ class DebugSessionManager @Inject constructor(
 
     suspend fun startRecording(): File = recorderModule.startRecorder()
 
-    suspend fun requestStopRecording(): RecorderModule.StopResult = recorderModule.requestStopRecorder()
+    suspend fun requestStopRecording(): RecorderModule.StopResult {
+        val result = recorderModule.requestStopRecorder()
+        if (result is RecorderModule.StopResult.Stopped) {
+            val sessionId = deriveId(result.logDir)
+            zipSessionAsync(sessionId, result.logDir)
+            return result.copy(sessionId = sessionId)
+        }
+        return result
+    }
 
-    suspend fun forceStopRecording(): File? = recorderModule.stopRecorder()
+    suspend fun forceStopRecording(): RecorderModule.StopResult.Stopped? {
+        val logDir = recorderModule.stopRecorder() ?: return null
+        val sessionId = deriveId(logDir)
+        zipSessionAsync(sessionId, logDir)
+        return RecorderModule.StopResult.Stopped(logDir, sessionId)
+    }
 
     fun refresh() {
-        refreshTrigger.value++
+        refreshTrigger.tryEmit(Unit)
     }
 
-    suspend fun zipSession(sessionId: String) = withContext(dispatcherProvider.IO) {
-        val logDir = fsMutex.withLock {
-            findSessionLogDir(sessionId)
-        }
-        if (logDir == null) {
-            log(TAG, WARN) { "zipSession($sessionId): logDir not found" }
-            return@withContext
-        }
+    private fun deriveId(file: File): String = deriveSessionId(
+        file, recorderModule.externalLogDir, recorderModule.cacheLogDir
+    )
 
-        zippingIds.value = zippingIds.value + sessionId
+    private fun activeSessionId(): String? = recorderModule.currentLogDir?.let { deriveId(it) }
 
-        try {
-            debugLogZipper.zip(logDir)
-            failedZipIds.value = failedZipIds.value - sessionId
-        } catch (e: Exception) {
-            log(TAG, ERROR) { "zipSession($sessionId) failed: $e" }
-            failedZipIds.value = failedZipIds.value + sessionId
-        } finally {
-            zippingIds.value = zippingIds.value - sessionId
-        }
-    }
+    suspend fun zipSession(sessionId: String): File = fsMutex.withLock {
+        require(activeSessionId() != sessionId) { "Cannot zip an active recording session" }
 
-    suspend fun getZipUri(sessionId: String): Uri? = withContext(dispatcherProvider.IO) {
-        fsMutex.withLock {
-            val logDir = findSessionLogDir(sessionId)
-            val zipFile = if (logDir != null) {
-                val existing = File(logDir.parentFile, "${logDir.name}.zip")
-                if (existing.exists() && existing.length() > 0) {
-                    existing
-                } else {
-                    try {
-                        debugLogZipper.zip(logDir)
-                    } catch (e: Exception) {
-                        log(TAG, ERROR) { "getZipUri($sessionId) zip failed: $e" }
-                        null
-                    }
-                }
-            } else {
-                findSessionZipFile(sessionId)
+        val (dir, existingZip) = findSessionFiles(sessionId)
+
+        if (existingZip != null && existingZip.length() > 0) {
+            if (dir == null || existingZip.lastModified() >= dir.lastModified()) {
+                return@withLock existingZip
             }
+        }
 
-            zipFile?.let { debugLogZipper.getUriForZip(it) }
+        requireNotNull(dir) { "No log directory found for session $sessionId" }
+        withContext(dispatcherProvider.IO) {
+            debugLogZipper.zip(dir)
         }
     }
 
-    suspend fun deleteSession(sessionId: String) = withContext(dispatcherProvider.IO) {
-        fsMutex.withLock {
-            // Don't delete active recording
-            if (recorderModule.currentLogDir?.let { deriveSessionId(it) } == sessionId) {
-                log(TAG, WARN) { "deleteSession($sessionId): is active recording, skipping" }
-                return@withContext
-            }
-            // Don't delete currently zipping
-            if (sessionId in zippingIds.value) {
-                log(TAG, WARN) { "deleteSession($sessionId): currently zipping, skipping" }
-                return@withContext
-            }
-            val dirs = recorderModule.getLogDirectories()
-            for (dir in dirs) {
-                if (!dir.exists()) continue
-                dir.listFiles()?.forEach { entry ->
-                    if (deriveSessionId(entry) == sessionId) {
-                        if (entry.isDirectory) {
-                            entry.deleteRecursively()
-                            val zip = File(entry.parentFile, "${entry.name}.zip")
-                            if (zip.exists()) zip.delete()
-                        } else {
-                            entry.delete()
-                        }
-                    }
-                }
-            }
-            failedZipIds.value = failedZipIds.value - sessionId
+    suspend fun getZipUri(sessionId: String): Uri {
+        val zipFile = zipSession(sessionId)
+        return debugLogZipper.getUriForZip(zipFile)
+    }
+
+    suspend fun deleteSession(sessionId: String) = fsMutex.withLock {
+        if (activeSessionId() == sessionId) {
+            log(TAG, WARN) { "deleteSession($sessionId): is active recording, skipping" }
+            return@withLock
         }
+        if (sessionId in zippingIds.value) {
+            log(TAG, WARN) { "deleteSession($sessionId): currently zipping, skipping" }
+            return@withLock
+        }
+
+        withContext(dispatcherProvider.IO) {
+            val (dir, zip) = findSessionFiles(sessionId)
+            if (dir?.deleteRecursively() == false) {
+                log(TAG, WARN) { "Failed to fully delete session dir: ${dir.path}" }
+            }
+            if (zip?.delete() == false) {
+                log(TAG, WARN) { "Failed to delete session zip: ${zip.path}" }
+            }
+        }
+        failedZipIds.update { it - sessionId }
+
+        log(TAG) { "Deleted session: $sessionId" }
         refresh()
     }
 
-    suspend fun deleteAllSessions() = withContext(dispatcherProvider.IO) {
-        val activeId = recorderModule.currentLogDir?.let { deriveSessionId(it) }
+    suspend fun deleteAllSessions() = fsMutex.withLock {
+        val activeDir = recorderModule.currentLogDir
         val currentlyZipping = zippingIds.value
-
-        fsMutex.withLock {
-            recorderModule.getLogDirectories().forEach { dir ->
-                if (!dir.exists()) return@forEach
-                dir.listFiles()?.forEach { entry ->
-                    val id = deriveSessionId(entry)
-                    if (id == activeId || id in currentlyZipping) {
-                        log(TAG) { "deleteAllSessions: skipping $id" }
-                        return@forEach
+        withContext(dispatcherProvider.IO) {
+            for (dir in recorderModule.getLogDirectories()) {
+                if (!dir.exists()) continue
+                for (entry in dir.listFiles() ?: emptyArray()) {
+                    if (entry == activeDir) {
+                        log(TAG) { "Skipping active session dir: $entry" }
+                        continue
                     }
-                    if (entry.isDirectory) {
-                        entry.deleteRecursively()
-                        val zip = File(entry.parentFile, "${entry.name}.zip")
-                        if (zip.exists()) zip.delete()
-                    } else {
-                        entry.delete()
+                    val entryId = deriveId(entry)
+                    if (entryId in currentlyZipping) {
+                        log(TAG) { "Skipping zipping session: $entry" }
+                        continue
                     }
+                    val deleted = if (entry.isDirectory) entry.deleteRecursively() else entry.delete()
+                    if (!deleted) log(TAG, WARN) { "Failed to delete: ${entry.path}" }
                 }
             }
-            failedZipIds.value = emptySet()
         }
-        log(TAG) { "All stored sessions deleted" }
+        failedZipIds.update { emptySet() }
+        pendingAutoZips.clear()
+        log(TAG) { "All stored logs deleted" }
         refresh()
     }
 
-    private fun findSessionLogDir(sessionId: String): File? {
-        return recorderModule.getLogDirectories().firstNotNullOfOrNull { dir ->
-            if (!dir.exists()) return@firstNotNullOfOrNull null
-            dir.listFiles()?.firstOrNull { it.isDirectory && deriveSessionId(it) == sessionId }
-        }
-    }
+    private fun findSessionFiles(sessionId: String): Pair<File?, File?> {
+        val (prefix, baseName) = parseSessionId(sessionId)
 
-    private fun findSessionZipFile(sessionId: String): File? {
-        return recorderModule.getLogDirectories().firstNotNullOfOrNull { dir ->
-            if (!dir.exists()) return@firstNotNullOfOrNull null
-            dir.listFiles()?.firstOrNull {
-                it.isFile && it.extension == "zip" && deriveSessionId(it) == sessionId
+        val targetDir = when (prefix) {
+            "ext" -> recorderModule.externalLogDir
+            "cache" -> recorderModule.cacheLogDir
+            else -> null
+        }
+        val allLogDirs = recorderModule.getLogDirectories()
+        val searchDirs = if (targetDir != null) {
+            listOf(targetDir) + allLogDirs.filter { it.absolutePath != targetDir.absolutePath }
+        } else {
+            allLogDirs
+        }
+
+        for (logParent in searchDirs) {
+            if (!logParent.exists()) continue
+            val dir = File(logParent, baseName)
+            val zip = File(logParent, "$baseName.zip")
+            val dirExists = dir.exists() && dir.isDirectory
+            val zipExists = zip.exists() && zip.isFile
+            if (dirExists || zipExists) {
+                return Pair(if (dirExists) dir else null, if (zipExists) zip else null)
             }
         }
+        return Pair(null, null)
     }
 
     companion object {
-        private val TAG = logTag("Debug", "Log", "SessionManager")
+        private val TAG = logTag("Debug", "Log", "Session", "Manager")
 
-        fun deriveSessionId(file: File): String {
-            val name = if (file.extension == "zip") file.nameWithoutExtension else file.name
-            return name
+        private val TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'")
+            .withZone(ZoneOffset.UTC)
+
+        private val TIMESTAMP_REGEX = Regex("(\\d{8}T\\d{6}Z)")
+
+        @VisibleForTesting
+        internal fun deriveBaseName(file: File): String {
+            return if (file.extension == "zip") file.nameWithoutExtension else file.name
         }
 
-        fun parseCreatedAt(name: String): Instant {
-            // Try to parse UTC timestamp from dir name: myperm_VERSION_yyyyMMddTHHmmssZ_INSTALLID
-            val parts = name.split("_")
-            if (parts.size >= 3) {
-                val timestampPart = parts[2]
+        @VisibleForTesting
+        internal fun deriveSessionId(file: File, externalLogDir: File?, cacheLogDir: File): String {
+            val baseName = deriveBaseName(file)
+            val parent = file.parentFile ?: return baseName
+            val parentPath = parent.absolutePath
+            if (externalLogDir != null && externalLogDir.absolutePath == parentPath) return "ext:$baseName"
+            if (cacheLogDir.absolutePath == parentPath) return "cache:$baseName"
+            return baseName
+        }
+
+        @VisibleForTesting
+        internal fun parseSessionId(sessionId: String): Pair<String?, String> {
+            val colonIdx = sessionId.indexOf(':')
+            return if (colonIdx >= 0) {
+                sessionId.substring(0, colonIdx) to sessionId.substring(colonIdx + 1)
+            } else {
+                null to sessionId
+            }
+        }
+
+        @VisibleForTesting
+        internal fun parseCreatedAt(name: String): Instant {
+            // Find timestamp via regex to handle version names with underscores
+            val match = TIMESTAMP_REGEX.find(name)
+            if (match != null) {
                 try {
-                    val sdf = SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'", Locale.US)
-                    sdf.timeZone = TimeZone.getTimeZone("UTC")
-                    return sdf.parse(timestampPart)?.toInstant() ?: Instant.EPOCH
+                    return TIMESTAMP_FORMAT.parse(match.groupValues[1], Instant::from)
                 } catch (_: Exception) {
                     // Fall through
                 }
-                // Legacy: millis-based timestamp
+            }
+
+            // Legacy: millis-based timestamp in third segment
+            val parts = name.split("_")
+            if (parts.size >= 3) {
                 try {
-                    return Instant.ofEpochMilli(timestampPart.toLong())
+                    return Instant.ofEpochMilli(parts[2].toLong())
                 } catch (_: Exception) {
                     // Fall through
                 }
@@ -378,6 +454,7 @@ class DebugSessionManager @Inject constructor(
             return Instant.EPOCH
         }
 
+        @VisibleForTesting
         internal fun computeDiskSize(logDir: File?, zipFile: File?): Long {
             var size = 0L
             logDir?.let { dir ->

--- a/app/src/main/java/eu/darken/myperm/common/debug/recording/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/myperm/common/debug/recording/core/RecorderModule.kt
@@ -55,7 +55,12 @@ class RecorderModule @Inject constructor(
 
     private val internalState = DynamicStateFlow(TAG, appScope + dispatcherProvider.IO) {
         val triggerFileExists = triggerFile.exists()
-        State(shouldRecord = triggerFileExists)
+        val persistedInfo = if (triggerFileExists) readTriggerFile() else null
+        State(
+            shouldRecord = triggerFileExists,
+            persistedLogDir = persistedInfo?.logDir,
+            recordingStartedAt = persistedInfo?.startedAt ?: 0L,
+        )
     }
     val state: Flow<State> = internalState.flow
 
@@ -68,17 +73,19 @@ class RecorderModule @Inject constructor(
 
                 internalState.updateBlocking {
                     if (shouldRecord && !isRecording) {
-                        val existingDir = findExistingSessionDir(getLogDirectories())
-                        val sessionDir = existingDir ?: createSessionDir()
-
-                        if (existingDir != null) {
-                            log(TAG, INFO) { "Resuming recording in existing session: ${existingDir.name}" }
+                        val resumed = persistedLogDir?.takeIf { it.exists() && it.isDirectory }
+                        val sessionDir = resumed ?: createSessionDir()
+                        val startTime = if (resumed != null) {
+                            log(TAG, INFO) { "Resuming recording in existing session: ${resumed.name}" }
+                            recordingStartedAt
+                        } else {
+                            System.currentTimeMillis()
                         }
 
                         val logFile = File(sessionDir, "core.log")
                         val newRecorder = Recorder()
                         newRecorder.start(logFile)
-                        triggerFile.createNewFile()
+                        writeTriggerFile(sessionDir, startTime)
 
                         log(TAG, INFO) { "Build.Fingerprint: ${Build.FINGERPRINT}" }
                         log(TAG, INFO) { "BuildConfig.Versions: ${BuildConfigWrap.VERSION_DESCRIPTION}" }
@@ -87,11 +94,8 @@ class RecorderModule @Inject constructor(
 
                         copy(
                             recorder = newRecorder,
-                            recordingStartedAt = if (existingDir != null) {
-                                existingDir.lastModified()
-                            } else {
-                                System.currentTimeMillis()
-                            },
+                            persistedLogDir = null,
+                            recordingStartedAt = startTime,
                             logDir = sessionDir,
                         )
                     } else if (!shouldRecord && isRecording) {
@@ -105,6 +109,7 @@ class RecorderModule @Inject constructor(
 
                         copy(
                             recorder = null,
+                            persistedLogDir = null,
                             recordingStartedAt = 0L,
                             logDir = null,
                         )
@@ -147,14 +152,15 @@ class RecorderModule @Inject constructor(
         return sessionDir
     }
 
-    internal fun getLogDirectories(): List<File> = listOfNotNull(
-        try {
-            context.getExternalFilesDir(null)?.let { File(it, "debug/logs") }
-        } catch (e: Exception) {
-            null
-        },
-        File(context.cacheDir, "debug/logs"),
-    )
+    internal val externalLogDir: File? = try {
+        context.getExternalFilesDir(null)?.let { File(it, "debug/logs") }
+    } catch (e: Exception) {
+        null
+    }
+
+    internal val cacheLogDir: File = File(context.cacheDir, "debug/logs")
+
+    internal fun getLogDirectories(): List<File> = listOfNotNull(externalLogDir, cacheLogDir)
 
     suspend fun startRecorder(): File {
         internalState.updateBlocking {
@@ -177,7 +183,7 @@ class RecorderModule @Inject constructor(
         if (duration < MIN_RECORDING_MS) return StopResult.TooShort
 
         val logDir = stopRecorder() ?: return StopResult.NotRecording
-        val sessionId = DebugSessionManager.deriveSessionId(logDir)
+        val sessionId = DebugSessionManager.deriveBaseName(logDir)
         return StopResult.Stopped(logDir, sessionId)
     }
 
@@ -195,9 +201,35 @@ class RecorderModule @Inject constructor(
         internal val recorder: Recorder? = null,
         val recordingStartedAt: Long = 0L,
         val logDir: File? = null,
+        internal val persistedLogDir: File? = null,
     ) {
         val isRecording: Boolean
             get() = recorder != null
+    }
+
+    data class TriggerInfo(val logDir: File, val startedAt: Long)
+
+    internal fun readTriggerFile(): TriggerInfo? {
+        return try {
+            val content = triggerFile.readText()
+            parseTriggerContent(content)
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Failed to read trigger file: $e" }
+            null
+        }
+    }
+
+    private fun writeTriggerFile(sessionDir: File, startTime: Long) {
+        try {
+            triggerFile.writeText("${sessionDir.absolutePath}\n$startTime")
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Failed to write trigger file metadata: $e" }
+            try {
+                triggerFile.createNewFile()
+            } catch (e2: Exception) {
+                log(TAG, ERROR) { "Failed to create trigger file: $e2" }
+            }
+        }
     }
 
     companion object {
@@ -206,16 +238,19 @@ class RecorderModule @Inject constructor(
         internal const val MIN_RECORDING_MS = 5_000L
 
         @VisibleForTesting
-        internal fun findExistingSessionDir(logDirectories: List<File>): File? {
-            for (parent in logDirectories) {
-                if (!parent.exists()) continue
-                val dirs = parent.listFiles { f -> f.isDirectory && f.name.startsWith("myperm_") }
-                    ?: continue
-                val mostRecent = dirs.maxByOrNull { it.lastModified() } ?: continue
-                val coreLog = File(mostRecent, "core.log")
-                if (coreLog.exists()) return mostRecent
-            }
-            return null
+        internal fun parseTriggerContent(content: String): TriggerInfo? {
+            if (content.isBlank()) return null
+            val lines = content.trim().lines()
+            if (lines.size != 2) return null
+
+            val dir = File(lines[0])
+            if (!dir.exists() || !dir.isDirectory) return null
+
+            val timestamp = lines[1].toLongOrNull() ?: return null
+            val now = System.currentTimeMillis()
+            if (timestamp < 1 || timestamp > now + 60_000L) return null
+
+            return TriggerInfo(logDir = dir, startedAt = timestamp)
         }
     }
 }

--- a/app/src/main/java/eu/darken/myperm/common/debug/recording/ui/RecorderActivityVM.kt
+++ b/app/src/main/java/eu/darken/myperm/common/debug/recording/ui/RecorderActivityVM.kt
@@ -41,6 +41,7 @@ class RecorderActivityVM @Inject constructor(
     data class State(
         val logDir: File? = null,
         val logEntries: List<LogEntry> = emptyList(),
+        val totalSize: Long = 0L,
         val compressedSize: Long = -1L,
         val recordingDurationSecs: Long = 0L,
         val isWorking: Boolean = true,
@@ -55,33 +56,42 @@ class RecorderActivityVM @Inject constructor(
     private val legacyPath: String? = handle.get<String>(RecorderActivity.RECORD_PATH)
 
     private val stater = DynamicStateFlow(TAG, vmScope + dispatcherProvider.IO) {
-        val resolved = resolveSession()
-        if (resolved == null) {
-            return@DynamicStateFlow State(logDir = null, isWorking = false)
+        val session = resolveSession()
+        val logDir = when (session) {
+            is DebugSession.Ready -> session.logDir
+            is DebugSession.Compressing -> session.path
+            is DebugSession.Failed -> session.path.takeIf { it.isDirectory }
+            is DebugSession.Recording -> session.path
+            null -> legacyPath?.let { File(it) }
         }
 
-        val logDir = resolved.logDir
-        val files = if (logDir != null) {
-            logDir.listFiles()?.filter { it.isFile }?.toList() ?: emptyList()
-        } else {
-            listOfNotNull(resolved.zipFile)
+        val isCompressing = session is DebugSession.Compressing
+
+        if (logDir == null || !logDir.exists()) {
+            return@DynamicStateFlow State(logDir = null, isWorking = isCompressing)
         }
+
+        val files = logDir.listFiles()?.toList() ?: emptyList()
         val entries = files.map { LogEntry(it, it.length()) }
+        val totalSize = entries.sumOf { it.size }
 
-        val durationSecs = if (logDir != null) {
-            val dirCreated = logDir.lastModified()
-            val latestFileModified = files.maxOfOrNull { it.lastModified() } ?: dirCreated
-            ((latestFileModified - dirCreated) / 1000).coerceAtLeast(0)
-        } else {
-            0L
+        val compressedSize = when (session) {
+            is DebugSession.Compressing -> -1L
+            is DebugSession.Ready -> session.compressedSize.takeIf { it > 0 } ?: -1L
+            else -> -1L
         }
+
+        val dirCreated = logDir.lastModified()
+        val latestFileModified = files.maxOfOrNull { it.lastModified() } ?: dirCreated
+        val durationSecs = ((latestFileModified - dirCreated) / 1000).coerceAtLeast(0)
 
         State(
             logDir = logDir,
             logEntries = entries,
-            compressedSize = resolved.compressedSize,
+            totalSize = totalSize,
+            compressedSize = compressedSize,
             recordingDurationSecs = durationSecs,
-            isWorking = resolved.compressedSize < 0L,
+            isWorking = isCompressing,
         )
     }
     val state = stater.flow
@@ -89,81 +99,50 @@ class RecorderActivityVM @Inject constructor(
     val events = SingleEventFlow<Event>()
 
     init {
-        // Watch for compression completion
         sessionManager.sessions
             .onEach { allSessions ->
                 val sid = sessionId ?: return@onEach
-                val session = allSessions.firstOrNull { it.id == sid }
+                val session = allSessions.firstOrNull { it.id == sid } ?: return@onEach
                 when (session) {
+                    is DebugSession.Compressing -> {
+                        stater.updateBlocking { copy(isWorking = true) }
+                    }
                     is DebugSession.Ready -> {
                         stater.updateBlocking {
+                            if (!isWorking) return@updateBlocking this
                             copy(
-                                compressedSize = session.compressedSize,
+                                compressedSize = session.compressedSize.takeIf { it > 0 } ?: -1L,
                                 isWorking = false,
                             )
-                        }
-                    }
-                    is DebugSession.Failed -> {
-                        stater.updateBlocking {
-                            copy(isWorking = false)
-                        }
-                    }
-                    is DebugSession.Compressing -> {
-                        stater.updateBlocking {
-                            copy(isWorking = true)
                         }
                     }
                     else -> {}
                 }
             }
             .launchIn(vmScope)
-
-        // Auto-zip if not yet zipped
-        if (sessionId != null) {
-            launch {
-                sessionManager.zipSession(sessionId)
-            }
-        }
     }
 
-    private suspend fun resolveSession(): DebugSession.Ready? {
+    private suspend fun resolveSession(): DebugSession? {
         if (sessionId != null) {
-            val sessions = sessionManager.sessions.first()
-            val session = sessions.firstOrNull { it.id == sessionId }
-            if (session is DebugSession.Ready) return session
-            // If not yet ready (e.g. compressing), build a placeholder from legacy path
-            if (legacyPath != null) {
-                val dir = File(legacyPath)
-                if (dir.exists()) {
-                    return DebugSession.Ready(
-                        id = sessionId,
-                        displayName = dir.name,
-                        createdAt = DebugSessionManager.parseCreatedAt(dir.name),
-                        diskSize = dir.walkTopDown().filter { it.isFile }.sumOf { it.length() },
-                        logDir = dir,
-                    )
-                }
-            }
+            val session = sessionManager.sessions.first().firstOrNull { it.id == sessionId }
+            if (session != null) return session
+            sessionManager.refresh()
+            return sessionManager.sessions.first().firstOrNull { it.id == sessionId }
         }
-        // Legacy path fallback
         if (legacyPath != null) {
-            val dir = File(legacyPath)
-            if (dir.exists()) {
-                val id = DebugSessionManager.deriveSessionId(dir)
-                return DebugSession.Ready(
-                    id = id,
-                    displayName = dir.name,
-                    createdAt = DebugSessionManager.parseCreatedAt(dir.name),
-                    diskSize = dir.walkTopDown().filter { it.isFile }.sumOf { it.length() },
-                    logDir = dir,
-                )
+            val file = File(legacyPath)
+            val baseName = DebugSessionManager.deriveBaseName(file)
+            sessionManager.refresh()
+            return sessionManager.sessions.first().firstOrNull {
+                val (_, sessionBase) = DebugSessionManager.parseSessionId(it.id)
+                sessionBase == baseName
             }
         }
         return null
     }
 
     fun share() = launch {
-        val sid = sessionId ?: legacyPath?.let { DebugSessionManager.deriveSessionId(File(it)) } ?: return@launch
+        val sid = sessionId ?: return@launch
 
         stater.updateBlocking { copy(isWorking = true) }
 
@@ -172,27 +151,24 @@ class RecorderActivityVM @Inject constructor(
                 sessionManager.getZipUri(sid)
             } catch (e: Exception) {
                 log(TAG, WARN) { "Failed to get zip URI for session $sid: $e" }
-                null
-            }
-            if (uri == null) {
-                log(TAG, WARN) { "Failed to get zip URI for session $sid" }
                 return@launch
             }
 
-            val currentState = stater.flow.first()
-            val dirName = currentState.logDir?.name ?: sid
+            val displayName = stater.flow.first().logDir?.name ?: sid
 
             val intent = Intent(Intent.ACTION_SEND).apply {
                 putExtra(Intent.EXTRA_STREAM, uri)
                 addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                 type = "application/zip"
                 addCategory(Intent.CATEGORY_DEFAULT)
-                putExtra(Intent.EXTRA_SUBJECT, context.getString(R.string.support_debuglog_share_subject, dirName))
+                putExtra(Intent.EXTRA_SUBJECT, context.getString(R.string.support_debuglog_share_subject, displayName))
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             }
 
             val chooserIntent = Intent.createChooser(intent, context.getString(R.string.support_debuglog_label))
             events.tryEmit(Event.ShareIntent(chooserIntent))
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Failed to share session $sid: $e" }
         } finally {
             stater.updateBlocking { copy(isWorking = false) }
         }
@@ -203,7 +179,7 @@ class RecorderActivityVM @Inject constructor(
     }
 
     fun discard() = launch {
-        val sid = sessionId ?: legacyPath?.let { DebugSessionManager.deriveSessionId(File(it)) } ?: return@launch
+        val sid = sessionId ?: return@launch
         sessionManager.deleteSession(sid)
         events.tryEmit(Event.Finish)
     }

--- a/app/src/main/java/eu/darken/myperm/main/ui/MainScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/main/ui/MainScreen.kt
@@ -22,7 +22,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
+import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import eu.darken.myperm.R
 import eu.darken.myperm.common.navigation.Nav
@@ -56,6 +58,10 @@ fun MainScreen(
                     activity?.finish()
                 }
             },
+            entryDecorators = listOf(
+                rememberSaveableStateHolderNavEntryDecorator(),
+                rememberViewModelStoreNavEntryDecorator(),
+            ),
             entryProvider = entryProvider {
                 navigationEntries.forEach { entry ->
                     entry.apply { setup() }

--- a/app/src/main/java/eu/darken/myperm/settings/ui/support/SupportViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/settings/ui/support/SupportViewModel.kt
@@ -113,10 +113,9 @@ class SupportViewModel @Inject constructor(
 
     fun forceStopDebugLog() = launch {
         log(TAG) { "forceStopDebugLog()" }
-        val logDir = debugSessionManager.forceStopRecording()
-        if (logDir != null) {
-            val sessionId = DebugSessionManager.deriveSessionId(logDir)
-            events.tryEmit(Event.OpenRecorderActivity(sessionId, logDir.path))
+        val result = debugSessionManager.forceStopRecording()
+        if (result != null) {
+            events.tryEmit(Event.OpenRecorderActivity(result.sessionId, result.logDir.path))
         }
     }
 

--- a/app/src/main/java/eu/darken/myperm/settings/ui/support/contact/ContactFormViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/settings/ui/support/contact/ContactFormViewModel.kt
@@ -152,7 +152,6 @@ class ContactFormViewModel @Inject constructor(
             is RecorderModule.StopResult.Stopped -> {
                 log(TAG) { "Recording stopped: ${result.sessionId}" }
                 autoSelectSessionId = result.sessionId
-                debugSessionManager.zipSession(result.sessionId)
             }
             is RecorderModule.StopResult.NotRecording -> {
                 log(TAG) { "stopRecording: not recording" }
@@ -162,11 +161,9 @@ class ContactFormViewModel @Inject constructor(
 
     fun forceStopRecording() = launch {
         log(TAG) { "forceStopRecording()" }
-        val logDir = debugSessionManager.forceStopRecording()
-        if (logDir != null) {
-            val sessionId = DebugSessionManager.deriveSessionId(logDir)
-            autoSelectSessionId = sessionId
-            debugSessionManager.zipSession(sessionId)
+        val result = debugSessionManager.forceStopRecording()
+        if (result != null) {
+            autoSelectSessionId = result.sessionId
         }
     }
 
@@ -191,15 +188,7 @@ class ContactFormViewModel @Inject constructor(
             val attachmentUri = if (currentState.isBug) {
                 currentState.selectedSessionId?.let { sessionId ->
                     try {
-                        val uri = debugSessionManager.getZipUri(sessionId)
-                        if (uri == null) {
-                            log(TAG) { "getZipUri returned null for session $sessionId" }
-                            events.tryEmit(
-                                Event.ShowSnackbar(context.getString(R.string.contact_debuglog_zip_error))
-                            )
-                            return@launch
-                        }
-                        uri
+                        debugSessionManager.getZipUri(sessionId)
                     } catch (e: Exception) {
                         log(TAG) { "Failed to prepare attachment: $e" }
                         events.tryEmit(

--- a/app/src/test/java/eu/darken/myperm/common/debug/recording/core/DebugSessionManagerTest.kt
+++ b/app/src/test/java/eu/darken/myperm/common/debug/recording/core/DebugSessionManagerTest.kt
@@ -1,7 +1,7 @@
 package eu.darken.myperm.common.debug.recording.core
 
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
@@ -12,77 +12,188 @@ class DebugSessionManagerTest {
     @TempDir
     lateinit var tempDir: File
 
-    @Test
-    fun `deriveSessionId returns dir name for directory`() {
-        val dir = File(tempDir, "myperm_1.0_20260101T120000Z_abc12345")
-        dir.mkdirs()
-        DebugSessionManager.deriveSessionId(dir) shouldBe "myperm_1.0_20260101T120000Z_abc12345"
+    @Nested
+    inner class DeriveBaseName {
+        @Test
+        fun `returns dir name for directory`() {
+            val dir = File(tempDir, "myperm_1.0_20260101T120000Z_abc12345")
+            dir.mkdirs()
+            DebugSessionManager.deriveBaseName(dir) shouldBe "myperm_1.0_20260101T120000Z_abc12345"
+        }
+
+        @Test
+        fun `strips zip extension`() {
+            val zip = File(tempDir, "myperm_1.0_20260101T120000Z_abc12345.zip")
+            zip.createNewFile()
+            DebugSessionManager.deriveBaseName(zip) shouldBe "myperm_1.0_20260101T120000Z_abc12345"
+        }
+
+        @Test
+        fun `dir and zip yield same base name`() {
+            val dir = File(tempDir, "myperm_1.0_20260101T120000Z_abc12345")
+            val zip = File(tempDir, "myperm_1.0_20260101T120000Z_abc12345.zip")
+            dir.mkdirs()
+            zip.createNewFile()
+            DebugSessionManager.deriveBaseName(dir) shouldBe DebugSessionManager.deriveBaseName(zip)
+        }
     }
 
-    @Test
-    fun `deriveSessionId strips zip extension`() {
-        val zip = File(tempDir, "myperm_1.0_20260101T120000Z_abc12345.zip")
-        zip.createNewFile()
-        DebugSessionManager.deriveSessionId(zip) shouldBe "myperm_1.0_20260101T120000Z_abc12345"
+    @Nested
+    inner class DeriveSessionId {
+        @Test
+        fun `adds ext prefix for external storage`() {
+            val extDir = File(tempDir, "ext/debug/logs").also { it.mkdirs() }
+            val cacheDir = File(tempDir, "cache/debug/logs").also { it.mkdirs() }
+            val session = File(extDir, "myperm_1.0_20260101T120000Z_abc12345").also { it.mkdirs() }
+
+            DebugSessionManager.deriveSessionId(session, extDir, cacheDir) shouldBe
+                    "ext:myperm_1.0_20260101T120000Z_abc12345"
+        }
+
+        @Test
+        fun `adds cache prefix for cache storage`() {
+            val extDir = File(tempDir, "ext/debug/logs").also { it.mkdirs() }
+            val cacheDir = File(tempDir, "cache/debug/logs").also { it.mkdirs() }
+            val session = File(cacheDir, "myperm_1.0_20260101T120000Z_abc12345").also { it.mkdirs() }
+
+            DebugSessionManager.deriveSessionId(session, extDir, cacheDir) shouldBe
+                    "cache:myperm_1.0_20260101T120000Z_abc12345"
+        }
+
+        @Test
+        fun `returns bare name for unknown storage location`() {
+            val extDir = File(tempDir, "ext/debug/logs").also { it.mkdirs() }
+            val cacheDir = File(tempDir, "cache/debug/logs").also { it.mkdirs() }
+            val otherDir = File(tempDir, "other/debug/logs").also { it.mkdirs() }
+            val session = File(otherDir, "myperm_1.0_20260101T120000Z_abc12345").also { it.mkdirs() }
+
+            DebugSessionManager.deriveSessionId(session, extDir, cacheDir) shouldBe
+                    "myperm_1.0_20260101T120000Z_abc12345"
+        }
+
+        @Test
+        fun `handles null external dir`() {
+            val cacheDir = File(tempDir, "cache/debug/logs").also { it.mkdirs() }
+            val session = File(cacheDir, "myperm_1.0_20260101T120000Z_abc12345").also { it.mkdirs() }
+
+            DebugSessionManager.deriveSessionId(session, null, cacheDir) shouldBe
+                    "cache:myperm_1.0_20260101T120000Z_abc12345"
+        }
+
+        @Test
+        fun `strips zip extension before prefixing`() {
+            val extDir = File(tempDir, "ext/debug/logs").also { it.mkdirs() }
+            val cacheDir = File(tempDir, "cache/debug/logs").also { it.mkdirs() }
+            val zip = File(extDir, "myperm_1.0_20260101T120000Z_abc12345.zip").also { it.createNewFile() }
+
+            DebugSessionManager.deriveSessionId(zip, extDir, cacheDir) shouldBe
+                    "ext:myperm_1.0_20260101T120000Z_abc12345"
+        }
+
+        @Test
+        fun `dir and zip in same storage yield same ID`() {
+            val extDir = File(tempDir, "ext/debug/logs").also { it.mkdirs() }
+            val cacheDir = File(tempDir, "cache/debug/logs").also { it.mkdirs() }
+            val dir = File(extDir, "myperm_1.0_20260101T120000Z_abc12345").also { it.mkdirs() }
+            val zip = File(extDir, "myperm_1.0_20260101T120000Z_abc12345.zip").also { it.createNewFile() }
+
+            DebugSessionManager.deriveSessionId(dir, extDir, cacheDir) shouldBe
+                    DebugSessionManager.deriveSessionId(zip, extDir, cacheDir)
+        }
+
+        @Test
+        fun `same name in different storage yields different IDs`() {
+            val extDir = File(tempDir, "ext/debug/logs").also { it.mkdirs() }
+            val cacheDir = File(tempDir, "cache/debug/logs").also { it.mkdirs() }
+            val extSession = File(extDir, "myperm_1.0_20260101T120000Z_abc12345").also { it.mkdirs() }
+            val cacheSession = File(cacheDir, "myperm_1.0_20260101T120000Z_abc12345").also { it.mkdirs() }
+
+            val extId = DebugSessionManager.deriveSessionId(extSession, extDir, cacheDir)
+            val cacheId = DebugSessionManager.deriveSessionId(cacheSession, extDir, cacheDir)
+            extId shouldBe "ext:myperm_1.0_20260101T120000Z_abc12345"
+            cacheId shouldBe "cache:myperm_1.0_20260101T120000Z_abc12345"
+        }
     }
 
-    @Test
-    fun `deriveSessionId roundtrip - dir and zip yield same ID`() {
-        val dir = File(tempDir, "myperm_1.0_20260101T120000Z_abc12345")
-        val zip = File(tempDir, "myperm_1.0_20260101T120000Z_abc12345.zip")
-        dir.mkdirs()
-        zip.createNewFile()
+    @Nested
+    inner class ParseSessionId {
+        @Test
+        fun `splits prefixed ID`() {
+            DebugSessionManager.parseSessionId("ext:session_name") shouldBe Pair("ext", "session_name")
+            DebugSessionManager.parseSessionId("cache:session_name") shouldBe Pair("cache", "session_name")
+        }
 
-        DebugSessionManager.deriveSessionId(dir) shouldBe DebugSessionManager.deriveSessionId(zip)
+        @Test
+        fun `returns null prefix for bare ID`() {
+            DebugSessionManager.parseSessionId("session_name") shouldBe Pair(null, "session_name")
+        }
+
+        @Test
+        fun `handles ID with multiple colons`() {
+            DebugSessionManager.parseSessionId("ext:name:with:colons") shouldBe Pair("ext", "name:with:colons")
+        }
     }
 
-    @Test
-    fun `parseCreatedAt parses UTC timestamp format`() {
-        val name = "myperm_1.0_20260309T143022Z_abc12345"
-        val instant = DebugSessionManager.parseCreatedAt(name)
-        instant shouldBe Instant.parse("2026-03-09T14:30:22Z")
+    @Nested
+    inner class ParseCreatedAt {
+        @Test
+        fun `parses UTC timestamp format`() {
+            val name = "myperm_1.0_20260309T143022Z_abc12345"
+            val instant = DebugSessionManager.parseCreatedAt(name)
+            instant shouldBe Instant.parse("2026-03-09T14:30:22Z")
+        }
+
+        @Test
+        fun `parses legacy millis timestamp`() {
+            val millis = 1709999999000L
+            val name = "myperm_1.0_${millis}_abc12345"
+            val instant = DebugSessionManager.parseCreatedAt(name)
+            instant shouldBe Instant.ofEpochMilli(millis)
+        }
+
+        @Test
+        fun `returns EPOCH for unparseable name`() {
+            val name = "unknown_format"
+            DebugSessionManager.parseCreatedAt(name) shouldBe Instant.EPOCH
+        }
+
+        @Test
+        fun `handles version name with underscores`() {
+            val name = "myperm_1.0.0_beta_20260309T143022Z_abc12345"
+            val instant = DebugSessionManager.parseCreatedAt(name)
+            instant shouldBe Instant.parse("2026-03-09T14:30:22Z")
+        }
     }
 
-    @Test
-    fun `parseCreatedAt parses legacy millis timestamp`() {
-        val millis = 1709999999000L
-        val name = "myperm_1.0_${millis}_abc12345"
-        val instant = DebugSessionManager.parseCreatedAt(name)
-        instant shouldBe Instant.ofEpochMilli(millis)
-    }
+    @Nested
+    inner class ComputeDiskSize {
+        @Test
+        fun `with dir and zip`() {
+            val dir = File(tempDir, "session").also { it.mkdirs() }
+            File(dir, "core.log").writeText("A".repeat(100))
+            val zip = File(tempDir, "session.zip").also { it.writeText("B".repeat(50)) }
 
-    @Test
-    fun `parseCreatedAt returns EPOCH for unparseable name`() {
-        val name = "unknown_format"
-        DebugSessionManager.parseCreatedAt(name) shouldBe Instant.EPOCH
-    }
+            DebugSessionManager.computeDiskSize(dir, zip) shouldBe 150L
+        }
 
-    @Test
-    fun `computeDiskSize with dir and zip`() {
-        val dir = File(tempDir, "session").also { it.mkdirs() }
-        File(dir, "core.log").writeText("A".repeat(100))
-        val zip = File(tempDir, "session.zip").also { it.writeText("B".repeat(50)) }
+        @Test
+        fun `with only dir`() {
+            val dir = File(tempDir, "session").also { it.mkdirs() }
+            File(dir, "core.log").writeText("A".repeat(100))
 
-        DebugSessionManager.computeDiskSize(dir, zip) shouldBe 150L
-    }
+            DebugSessionManager.computeDiskSize(dir, null) shouldBe 100L
+        }
 
-    @Test
-    fun `computeDiskSize with only dir`() {
-        val dir = File(tempDir, "session").also { it.mkdirs() }
-        File(dir, "core.log").writeText("A".repeat(100))
+        @Test
+        fun `with only zip`() {
+            val zip = File(tempDir, "session.zip").also { it.writeText("B".repeat(50)) }
 
-        DebugSessionManager.computeDiskSize(dir, null) shouldBe 100L
-    }
+            DebugSessionManager.computeDiskSize(null, zip) shouldBe 50L
+        }
 
-    @Test
-    fun `computeDiskSize with only zip`() {
-        val zip = File(tempDir, "session.zip").also { it.writeText("B".repeat(50)) }
-
-        DebugSessionManager.computeDiskSize(null, zip) shouldBe 50L
-    }
-
-    @Test
-    fun `computeDiskSize with null dir and null zip`() {
-        DebugSessionManager.computeDiskSize(null, null) shouldBe 0L
+        @Test
+        fun `with null dir and null zip`() {
+            DebugSessionManager.computeDiskSize(null, null) shouldBe 0L
+        }
     }
 }

--- a/app/src/test/java/eu/darken/myperm/common/debug/recording/core/RecorderModuleTest.kt
+++ b/app/src/test/java/eu/darken/myperm/common/debug/recording/core/RecorderModuleTest.kt
@@ -3,6 +3,7 @@ package eu.darken.myperm.common.debug.recording.core
 import android.content.Context
 import eu.darken.myperm.common.InstallId
 import eu.darken.myperm.common.coroutine.DispatcherProvider
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
@@ -93,88 +94,71 @@ class RecorderModuleTest {
     }
 
     @Nested
-    inner class FindExistingSessionDir {
+    inner class ParseTriggerContent {
         @Test
-        fun `returns null when no directories exist`(@TempDir tempDir: File) {
-            val logDir = File(tempDir, "debug/logs")
-            RecorderModule.findExistingSessionDir(listOf(logDir)) shouldBe null
+        fun `returns TriggerInfo for valid content`(@TempDir tempDir: File) {
+            val sessionDir = File(tempDir, "myperm_session").also { it.mkdirs() }
+            val startTime = System.currentTimeMillis() - 10_000L
+            val content = "${sessionDir.absolutePath}\n$startTime"
+
+            val result = RecorderModule.parseTriggerContent(content)
+
+            result shouldBe RecorderModule.TriggerInfo(logDir = sessionDir, startedAt = startTime)
         }
 
         @Test
-        fun `returns null when log directory is empty`(@TempDir tempDir: File) {
-            val logDir = File(tempDir, "debug/logs").also { it.mkdirs() }
-            RecorderModule.findExistingSessionDir(listOf(logDir)) shouldBe null
+        fun `returns null for empty content`() {
+            RecorderModule.parseTriggerContent("").shouldBeNull()
         }
 
         @Test
-        fun `returns null when session dir has no core log`(@TempDir tempDir: File) {
-            val logDir = File(tempDir, "debug/logs").also { it.mkdirs() }
-            File(logDir, "myperm_1.0_20260309T120000Z_abc12345").mkdirs()
-            RecorderModule.findExistingSessionDir(listOf(logDir)) shouldBe null
+        fun `returns null for blank content`() {
+            RecorderModule.parseTriggerContent("   ").shouldBeNull()
         }
 
         @Test
-        fun `returns null for non-myperm directories`(@TempDir tempDir: File) {
-            val logDir = File(tempDir, "debug/logs").also { it.mkdirs() }
-            val dir = File(logDir, "some_other_dir").also { it.mkdirs() }
-            File(dir, "core.log").createNewFile()
-            RecorderModule.findExistingSessionDir(listOf(logDir)) shouldBe null
+        fun `returns null when missing timestamp line`(@TempDir tempDir: File) {
+            val sessionDir = File(tempDir, "myperm_session").also { it.mkdirs() }
+            RecorderModule.parseTriggerContent(sessionDir.absolutePath).shouldBeNull()
         }
 
         @Test
-        fun `finds existing session with core log`(@TempDir tempDir: File) {
-            val logDir = File(tempDir, "debug/logs").also { it.mkdirs() }
-            val sessionDir = File(logDir, "myperm_1.0_20260309T120000Z_abc12345").also { it.mkdirs() }
-            File(sessionDir, "core.log").createNewFile()
-
-            RecorderModule.findExistingSessionDir(listOf(logDir)) shouldBe sessionDir
+        fun `returns null for invalid timestamp`(@TempDir tempDir: File) {
+            val sessionDir = File(tempDir, "myperm_session").also { it.mkdirs() }
+            RecorderModule.parseTriggerContent("${sessionDir.absolutePath}\nnotanumber").shouldBeNull()
         }
 
         @Test
-        fun `returns most recent session when multiple exist`(@TempDir tempDir: File) {
-            val logDir = File(tempDir, "debug/logs").also { it.mkdirs() }
-
-            val older = File(logDir, "myperm_1.0_20260308T100000Z_abc12345").also { it.mkdirs() }
-            File(older, "core.log").createNewFile()
-            older.setLastModified(1000L)
-
-            val newer = File(logDir, "myperm_1.0_20260309T120000Z_abc12345").also { it.mkdirs() }
-            File(newer, "core.log").createNewFile()
-            newer.setLastModified(2000L)
-
-            RecorderModule.findExistingSessionDir(listOf(logDir)) shouldBe newer
+        fun `returns null for future timestamp beyond tolerance`(@TempDir tempDir: File) {
+            val sessionDir = File(tempDir, "myperm_session").also { it.mkdirs() }
+            val futureTime = System.currentTimeMillis() + 120_000L
+            RecorderModule.parseTriggerContent("${sessionDir.absolutePath}\n$futureTime").shouldBeNull()
         }
 
         @Test
-        fun `returns null when most recent session has no core log`(@TempDir tempDir: File) {
-            val logDir = File(tempDir, "debug/logs").also { it.mkdirs() }
-
-            val withLog = File(logDir, "myperm_1.0_20260308T100000Z_abc12345").also { it.mkdirs() }
-            File(withLog, "core.log").createNewFile()
-            withLog.setLastModified(1000L)
-
-            val withoutLog = File(logDir, "myperm_1.0_20260309T120000Z_abc12345").also { it.mkdirs() }
-            withoutLog.setLastModified(2000L)
-
-            // Only checks the most recent dir - if it has no core.log, returns null
-            RecorderModule.findExistingSessionDir(listOf(logDir)) shouldBe null
+        fun `returns null for zero timestamp`(@TempDir tempDir: File) {
+            val sessionDir = File(tempDir, "myperm_session").also { it.mkdirs() }
+            RecorderModule.parseTriggerContent("${sessionDir.absolutePath}\n0").shouldBeNull()
         }
 
         @Test
-        fun `prefers first directory with a match`(@TempDir tempDir: File) {
-            val extDir = File(tempDir, "ext/debug/logs").also { it.mkdirs() }
-            val cacheDir = File(tempDir, "cache/debug/logs").also { it.mkdirs() }
+        fun `returns null for non-existent directory`() {
+            val content = "/non/existent/path\n${System.currentTimeMillis()}"
+            RecorderModule.parseTriggerContent(content).shouldBeNull()
+        }
 
-            val extSession = File(extDir, "myperm_1.0_20260309T120000Z_abc12345").also { it.mkdirs() }
-            File(extSession, "core.log").createNewFile()
-            extSession.setLastModified(1000L)
+        @Test
+        fun `returns null when path points to a file not directory`(@TempDir tempDir: File) {
+            val file = File(tempDir, "not_a_dir").also { it.createNewFile() }
+            val content = "${file.absolutePath}\n${System.currentTimeMillis()}"
+            RecorderModule.parseTriggerContent(content).shouldBeNull()
+        }
 
-            val cacheSession = File(cacheDir, "myperm_1.0_20260309T130000Z_abc12345").also { it.mkdirs() }
-            File(cacheSession, "core.log").createNewFile()
-            cacheSession.setLastModified(2000L)
-
-            // Returns from first directory that has a match (ext), not the globally most recent
-            RecorderModule.findExistingSessionDir(listOf(extDir, cacheDir)) shouldBe extSession
+        @Test
+        fun `returns null for extra lines`(@TempDir tempDir: File) {
+            val sessionDir = File(tempDir, "myperm_session").also { it.mkdirs() }
+            val content = "${sessionDir.absolutePath}\n${System.currentTimeMillis()}\nextra"
+            RecorderModule.parseTriggerContent(content).shouldBeNull()
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fix critical concurrency bugs in DebugSessionManager (CancellationException swallowing, non-atomic state mutations, zip/delete races)
- Add auto-zip for orphaned sessions and centralized post-stop zipping
- Add session ID storage prefix (ext:/cache:) for location disambiguation
- Wire up NavDisplay entryDecorators to scope ViewModels to nav entries instead of Activity, fixing stale state on re-navigation
- Consolidate zip logic, improve timestamp parsing with regex, update tests

## Code review fixes applied
C1-C4 (critical), H1-H7 (high), M1-M4 (medium) from debug recording system review

## Test plan
- [x] `./gradlew testFossDebugUnitTest` passes
- [x] `./gradlew assembleFossDebug` builds
- [ ] Manual: start recording -> stop -> auto-zip -> share -> delete
- [ ] Manual: process death during recording -> restart -> orphan recovery
- [ ] Manual: Contact Developer -> send -> confirm -> re-open -> fields empty