### PR TITLE
Add LEGACY_STORAGE permission detection via AppOps

### DIFF
--- a/app/src/main/java/eu/darken/myperm/apps/core/container/SecondaryProfilePkg.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/container/SecondaryProfilePkg.kt
@@ -163,7 +163,7 @@ suspend fun getSecondaryProfilePkgs(ipcFunnel: IPCFunnel): Collection<BasePkg> =
                 installerInfo = pkgInfo.getInstallerInfo(ipcFunnel),
                 launcherAppInfo = appInfo,
                 userHandle = userHandle,
-                extraPermissions = pkgInfo.determineSpecialPermissions(ipcFunnel),
+                extraPermissions = pkgInfo.determineSpecialPermissions(ipcFunnel, uidOverride = appInfo.uid),
                 specialPermissionStatuses = pkgInfo.getSpecialPermissionStatuses(ipcFunnel, uidOverride = appInfo.uid),
             ).also { log(AppRepo.TAG) { "PKG[profile=${userHandle}}: $it" } }
         }

--- a/app/src/main/java/eu/darken/myperm/apps/core/features/ExtraPermissionScanner.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/features/ExtraPermissionScanner.kt
@@ -16,7 +16,10 @@ import eu.darken.myperm.permissions.core.known.APerm
 
 private val TAG = logTag("ExtraPermissionScanner")
 
-suspend fun PackageInfo.determineSpecialPermissions(ipcFunnel: IPCFunnel): Collection<UsesPermission> {
+suspend fun PackageInfo.determineSpecialPermissions(
+    ipcFunnel: IPCFunnel,
+    uidOverride: Int? = null,
+): Collection<UsesPermission> {
     val permissions = mutableSetOf<UsesPermission>()
 
     val withActivities = try {
@@ -27,6 +30,28 @@ suspend fun PackageInfo.determineSpecialPermissions(ipcFunnel: IPCFunnel): Colle
 
     if (withActivities?.activities?.any { it.flags and 0x400000 != 0 } == true) {
         permissions.add(UsesPermission.Unknown(AExtraPerm.PICTURE_IN_PICTURE.id))
+    }
+
+    // Legacy Storage (API 29+): AppOps-based, not a manifest permission
+    if (hasApiLevel(Build.VERSION_CODES.Q)) {
+        val uid = uidOverride ?: applicationInfo?.uid
+        if (uid != null) {
+            try {
+                val result = ipcFunnel.appOpsManager.checkOpNoThrow("android:legacy_storage", uid, packageName)
+                val status = mapAppOpResult(result)
+                if (status.isGranted) {
+                    permissions.add(
+                        UsesPermission.WithState(
+                            id = AExtraPerm.LEGACY_STORAGE.id,
+                            flags = PackageInfo.REQUESTED_PERMISSION_GRANTED,
+                            overrideStatus = status,
+                        )
+                    )
+                }
+            } catch (e: Exception) {
+                log(TAG, WARN) { "Failed to check LEGACY_STORAGE for $packageName: ${e.asLog()}" }
+            }
+        }
     }
 
     return permissions

--- a/app/src/main/java/eu/darken/myperm/permissions/core/known/AExtraPerm.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/core/known/AExtraPerm.kt
@@ -26,6 +26,12 @@ sealed class AExtraPerm constructor(val id: Permission.Id) {
         override val tags = setOf(NotNormalPerm, SpecialAccess)
     }
 
+    object LEGACY_STORAGE : AExtraPerm("android:legacy_storage") {
+        override val labelRes: Int = R.string.permission_legacy_storage_label
+        override val descriptionRes: Int = R.string.permission_legacy_storage_description
+        override val groupIds: Set<PermissionGroup.Id> = grpIds(APermGrp.Files)
+        override val tags = setOf(NotNormalPerm, SpecialAccess)
+    }
 
     companion object {
         val values: List<AExtraPerm> by lazy {


### PR DESCRIPTION
## Summary
- Detects legacy external storage access on API 29+ via `AppOpsManager.checkOpNoThrow("android:legacy_storage", ...)`
- Only surfaces the permission for apps that actually have legacy storage granted (`MODE_ALLOWED`), avoiding noise for modern apps
- Adds `LEGACY_STORAGE` to `AExtraPerm` with label, description, and Files group
- Passes `uidOverride` to `determineSpecialPermissions()` for correct secondary profile handling

Closes #175

## Test plan
- [ ] Run `./gradlew testFossDebugUnitTest` — all tests pass
- [ ] Install on API 29+ device and verify only apps with actual legacy storage access show the permission
- [ ] Verify the permission appears in the Permissions list under the Files group
- [ ] Verify the watcher does not flag all apps as having gained a new permission