### PR TITLE
Add permission gain tracking and refresh FAB to watcher

### DIFF
--- a/app/src/main/java/eu/darken/myperm/main/ui/MainScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/main/ui/MainScreen.kt
@@ -1,9 +1,11 @@
 package eu.darken.myperm.main.ui
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Apps
 import eu.darken.myperm.common.compose.LucideRadar
@@ -16,11 +18,9 @@ import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
@@ -45,8 +45,11 @@ fun MainScreen(
     val currentEntry = backStack.lastOrNull()
     val isTabScreen = currentEntry is Nav.Tab
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.fillMaxSize()) {
         NavDisplay(
+            modifier = Modifier
+                .weight(1f)
+                .consumeWindowInsets(WindowInsets.navigationBars),
             backStack = backStack,
             onBack = {
                 if (!navCtrl.up()) {
@@ -66,9 +69,7 @@ fun MainScreen(
 
         if (isTabScreen) {
             NavigationBar(
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .navigationBarsPadding(),
+                modifier = Modifier.fillMaxWidth(),
             ) {
                 NavigationBarItem(
                     selected = currentEntry is Nav.Tab.Overview,

--- a/app/src/main/java/eu/darken/myperm/watcher/core/PermissionDiff.kt
+++ b/app/src/main/java/eu/darken/myperm/watcher/core/PermissionDiff.kt
@@ -10,6 +10,8 @@ data class PermissionDiff(
     val grantChanges: List<GrantChange> = emptyList(),
     val addedDeclared: List<String> = emptyList(),
     val removedDeclared: List<String> = emptyList(),
+    val gainedCount: Int = 0,
+    val lostCount: Int = 0,
 ) {
     @Serializable
     data class GrantChange(

--- a/app/src/main/java/eu/darken/myperm/watcher/core/SnapshotDiffer.kt
+++ b/app/src/main/java/eu/darken/myperm/watcher/core/SnapshotDiffer.kt
@@ -40,12 +40,20 @@ class SnapshotDiffer @Inject constructor() {
         val addedDeclared = (currDeclaredIds - prevDeclaredIds).toList()
         val removedDeclared = (prevDeclaredIds - currDeclaredIds).toList()
 
+        val currentStatusMap = currentPerms.associate { it.permissionId to it.status }
+        val gainedCount = addedPermissions.count { currentStatusMap[it]?.isGranted == true } +
+            grantChanges.count { !it.oldStatus.isGranted && it.newStatus.isGranted }
+        val lostCount = removedPermissions.count { prevStatusMap[it]?.isGranted == true } +
+            grantChanges.count { it.oldStatus.isGranted && !it.newStatus.isGranted }
+
         return PermissionDiff(
             addedPermissions = addedPermissions,
             removedPermissions = removedPermissions,
             grantChanges = grantChanges,
             addedDeclared = addedDeclared,
             removedDeclared = removedDeclared,
+            gainedCount = gainedCount,
+            lostCount = lostCount,
         )
     }
 

--- a/app/src/main/java/eu/darken/myperm/watcher/ui/dashboard/WatcherDashboardScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/watcher/ui/dashboard/WatcherDashboardScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -173,6 +174,19 @@ fun WatcherDashboardScreen(
     var searchQuery by rememberSaveable { mutableStateOf("") }
 
     Scaffold(
+        floatingActionButton = {
+            if (isEnabled) {
+                FloatingActionButton(
+                    onClick = { if (refreshPhase == null) onRefresh() },
+                ) {
+                    if (refreshPhase != null) {
+                        CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                    } else {
+                        Icon(Icons.Filled.Refresh, contentDescription = stringResource(R.string.general_refresh_action))
+                    }
+                }
+            }
+        },
         topBar = {
             TopAppBar(
                 title = {
@@ -193,13 +207,6 @@ fun WatcherDashboardScreen(
                 },
                 actions = {
                     if (isEnabled) {
-                        IconButton(onClick = onRefresh, enabled = refreshPhase == null) {
-                            if (refreshPhase != null) {
-                                CircularProgressIndicator(modifier = Modifier.size(24.dp))
-                            } else {
-                                Icon(Icons.Filled.Refresh, contentDescription = stringResource(R.string.general_refresh_action))
-                            }
-                        }
                         IconButton(onClick = {
                             if (isSearchActive) {
                                 searchQuery = ""
@@ -536,10 +543,20 @@ private fun ReportListItem(
                         WatcherEventType.REMOVED -> stringResource(R.string.watcher_event_removed)
                         WatcherEventType.GRANT_CHANGE -> stringResource(R.string.watcher_event_grant_change)
                     }
+                    val countSuffix = when {
+                        item.gainedCount > 0 && item.lostCount > 0 -> "(+${item.gainedCount}, -${item.lostCount})"
+                        item.gainedCount > 0 -> "(+${item.gainedCount})"
+                        item.lostCount > 0 -> "(-${item.lostCount})"
+                        else -> null
+                    }
+                    val displayLabel = if (countSuffix != null) "$eventLabel $countSuffix" else eventLabel
                     Text(
-                        text = eventLabel,
+                        text = displayLabel,
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.primary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f),
                     )
                     Text(
                         text = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM)
@@ -583,6 +600,7 @@ private fun WatcherDashboardWithReportsPreview() = PreviewWrapper {
                     isSeen = false,
                     hasAddedPermissions = true,
                     hasLostPermissions = false,
+                    gainedCount = 2,
                 ),
                 WatcherReportItem(
                     id = 2,
@@ -595,6 +613,7 @@ private fun WatcherDashboardWithReportsPreview() = PreviewWrapper {
                     isSeen = true,
                     hasAddedPermissions = false,
                     hasLostPermissions = false,
+                    lostCount = 1,
                 ),
             ),
             hasUnseen = true,
@@ -631,6 +650,8 @@ private fun WatcherDashboardNotificationCardPreview() = PreviewWrapper {
                     isSeen = false,
                     hasAddedPermissions = true,
                     hasLostPermissions = false,
+                    gainedCount = 3,
+                    lostCount = 1,
                 ),
             ),
             hasUnseen = true,

--- a/app/src/main/java/eu/darken/myperm/watcher/ui/dashboard/WatcherDashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/watcher/ui/dashboard/WatcherDashboardViewModel.kt
@@ -164,6 +164,8 @@ class WatcherDashboardViewModel @Inject constructor(
             isSeen = isSeen,
             hasAddedPermissions = diff?.let { it.addedPermissions.isNotEmpty() || it.addedDeclared.isNotEmpty() } ?: false,
             hasLostPermissions = diff?.let { it.removedPermissions.isNotEmpty() || it.removedDeclared.isNotEmpty() } ?: false,
+            gainedCount = diff?.gainedCount ?: 0,
+            lostCount = diff?.lostCount ?: 0,
         )
     }
 

--- a/app/src/main/java/eu/darken/myperm/watcher/ui/dashboard/WatcherFilterOptions.kt
+++ b/app/src/main/java/eu/darken/myperm/watcher/ui/dashboard/WatcherFilterOptions.kt
@@ -32,6 +32,7 @@ data class WatcherFilterOptions(
         GRANT_CHANGE(Group.EVENT_TYPE, R.string.watcher_event_grant_change),
         HAS_ADDED_PERMISSIONS(Group.PERMISSION_CHANGES, R.string.watcher_filter_has_added_permissions),
         HAS_LOST_PERMISSIONS(Group.PERMISSION_CHANGES, R.string.watcher_filter_has_lost_permissions),
+        HAS_GAINED_PERMISSIONS(Group.PERMISSION_CHANGES, R.string.watcher_filter_has_gained_permissions),
         UNSEEN_ONLY(Group.STATUS, R.string.watcher_filter_unseen_only);
 
         fun matches(item: WatcherReportItem): Boolean = when (this) {
@@ -41,6 +42,7 @@ data class WatcherFilterOptions(
             GRANT_CHANGE -> item.eventType == WatcherEventType.GRANT_CHANGE
             HAS_ADDED_PERMISSIONS -> item.hasAddedPermissions
             HAS_LOST_PERMISSIONS -> item.hasLostPermissions
+            HAS_GAINED_PERMISSIONS -> item.gainedCount > 0
             UNSEEN_ONLY -> !item.isSeen
         }
     }

--- a/app/src/main/java/eu/darken/myperm/watcher/ui/dashboard/WatcherReportItem.kt
+++ b/app/src/main/java/eu/darken/myperm/watcher/ui/dashboard/WatcherReportItem.kt
@@ -14,4 +14,6 @@ data class WatcherReportItem(
     val isSeen: Boolean,
     val hasAddedPermissions: Boolean,
     val hasLostPermissions: Boolean,
+    val gainedCount: Int = 0,
+    val lostCount: Int = 0,
 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -579,6 +579,7 @@
     <string name="watcher_search_hint">Search reports</string>
     <string name="watcher_filter_has_added_permissions">Has added permissions</string>
     <string name="watcher_filter_has_lost_permissions">Has lost permissions</string>
+    <string name="watcher_filter_has_gained_permissions">Has gained permissions</string>
     <string name="watcher_filter_unseen_only">Unseen only</string>
     <string name="watcher_filter_section_event_type">Event type</string>
     <string name="watcher_filter_section_permission_changes">Permission changes</string>

--- a/app/src/test/java/eu/darken/myperm/watcher/core/PermissionDiffSerializationTest.kt
+++ b/app/src/test/java/eu/darken/myperm/watcher/core/PermissionDiffSerializationTest.kt
@@ -29,7 +29,9 @@ class PermissionDiffSerializationTest : BaseTest() {
                 }
               ],
               "addedDeclared": ["com.example.CUSTOM_PERM"],
-              "removedDeclared": ["com.example.OLD_PERM"]
+              "removedDeclared": ["com.example.OLD_PERM"],
+              "gainedCount": 0,
+              "lostCount": 0
             }
         """.trimIndent()
 
@@ -43,6 +45,8 @@ class PermissionDiffSerializationTest : BaseTest() {
         parsed.grantChanges[0].newStatus shouldBe UsesPermission.Status.GRANTED
         parsed.addedDeclared shouldBe listOf("com.example.CUSTOM_PERM")
         parsed.removedDeclared shouldBe listOf("com.example.OLD_PERM")
+        parsed.gainedCount shouldBe 0
+        parsed.lostCount shouldBe 0
 
         json.encodeToString(parsed).toComparableJson() shouldBe raw.toComparableJson()
     }
@@ -55,7 +59,9 @@ class PermissionDiffSerializationTest : BaseTest() {
               "removedPermissions": [],
               "grantChanges": [],
               "addedDeclared": [],
-              "removedDeclared": []
+              "removedDeclared": [],
+              "gainedCount": 0,
+              "lostCount": 0
             }
         """.trimIndent()
 
@@ -66,6 +72,8 @@ class PermissionDiffSerializationTest : BaseTest() {
         parsed.grantChanges shouldBe emptyList()
         parsed.addedDeclared shouldBe emptyList()
         parsed.removedDeclared shouldBe emptyList()
+        parsed.gainedCount shouldBe 0
+        parsed.lostCount shouldBe 0
 
         json.encodeToString(parsed).toComparableJson() shouldBe raw.toComparableJson()
     }
@@ -95,6 +103,39 @@ class PermissionDiffSerializationTest : BaseTest() {
 
         parsed.addedPermissions shouldBe listOf("android.permission.CAMERA")
         parsed.removedPermissions shouldBe emptyList()
+    }
+
+    @Test
+    fun `old JSON without gainedCount and lostCount deserializes to zero defaults`() {
+        val raw = """
+            {
+              "addedPermissions": ["android.permission.CAMERA"],
+              "removedPermissions": [],
+              "grantChanges": [],
+              "addedDeclared": [],
+              "removedDeclared": []
+            }
+        """.trimIndent()
+
+        val parsed = json.decodeFromString<PermissionDiff>(raw)
+
+        parsed.gainedCount shouldBe 0
+        parsed.lostCount shouldBe 0
+    }
+
+    @Test
+    fun `new JSON with gainedCount and lostCount roundtrips correctly`() {
+        val diff = PermissionDiff(
+            addedPermissions = listOf("android.permission.CAMERA"),
+            gainedCount = 1,
+            lostCount = 2,
+        )
+
+        val serialized = json.encodeToString(diff)
+        val restored = json.decodeFromString<PermissionDiff>(serialized)
+
+        restored.gainedCount shouldBe 1
+        restored.lostCount shouldBe 2
     }
 
     @Test

--- a/app/src/test/java/eu/darken/myperm/watcher/core/SnapshotDifferTest.kt
+++ b/app/src/test/java/eu/darken/myperm/watcher/core/SnapshotDifferTest.kt
@@ -221,6 +221,198 @@ class SnapshotDifferTest : BaseTest() {
     }
 
     @Test
+    fun `install - gainedCount only counts granted permissions`() {
+        val diff = differ.diff(
+            previousPerms = emptyList(),
+            previousDeclared = emptyList(),
+            currentPerms = listOf(
+                current("android.permission.CAMERA", "GRANTED"),
+                current("android.permission.INTERNET", "GRANTED"),
+                current("android.permission.LOCATION", "DENIED"),
+            ),
+            currentDeclared = emptyList(),
+        )
+
+        diff.gainedCount shouldBe 2
+        diff.lostCount shouldBe 0
+    }
+
+    @Test
+    fun `install - denied permissions not counted as gained`() {
+        val diff = differ.diff(
+            previousPerms = emptyList(),
+            previousDeclared = emptyList(),
+            currentPerms = listOf(
+                current("android.permission.CAMERA", "DENIED"),
+                current("android.permission.INTERNET", "DENIED"),
+            ),
+            currentDeclared = emptyList(),
+        )
+
+        diff.gainedCount shouldBe 0
+        diff.lostCount shouldBe 0
+    }
+
+    @Test
+    fun `update - added granted permission counted as gained`() {
+        val diff = differ.diff(
+            previousPerms = listOf(
+                perm("android.permission.INTERNET", "GRANTED"),
+            ),
+            previousDeclared = emptyList(),
+            currentPerms = listOf(
+                current("android.permission.INTERNET", "GRANTED"),
+                current("android.permission.CAMERA", "GRANTED"),
+            ),
+            currentDeclared = emptyList(),
+        )
+
+        diff.gainedCount shouldBe 1
+        diff.lostCount shouldBe 0
+    }
+
+    @Test
+    fun `update - added denied permission not counted as gained`() {
+        val diff = differ.diff(
+            previousPerms = listOf(
+                perm("android.permission.INTERNET", "GRANTED"),
+            ),
+            previousDeclared = emptyList(),
+            currentPerms = listOf(
+                current("android.permission.INTERNET", "GRANTED"),
+                current("android.permission.CAMERA", "DENIED"),
+            ),
+            currentDeclared = emptyList(),
+        )
+
+        diff.gainedCount shouldBe 0
+        diff.lostCount shouldBe 0
+    }
+
+    @Test
+    fun `grant change - DENIED to GRANTED counted as gained`() {
+        val diff = differ.diff(
+            previousPerms = listOf(
+                perm("android.permission.CAMERA", "DENIED"),
+            ),
+            previousDeclared = emptyList(),
+            currentPerms = listOf(
+                current("android.permission.CAMERA", "GRANTED"),
+            ),
+            currentDeclared = emptyList(),
+        )
+
+        diff.gainedCount shouldBe 1
+        diff.lostCount shouldBe 0
+    }
+
+    @Test
+    fun `grant change - GRANTED to DENIED counted as lost`() {
+        val diff = differ.diff(
+            previousPerms = listOf(
+                perm("android.permission.CAMERA", "GRANTED"),
+            ),
+            previousDeclared = emptyList(),
+            currentPerms = listOf(
+                current("android.permission.CAMERA", "DENIED"),
+            ),
+            currentDeclared = emptyList(),
+        )
+
+        diff.gainedCount shouldBe 0
+        diff.lostCount shouldBe 1
+    }
+
+    @Test
+    fun `grant change - DENIED to UNKNOWN not counted`() {
+        val diff = differ.diff(
+            previousPerms = listOf(
+                perm("android.permission.CAMERA", "DENIED"),
+            ),
+            previousDeclared = emptyList(),
+            currentPerms = listOf(
+                current("android.permission.CAMERA", "UNKNOWN"),
+            ),
+            currentDeclared = emptyList(),
+        )
+
+        diff.gainedCount shouldBe 0
+        diff.lostCount shouldBe 0
+    }
+
+    @Test
+    fun `grant change - GRANTED to GRANTED_IN_USE not counted`() {
+        val diff = differ.diff(
+            previousPerms = listOf(
+                perm("android.permission.CAMERA", "GRANTED"),
+            ),
+            previousDeclared = emptyList(),
+            currentPerms = listOf(
+                current("android.permission.CAMERA", "GRANTED_IN_USE"),
+            ),
+            currentDeclared = emptyList(),
+        )
+
+        diff.gainedCount shouldBe 0
+        diff.lostCount shouldBe 0
+    }
+
+    @Test
+    fun `removed granted permission counted as lost`() {
+        val diff = differ.diff(
+            previousPerms = listOf(
+                perm("android.permission.CAMERA", "GRANTED"),
+                perm("android.permission.INTERNET", "GRANTED"),
+            ),
+            previousDeclared = emptyList(),
+            currentPerms = listOf(
+                current("android.permission.INTERNET", "GRANTED"),
+            ),
+            currentDeclared = emptyList(),
+        )
+
+        diff.gainedCount shouldBe 0
+        diff.lostCount shouldBe 1
+    }
+
+    @Test
+    fun `removed denied permission not counted as lost`() {
+        val diff = differ.diff(
+            previousPerms = listOf(
+                perm("android.permission.CAMERA", "DENIED"),
+                perm("android.permission.INTERNET", "GRANTED"),
+            ),
+            previousDeclared = emptyList(),
+            currentPerms = listOf(
+                current("android.permission.INTERNET", "GRANTED"),
+            ),
+            currentDeclared = emptyList(),
+        )
+
+        diff.gainedCount shouldBe 0
+        diff.lostCount shouldBe 0
+    }
+
+    @Test
+    fun `mixed - gains and losses combined correctly`() {
+        val diff = differ.diff(
+            previousPerms = listOf(
+                perm("android.permission.CAMERA", "DENIED"),
+                perm("android.permission.INTERNET", "GRANTED"),
+            ),
+            previousDeclared = emptyList(),
+            currentPerms = listOf(
+                current("android.permission.CAMERA", "GRANTED"),
+                current("android.permission.LOCATION", "GRANTED"),
+            ),
+            currentDeclared = emptyList(),
+        )
+
+        diff.gainedCount shouldBe 2
+        diff.lostCount shouldBe 1
+    }
+
+    @Test
     fun `GRANTED_IN_USE status is preserved in diff`() {
         val diff = differ.diff(
             previousPerms = listOf(

--- a/app/src/test/java/eu/darken/myperm/watcher/ui/dashboard/WatcherFilterOptionsTest.kt
+++ b/app/src/test/java/eu/darken/myperm/watcher/ui/dashboard/WatcherFilterOptionsTest.kt
@@ -1,0 +1,80 @@
+package eu.darken.myperm.watcher.ui.dashboard
+
+import eu.darken.myperm.watcher.core.WatcherEventType
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelper.BaseTest
+
+class WatcherFilterOptionsTest : BaseTest() {
+
+    private fun item(
+        eventType: WatcherEventType = WatcherEventType.UPDATE,
+        isSeen: Boolean = true,
+        hasAddedPermissions: Boolean = false,
+        hasLostPermissions: Boolean = false,
+        gainedCount: Int = 0,
+        lostCount: Int = 0,
+    ) = WatcherReportItem(
+        id = 1,
+        packageName = "com.example.app",
+        appLabel = "Test App",
+        versionName = "1.0",
+        previousVersionName = null,
+        eventType = eventType,
+        detectedAt = System.currentTimeMillis(),
+        isSeen = isSeen,
+        hasAddedPermissions = hasAddedPermissions,
+        hasLostPermissions = hasLostPermissions,
+        gainedCount = gainedCount,
+        lostCount = lostCount,
+    )
+
+    @Test
+    fun `empty filters match everything`() {
+        val options = WatcherFilterOptions()
+        options.matches(item()) shouldBe true
+        options.matches(item(eventType = WatcherEventType.INSTALL)) shouldBe true
+        options.matches(item(gainedCount = 5)) shouldBe true
+    }
+
+    @Test
+    fun `HAS_GAINED_PERMISSIONS matches item with gainedCount greater than zero`() {
+        val filter = WatcherFilterOptions.Filter.HAS_GAINED_PERMISSIONS
+        filter.matches(item(gainedCount = 2)) shouldBe true
+        filter.matches(item(gainedCount = 1)) shouldBe true
+    }
+
+    @Test
+    fun `HAS_GAINED_PERMISSIONS does not match item with gainedCount zero`() {
+        val filter = WatcherFilterOptions.Filter.HAS_GAINED_PERMISSIONS
+        filter.matches(item(gainedCount = 0)) shouldBe false
+    }
+
+    @Test
+    fun `filters within same group are OR-ed`() {
+        val options = WatcherFilterOptions(
+            filters = setOf(
+                WatcherFilterOptions.Filter.HAS_GAINED_PERMISSIONS,
+                WatcherFilterOptions.Filter.HAS_LOST_PERMISSIONS,
+            )
+        )
+
+        options.matches(item(gainedCount = 1, hasLostPermissions = false)) shouldBe true
+        options.matches(item(gainedCount = 0, hasLostPermissions = true)) shouldBe true
+        options.matches(item(gainedCount = 0, hasLostPermissions = false)) shouldBe false
+    }
+
+    @Test
+    fun `filters across groups are AND-ed`() {
+        val options = WatcherFilterOptions(
+            filters = setOf(
+                WatcherFilterOptions.Filter.INSTALL,
+                WatcherFilterOptions.Filter.HAS_GAINED_PERMISSIONS,
+            )
+        )
+
+        options.matches(item(eventType = WatcherEventType.INSTALL, gainedCount = 1)) shouldBe true
+        options.matches(item(eventType = WatcherEventType.INSTALL, gainedCount = 0)) shouldBe false
+        options.matches(item(eventType = WatcherEventType.UPDATE, gainedCount = 1)) shouldBe false
+    }
+}


### PR DESCRIPTION
## Summary

- Show permission gain/loss counts behind event type labels (e.g., "Updated (+2)", "Permission changed (-1)") so users immediately see how many effective capabilities changed
- Add "Has gained permissions" filter to only show events where an app actually gained new capabilities (auto-granted or user-granted permissions)
- Move the refresh button from the toolbar into a floating action button
- Fix main screen layout so child screens render above the bottom navigation bar instead of behind it

## Details

**Gained/lost counting** is computed at diff time in `SnapshotDiffer` where permission grant status is available. Only counts permissions that actually cross the grant boundary — denied permissions added in an update don't count as "gained", and `DENIED→UNKNOWN` transitions are ignored. Counts are stored in `PermissionDiff` with default values for backward-compatible JSON deserialization of existing reports.

**Main screen layout** changed from `Box` overlay to `Column` so `NavDisplay` content sits above the `NavigationBar` rather than behind it. Navigation bar window insets are consumed at the `NavDisplay` level to prevent child Scaffolds from double-applying bottom padding.

## Test plan

- [x] 11 new unit tests for `SnapshotDiffer` gained/lost counting (boundary crossings, denied permissions, mixed scenarios)
- [x] 2 new serialization tests for backward compatibility with old JSON
- [x] 5 new `WatcherFilterOptions` tests (filter matching, OR within group, AND across groups)
- [ ] Verify FAB visible above bottom nav bar on device
- [ ] Verify count suffixes appear on watcher event list items
- [ ] Verify "Has gained permissions" filter chip appears in filter bottom sheet
