### PR TITLE
Make overview category rows clickable to show filtered apps

### DIFF
--- a/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsFilterOptions.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsFilterOptions.kt
@@ -94,6 +94,24 @@ data class AppsFilterOptions(
             labelRes = R.string.apps_filter_device_admin_label,
             matches = { it.hasDeviceAdmin }
         ),
+        INSTALL_PACKAGES(
+            group = Group.PROPERTIES,
+            labelRes = R.string.apps_filter_install_packages_label,
+            matches = { app ->
+                app.requestedPermissions.any {
+                    it.permissionId == "android.permission.REQUEST_INSTALL_PACKAGES" && it.status.isGranted
+                }
+            }
+        ),
+        OVERLAY(
+            group = Group.PROPERTIES,
+            labelRes = R.string.apps_filter_overlay_label,
+            matches = { app ->
+                app.requestedPermissions.any {
+                    it.permissionId == "android.permission.SYSTEM_ALERT_WINDOW" && it.status.isGranted
+                }
+            }
+        ),
         PRIMARY_PROFILE(
             group = Group.PROFILE,
             labelRes = R.string.apps_filter_profile_active_label,

--- a/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewScreen.kt
@@ -1,6 +1,7 @@
 package eu.darken.myperm.main.ui.overview
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -49,6 +50,7 @@ import eu.darken.myperm.R
 import eu.darken.myperm.common.compose.Preview2
 import eu.darken.myperm.common.compose.PreviewWrapper
 import androidx.compose.runtime.collectAsState
+import eu.darken.myperm.apps.ui.list.AppsFilterOptions
 import eu.darken.myperm.common.error.ErrorEventHandler
 import eu.darken.myperm.common.navigation.NavigationEventHandler
 
@@ -64,6 +66,7 @@ fun OverviewScreenHost(vm: OverviewViewModel = hiltViewModel()) {
             state = it,
             onRefresh = { vm.onRefresh() },
             onSettings = { vm.goToSettings() },
+            onCategoryClick = { filters -> vm.onCategoryClicked(filters) },
         )
     }
 }
@@ -73,6 +76,7 @@ fun OverviewScreen(
     state: OverviewViewModel.State,
     onRefresh: () -> Unit,
     onSettings: () -> Unit,
+    onCategoryClick: (Set<AppsFilterOptions.Filter>) -> Unit = {},
 ) {
     Scaffold(
         topBar = {
@@ -120,7 +124,7 @@ fun OverviewScreen(
                 val device = state.deviceInfo
                 if (summary != null) {
                     HeroCard(summary, device)
-                    SummaryList(summary)
+                    SummaryList(summary, onCategoryClick)
                 }
             }
         }
@@ -190,24 +194,39 @@ private fun AppRatioBar(userCount: Int, systemCount: Int, total: Int) {
 }
 
 @Composable
-private fun SummaryList(summary: OverviewViewModel.SummaryInfo) {
-    data class Category(val icon: ImageVector, val label: String, val userCount: Int, val systemCount: Int)
+private fun SummaryList(
+    summary: OverviewViewModel.SummaryInfo,
+    onCategoryClick: (Set<AppsFilterOptions.Filter>) -> Unit,
+) {
+    data class Category(
+        val icon: ImageVector,
+        val label: String,
+        val userCount: Int,
+        val systemCount: Int,
+        val filters: Set<AppsFilterOptions.Filter>,
+    )
 
     val categories = listOf(
-        Category(Icons.Filled.PhoneAndroid, stringResource(R.string.overview_summary_apps_active_profile_label), summary.activeProfileUser, summary.activeProfileSystem),
-        Category(Icons.Filled.People, stringResource(R.string.overview_summary_apps_other_profile_label), summary.otherProfileUser, summary.otherProfileSystem),
-        Category(Icons.Filled.InstallMobile, stringResource(R.string.overview_summary_apps_sideloaded_label), summary.sideloaded, 0),
-        Category(Icons.Filled.GetApp, stringResource(R.string.overview_summary_apps_installers_label), summary.installerAppsUser, summary.installerAppsSystem),
-        Category(Icons.Filled.Layers, stringResource(R.string.overview_summary_apps_overlayers_label), summary.systemAlertWindowUser, summary.systemAlertWindowSystem),
-        Category(Icons.Filled.WifiOff, stringResource(R.string.overview_summary_apps_offline_label), summary.noInternetUser, summary.noInternetSystem),
-        Category(Icons.Filled.ContentCopy, stringResource(R.string.overview_summary_apps_clones_label), summary.clonesUser, summary.clonesSystem),
-        Category(Icons.Filled.Share, stringResource(R.string.overview_summary_apps_sharedids_label), summary.sharedIdsUser, summary.sharedIdsSystem),
+        Category(Icons.Filled.PhoneAndroid, stringResource(R.string.overview_summary_apps_active_profile_label), summary.activeProfileUser, summary.activeProfileSystem, setOf(AppsFilterOptions.Filter.PRIMARY_PROFILE)),
+        Category(Icons.Filled.People, stringResource(R.string.overview_summary_apps_other_profile_label), summary.otherProfileUser, summary.otherProfileSystem, setOf(AppsFilterOptions.Filter.SECONDARY_PROFILE)),
+        Category(Icons.Filled.InstallMobile, stringResource(R.string.overview_summary_apps_sideloaded_label), summary.sideloaded, 0, setOf(AppsFilterOptions.Filter.SIDELOADED)),
+        Category(Icons.Filled.GetApp, stringResource(R.string.overview_summary_apps_installers_label), summary.installerAppsUser, summary.installerAppsSystem, setOf(AppsFilterOptions.Filter.INSTALL_PACKAGES)),
+        Category(Icons.Filled.Layers, stringResource(R.string.overview_summary_apps_overlayers_label), summary.systemAlertWindowUser, summary.systemAlertWindowSystem, setOf(AppsFilterOptions.Filter.OVERLAY)),
+        Category(Icons.Filled.WifiOff, stringResource(R.string.overview_summary_apps_offline_label), summary.noInternetUser, summary.noInternetSystem, setOf(AppsFilterOptions.Filter.NO_INTERNET)),
+        Category(Icons.Filled.ContentCopy, stringResource(R.string.overview_summary_apps_clones_label), summary.clonesUser, summary.clonesSystem, setOf(AppsFilterOptions.Filter.MULTI_PROFILE)),
+        Category(Icons.Filled.Share, stringResource(R.string.overview_summary_apps_sharedids_label), summary.sharedIdsUser, summary.sharedIdsSystem, setOf(AppsFilterOptions.Filter.SHARED_ID)),
     )
 
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(vertical = 4.dp)) {
             categories.forEachIndexed { index, category ->
-                CategoryRow(category.icon, category.label, category.userCount, category.systemCount)
+                CategoryRow(
+                    icon = category.icon,
+                    label = category.label,
+                    userCount = category.userCount,
+                    systemCount = category.systemCount,
+                    onClick = { onCategoryClick(category.filters) },
+                )
                 if (index < categories.lastIndex) {
                     HorizontalDivider(modifier = Modifier.padding(start = 48.dp))
                 }
@@ -217,11 +236,12 @@ private fun SummaryList(summary: OverviewViewModel.SummaryInfo) {
 }
 
 @Composable
-private fun CategoryRow(icon: ImageVector, label: String, userCount: Int, systemCount: Int) {
+private fun CategoryRow(icon: ImageVector, label: String, userCount: Int, systemCount: Int, onClick: () -> Unit) {
     val total = userCount + systemCount
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .clickable(onClick = onClick)
             .padding(horizontal = 12.dp, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),

--- a/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewViewModel.kt
@@ -15,9 +15,11 @@ import eu.darken.myperm.common.navigation.Nav
 import eu.darken.myperm.apps.core.AppInfo
 import eu.darken.myperm.apps.core.features.InternetAccess
 import eu.darken.myperm.apps.core.AppRepo
+import eu.darken.myperm.apps.ui.list.AppsFilterOptions
 import eu.darken.myperm.common.uix.ViewModel4
 import eu.darken.myperm.common.upgrade.UpgradeRepo
 import eu.darken.myperm.permissions.core.known.APerm
+import eu.darken.myperm.settings.core.GeneralSettings
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flow
@@ -32,6 +34,7 @@ class OverviewViewModel @Inject constructor(
     dispatcherProvider: DispatcherProvider,
     private val appRepo: AppRepo,
     private val upgradeRepo: UpgradeRepo,
+    private val generalSettings: GeneralSettings,
 ) : ViewModel4(dispatcherProvider = dispatcherProvider) {
 
     data class DeviceInfo(
@@ -109,8 +112,8 @@ class OverviewViewModel @Inject constructor(
             installerAppsSystem = apps.count { it.isSystemApp && it.hasGrantedPermission(installPackagesId) },
             systemAlertWindowUser = apps.count { !it.isSystemApp && it.hasGrantedPermission(systemAlertWindowId) },
             systemAlertWindowSystem = apps.count { it.isSystemApp && it.hasGrantedPermission(systemAlertWindowId) },
-            noInternetUser = apps.count { !it.isSystemApp && it.internetAccess != InternetAccess.DIRECT },
-            noInternetSystem = apps.count { it.isSystemApp && it.internetAccess != InternetAccess.DIRECT },
+            noInternetUser = apps.count { !it.isSystemApp && it.internetAccess != InternetAccess.DIRECT && it.internetAccess != InternetAccess.UNKNOWN },
+            noInternetSystem = apps.count { it.isSystemApp && it.internetAccess != InternetAccess.DIRECT && it.internetAccess != InternetAccess.UNKNOWN },
             clonesUser = apps.count { !it.isSystemApp && it.twinCount > 0 },
             clonesSystem = apps.count { it.isSystemApp && it.twinCount > 0 },
             sharedIdsUser = apps.count { !it.isSystemApp && it.siblingCount > 0 },
@@ -127,6 +130,11 @@ class OverviewViewModel @Inject constructor(
 
     fun onUpgrade() {
         navTo(Nav.Main.Upgrade)
+    }
+
+    fun onCategoryClicked(filters: Set<AppsFilterOptions.Filter>) = launch {
+        generalSettings.appsFilterOptions.update { AppsFilterOptions(filters) }
+        navTo(Nav.Tab.Apps)
     }
 
     fun goToSettings() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -150,6 +150,8 @@
     <string name="apps_filter_battery_optimization_label">Apps with custom battery options</string>
     <string name="apps_filter_accessibility_label">Apps with accessibility services</string>
     <string name="apps_filter_device_admin_label">Device admin</string>
+    <string name="apps_filter_install_packages_label">Can install apps</string>
+    <string name="apps_filter_overlay_label">Draw over apps</string>
     <string name="apps_filter_section_app_type">App type</string>
     <string name="apps_filter_section_install_source">Install source</string>
     <string name="apps_filter_section_properties">Properties</string>


### PR DESCRIPTION
## Summary
- Clicking a category row on the overview page (e.g. Sideloaded, No internet) navigates to the Apps tab with the matching filter pre-set
- Added two new filter chips: **Can install apps** (REQUEST_INSTALL_PACKAGES) and **Draw over apps** (SYSTEM_ALERT_WINDOW) — these auto-appear in the filter bottom sheet
- Fixed no-internet overview count to exclude UNKNOWN status, aligning with the existing filter predicate

## Test plan
- [ ] Tap each of the 8 overview category rows and verify the Apps tab shows with the correct filter
- [ ] Press Back from the Apps tab and verify return to Overview
- [ ] Open the filter bottom sheet and verify the two new chips appear under Properties
- [ ] Verify filter persists when leaving and returning to the Apps tab
- [ ] Tap Reset in the filter sheet to verify it clears the filter
- [ ] Tap a category with 0 count to verify it shows an empty list (no crash)