### PR TITLE
Add option to only notify when permissions are gained

### DIFF
--- a/app/src/main/java/eu/darken/myperm/settings/core/GeneralSettings.kt
+++ b/app/src/main/java/eu/darken/myperm/settings/core/GeneralSettings.kt
@@ -108,6 +108,7 @@ class GeneralSettings @Inject constructor(
         writer = kotlinxWriter(json),
     )
     val isWatcherNotificationsEnabled = dataStore.createValue("watcher.notifications.enabled", true)
+    val isWatcherNotifyOnlyOnGained = dataStore.createValue("watcher.notifications.only.gained", true)
     val watcherRetentionDays = dataStore.createValue("watcher.retention.days", 30)
 
     val watcherPollingIntervalHours = dataStore.createValue("watcher.polling.interval.hours", 4)

--- a/app/src/main/java/eu/darken/myperm/settings/ui/watcher/WatcherSettingsScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/settings/ui/watcher/WatcherSettingsScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.twotone.FilterList
 import eu.darken.myperm.common.compose.LucideRadar
 import androidx.compose.material.icons.twotone.Notifications
 import androidx.compose.material.icons.twotone.Schedule
+import androidx.compose.material.icons.twotone.Stars
 import androidx.compose.material.icons.twotone.Timer
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
@@ -58,21 +59,27 @@ fun WatcherSettingsScreenHost() {
     ErrorEventHandler(vm)
     NavigationEventHandler(vm)
 
+    val isPro by vm.isPro.collectAsState()
     val isWatcherEnabled by vm.isWatcherEnabled.collectAsState(initial = false)
     val watcherScope by vm.watcherScope.collectAsState(initial = WatcherScope.NON_SYSTEM)
     val isNotificationsEnabled by vm.isNotificationsEnabled.collectAsState(initial = true)
+    val isNotifyOnlyOnGained by vm.isNotifyOnlyOnGained.collectAsState(initial = true)
     val retentionDays by vm.retentionDays.collectAsState(initial = 30)
     val pollingIntervalHours by vm.pollingIntervalHours.collectAsState(initial = 4)
     val reportCount by vm.reportCount.collectAsState(initial = 0)
 
     WatcherSettingsScreen(
         onBack = { navCtrl?.up() },
+        isPro = isPro,
         isWatcherEnabled = isWatcherEnabled,
         onWatcherEnabledChanged = { vm.setWatcherEnabled(it) },
+        onUpgrade = { vm.onUpgrade() },
         watcherScope = watcherScope,
         onWatcherScopeSelected = { vm.setWatcherScope(it) },
         isNotificationsEnabled = isNotificationsEnabled,
         onNotificationsEnabledChanged = { vm.setNotificationsEnabled(it) },
+        isNotifyOnlyOnGained = isNotifyOnlyOnGained,
+        onNotifyOnlyOnGainedChanged = { vm.setNotifyOnlyOnGained(it) },
         retentionDays = retentionDays,
         onRetentionDaysSelected = { vm.setRetentionDays(it) },
         pollingIntervalHours = pollingIntervalHours,
@@ -85,12 +92,16 @@ fun WatcherSettingsScreenHost() {
 @Composable
 fun WatcherSettingsScreen(
     onBack: () -> Unit,
+    isPro: Boolean = true,
     isWatcherEnabled: Boolean = false,
     onWatcherEnabledChanged: (Boolean) -> Unit = {},
+    onUpgrade: () -> Unit = {},
     watcherScope: WatcherScope = WatcherScope.NON_SYSTEM,
     onWatcherScopeSelected: (WatcherScope) -> Unit = {},
     isNotificationsEnabled: Boolean = true,
     onNotificationsEnabledChanged: (Boolean) -> Unit = {},
+    isNotifyOnlyOnGained: Boolean = true,
+    onNotifyOnlyOnGainedChanged: (Boolean) -> Unit = {},
     retentionDays: Int = 30,
     onRetentionDaysSelected: (Int) -> Unit = {},
     pollingIntervalHours: Int = 4,
@@ -120,13 +131,22 @@ fun WatcherSettingsScreen(
                 .padding(innerPadding)
                 .verticalScroll(rememberScrollState()),
         ) {
-            SettingsSwitchItem(
-                icon = LucideRadar,
-                title = stringResource(R.string.watcher_enabled_label),
-                subtitle = stringResource(R.string.watcher_enabled_desc),
-                checked = isWatcherEnabled,
-                onCheckedChange = onWatcherEnabledChanged,
-            )
+            if (isPro) {
+                SettingsSwitchItem(
+                    icon = LucideRadar,
+                    title = stringResource(R.string.watcher_enabled_label),
+                    subtitle = stringResource(R.string.watcher_enabled_desc),
+                    checked = isWatcherEnabled,
+                    onCheckedChange = onWatcherEnabledChanged,
+                )
+            } else {
+                SettingsBaseItem(
+                    icon = Icons.TwoTone.Stars,
+                    title = stringResource(R.string.watcher_enabled_label),
+                    subtitle = stringResource(R.string.watcher_enabled_desc),
+                    onClick = onUpgrade,
+                )
+            }
             SettingsDivider()
             SettingsBaseItem(
                 title = stringResource(R.string.watcher_scope_label),
@@ -150,6 +170,14 @@ fun WatcherSettingsScreen(
                 subtitle = stringResource(R.string.watcher_settings_notifications_desc),
                 checked = isNotificationsEnabled,
                 onCheckedChange = onNotificationsEnabledChanged,
+            )
+            SettingsSwitchItem(
+                icon = Icons.TwoTone.Notifications,
+                title = stringResource(R.string.watcher_settings_notifications_only_gained_label),
+                subtitle = stringResource(R.string.watcher_settings_notifications_only_gained_desc),
+                checked = isNotifyOnlyOnGained,
+                onCheckedChange = onNotifyOnlyOnGainedChanged,
+                enabled = isNotificationsEnabled,
             )
             SettingsDivider()
             SettingsBaseItem(

--- a/app/src/main/java/eu/darken/myperm/settings/ui/watcher/WatcherSettingsViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/settings/ui/watcher/WatcherSettingsViewModel.kt
@@ -4,12 +4,18 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.myperm.common.coroutine.DispatcherProvider
 import eu.darken.myperm.common.debug.logging.log
 import eu.darken.myperm.common.debug.logging.logTag
+import eu.darken.myperm.common.navigation.Nav
 import eu.darken.myperm.common.room.dao.PermissionChangeDao
 import eu.darken.myperm.common.uix.ViewModel4
+import eu.darken.myperm.common.upgrade.UpgradeRepo
 import eu.darken.myperm.settings.core.GeneralSettings
 import eu.darken.myperm.watcher.core.WatcherScope
 import eu.darken.myperm.watcher.core.WatcherWorkScheduler
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
@@ -19,19 +25,33 @@ class WatcherSettingsViewModel @Inject constructor(
     private val generalSettings: GeneralSettings,
     private val changeDao: PermissionChangeDao,
     private val watcherWorkScheduler: WatcherWorkScheduler,
+    private val upgradeRepo: UpgradeRepo,
 ) : ViewModel4(dispatcherProvider) {
+
+    val isPro: StateFlow<Boolean> = upgradeRepo.upgradeInfo
+        .map { it.isPro }
+        .stateIn(vmScope, SharingStarted.Eagerly, upgradeRepo.upgradeInfo.value.isPro)
 
     val isWatcherEnabled: Flow<Boolean> = generalSettings.isWatcherEnabled.flow
     val watcherScope: Flow<WatcherScope> = generalSettings.watcherScope.flow
     val isNotificationsEnabled: Flow<Boolean> = generalSettings.isWatcherNotificationsEnabled.flow
+    val isNotifyOnlyOnGained: Flow<Boolean> = generalSettings.isWatcherNotifyOnlyOnGained.flow
     val retentionDays: Flow<Int> = generalSettings.watcherRetentionDays.flow
     val pollingIntervalHours: Flow<Int> = generalSettings.watcherPollingIntervalHours.flow
     val reportCount: Flow<Int> = changeDao.getTotalCount()
 
     fun setWatcherEnabled(enabled: Boolean) = launch {
+        if (!upgradeRepo.upgradeInfo.value.isPro) {
+            navTo(Nav.Main.Upgrade)
+            return@launch
+        }
         log(TAG) { "Setting watcher enabled: $enabled" }
         generalSettings.isWatcherEnabled.value(enabled)
         watcherWorkScheduler.ensureScheduled()
+    }
+
+    fun onUpgrade() {
+        navTo(Nav.Main.Upgrade)
     }
 
     fun setWatcherScope(scope: WatcherScope) = launch {
@@ -40,6 +60,10 @@ class WatcherSettingsViewModel @Inject constructor(
 
     fun setNotificationsEnabled(enabled: Boolean) = launch {
         generalSettings.isWatcherNotificationsEnabled.value(enabled)
+    }
+
+    fun setNotifyOnlyOnGained(enabled: Boolean) = launch {
+        generalSettings.isWatcherNotifyOnlyOnGained.value(enabled)
     }
 
     fun setRetentionDays(days: Int) = launch {

--- a/app/src/main/java/eu/darken/myperm/watcher/core/WatcherDiffRunner.kt
+++ b/app/src/main/java/eu/darken/myperm/watcher/core/WatcherDiffRunner.kt
@@ -129,19 +129,22 @@ class WatcherDiffRunner @Inject constructor(
         log(TAG) { "Processing ${chain.pairs.size} new snapshot pair(s)" }
 
         var totalReports = 0
+        var totalNotified = 0
         val reportedPackages = mutableSetOf<Pair<String, Int>>()
 
         for (pair in chain.pairs) {
-            totalReports += diffSnapshotPair(pair, scope, reportedPackages)
+            val (reports, notified) = diffSnapshotPair(pair, scope, reportedPackages)
+            totalReports += reports
+            totalNotified += notified
             // Progressive update: advance after each pair so cancellation only re-processes the current pair
             generalSettings.lastDiffedSnapshotId.update { pair.newSnapshotId }
         }
 
-        if (totalReports > 1) {
-            watcherNotifications.postSummaryNotification(totalReports)
+        if (totalNotified > 1) {
+            watcherNotifications.postSummaryNotification(totalNotified)
         }
 
-        log(TAG) { "Processed ${chain.pairs.size} pair(s), created $totalReports report(s)" }
+        log(TAG) { "Processed ${chain.pairs.size} pair(s), created $totalReports report(s), notified $totalNotified" }
         return totalReports
     }
 
@@ -149,8 +152,9 @@ class WatcherDiffRunner @Inject constructor(
         pair: SnapshotPair,
         scope: WatcherScope,
         reportedPackages: MutableSet<Pair<String, Int>>,
-    ): Int {
+    ): Pair<Int, Int> {
         var reportsCreated = 0
+        var notifiedCount = 0
 
         val oldPkgMap = pair.oldPkgs.associateBy { Pair(it.pkgName, it.userHandleId) }
         val newPkgMap = pair.newPkgs.associateBy { Pair(it.pkgName, it.userHandleId) }
@@ -246,7 +250,7 @@ class WatcherDiffRunner @Inject constructor(
                 )
             )
 
-            watcherNotifications.postChangeNotification(
+            val notified = watcherNotifications.postChangeNotification(
                 reportId = reportId,
                 appLabel = newPkg?.cachedLabel ?: oldPkg?.cachedLabel,
                 packageName = pkgName,
@@ -255,9 +259,10 @@ class WatcherDiffRunner @Inject constructor(
 
             reportedPackages.add(key)
             reportsCreated++
+            if (notified) notifiedCount++
         }
 
-        return reportsCreated
+        return Pair(reportsCreated, notifiedCount)
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/myperm/watcher/core/WatcherNotifications.kt
+++ b/app/src/main/java/eu/darken/myperm/watcher/core/WatcherNotifications.kt
@@ -47,15 +47,20 @@ class WatcherNotifications @Inject constructor(
         appLabel: String?,
         packageName: String,
         diff: PermissionDiff,
-    ) {
+    ): Boolean {
         if (!generalSettings.isWatcherNotificationsEnabled.value()) {
             log(TAG) { "Notifications disabled, skipping for $packageName" }
-            return
+            return false
+        }
+
+        if (generalSettings.isWatcherNotifyOnlyOnGained.value() && diff.gainedCount == 0) {
+            log(TAG) { "Notify-only-on-gained enabled and gainedCount=0, skipping $packageName" }
+            return false
         }
 
         if (!capability.areNotificationsEnabled()) {
             log(TAG) { "Notifications not available, skipping notification for $packageName" }
-            return
+            return false
         }
 
         ensureChannel()
@@ -131,6 +136,7 @@ class WatcherNotifications @Inject constructor(
             .build()
 
         notificationManager.notify(packageName.hashCode(), notification)
+        return true
     }
 
     suspend fun postSummaryNotification(reportCount: Int) {

--- a/app/src/main/java/eu/darken/myperm/watcher/ui/dashboard/WatcherDashboardScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/watcher/ui/dashboard/WatcherDashboardScreen.kt
@@ -350,11 +350,13 @@ private fun DisabledContent(
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSecondaryContainer,
                 )
-                Text(
-                    text = stringResource(R.string.watcher_dashboard_manage_in_settings),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                )
+                if (isPro) {
+                    Text(
+                        text = stringResource(R.string.watcher_dashboard_manage_in_settings),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    )
+                }
                 Button(
                     onClick = onToggle,
                     modifier = Modifier.align(Alignment.End),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -547,6 +547,8 @@
     </plurals>
     <string name="watcher_settings_notifications_label">Show notifications</string>
     <string name="watcher_settings_notifications_desc">Show a notification when permission changes are detected</string>
+    <string name="watcher_settings_notifications_only_gained_label">Only notify on permissions gained</string>
+    <string name="watcher_settings_notifications_only_gained_desc">Only notify when apps are granted new permissions, e.g. a runtime permission is allowed or an install-time permission like internet is added</string>
     <string name="watcher_settings_retention_label">Keep reports</string>
     <string name="watcher_settings_retention_7">7 days</string>
     <string name="watcher_settings_retention_14">14 days</string>


### PR DESCRIPTION
## Summary

- Add a new watcher setting "Only notify on permissions gained" (enabled by default) that filters notifications to only fire when apps gain new permissions (`gainedCount > 0`), reducing notification spam
- Guard the watcher enable toggle in settings behind a pro check — non-pro users see a stars icon that opens the upgrade screen instead of a toggle
- Hide the "can be configured in settings" hint on the watcher dashboard card when the user hasn't unlocked pro
- Track notified count separately from report count so the summary notification reflects actual notifications posted

## Changes

- `GeneralSettings.kt` — new `isWatcherNotifyOnlyOnGained` DataStoreValue
- `WatcherNotifications.kt` — gained-only filter + return `Boolean` indicating whether notification was posted
- `WatcherDiffRunner.kt` — track notified count for correct summary notification
- `WatcherSettingsViewModel.kt` — pro state, upgrade navigation, gained-only flow/setter
- `WatcherSettingsScreen.kt` — conditional pro/non-pro watcher toggle, gained-only toggle
- `WatcherDashboardScreen.kt` — conditional settings hint visibility
- `strings.xml` — 2 new string resources
