### PR TITLE
Show funny loading messages on all screens

### DIFF
--- a/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.outlined.Group
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -52,7 +51,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.pluralStringResource
-import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -63,6 +61,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import eu.darken.myperm.R
 import eu.darken.myperm.apps.core.features.UsesPermission
 import eu.darken.myperm.common.compose.AppIcon
+import eu.darken.myperm.common.compose.LoadingContent
 import eu.darken.myperm.common.compose.Pill
 import eu.darken.myperm.common.compose.PermissionIcon
 import eu.darken.myperm.common.compose.LabeledOption
@@ -172,22 +171,7 @@ fun AppDetailsScreen(
         }
     ) { innerPadding ->
         if (state.isLoading) {
-            val loadingLabels = stringArrayResource(R.array.generic_loading_labels)
-            val loadingLabel = remember(loadingLabels) { loadingLabels.random() }
-            Box(
-                modifier = Modifier.fillMaxSize().padding(innerPadding),
-                contentAlignment = Alignment.Center,
-            ) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    CircularProgressIndicator()
-                    Spacer(modifier = Modifier.height(16.dp))
-                    Text(
-                        text = loadingLabel,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
+            LoadingContent(modifier = Modifier.padding(innerPadding))
         } else {
             LazyColumn(
                 modifier = Modifier.fillMaxSize().padding(innerPadding),

--- a/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsScreen.kt
@@ -21,7 +21,7 @@ import androidx.compose.material.icons.twotone.Stars
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.CircularProgressIndicator
+import eu.darken.myperm.common.compose.LoadingContent
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
@@ -137,7 +137,13 @@ fun AppsScreen(
                             Icon(Icons.TwoTone.Stars, contentDescription = stringResource(R.string.upgrade_required_subtitle))
                         }
                     }
-                    IconButton(onClick = { isSearchActive = !isSearchActive }) {
+                    IconButton(onClick = {
+                        isSearchActive = !isSearchActive
+                        if (!isSearchActive) {
+                            searchQuery = ""
+                            onSearchChanged(null)
+                        }
+                    }) {
                         Icon(Icons.Filled.Search, contentDescription = stringResource(R.string.apps_search_list_hint))
                     }
                     if (state is AppsViewModel.State.Ready) {
@@ -198,12 +204,7 @@ fun AppsScreen(
 
             when (state) {
                 is AppsViewModel.State.Loading -> {
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        CircularProgressIndicator()
-                    }
+                    LoadingContent()
                 }
 
                 is AppsViewModel.State.Ready -> {

--- a/app/src/main/java/eu/darken/myperm/common/compose/LoadingContent.kt
+++ b/app/src/main/java/eu/darken/myperm/common/compose/LoadingContent.kt
@@ -1,0 +1,37 @@
+package eu.darken.myperm.common.compose
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringArrayResource
+import androidx.compose.ui.unit.dp
+import eu.darken.myperm.R
+
+@Composable
+fun LoadingContent(modifier: Modifier = Modifier) {
+    val loadingLabels = stringArrayResource(R.array.generic_loading_labels)
+    val loadingLabel = remember(loadingLabels) { loadingLabels.random() }
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            CircularProgressIndicator()
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = loadingLabel,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.WifiOff
 import androidx.compose.material3.Card
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -47,6 +46,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import eu.darken.myperm.R
+import eu.darken.myperm.common.compose.LoadingContent
 import eu.darken.myperm.common.compose.Preview2
 import eu.darken.myperm.common.compose.PreviewWrapper
 import androidx.compose.runtime.collectAsState
@@ -103,14 +103,7 @@ fun OverviewScreen(
         }
     ) { innerPadding ->
         if (state.isLoading) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(innerPadding),
-                contentAlignment = Alignment.Center,
-            ) {
-                CircularProgressIndicator()
-            }
+            LoadingContent(modifier = Modifier.padding(innerPadding))
         } else {
             Column(
                 modifier = Modifier

--- a/app/src/main/java/eu/darken/myperm/permissions/ui/details/PermissionDetailsScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/details/PermissionDetailsScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.material.icons.automirrored.filled.HelpOutline
 import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -53,6 +52,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import eu.darken.myperm.R
 import eu.darken.myperm.apps.core.features.UsesPermission
 import eu.darken.myperm.common.compose.AppIcon
+import eu.darken.myperm.common.compose.LoadingContent
 import eu.darken.myperm.common.compose.PermissionIcon
 import eu.darken.myperm.common.compose.LabeledOption
 import eu.darken.myperm.common.compose.MultiChoiceFilterDialog
@@ -155,12 +155,7 @@ fun PermissionDetailsScreen(
         }
     ) { innerPadding ->
         if (state.isLoading) {
-            Box(
-                modifier = Modifier.fillMaxSize().padding(innerPadding),
-                contentAlignment = Alignment.Center,
-            ) {
-                CircularProgressIndicator()
-            }
+            LoadingContent(modifier = Modifier.padding(innerPadding))
         } else {
             LazyColumn(
                 modifier = Modifier.fillMaxSize().padding(innerPadding),

--- a/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsScreen.kt
@@ -34,7 +34,7 @@ import androidx.compose.material.icons.twotone.Stars
 import androidx.compose.material.icons.filled.UnfoldLess
 import androidx.compose.material.icons.filled.UnfoldMore
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.CircularProgressIndicator
+import eu.darken.myperm.common.compose.LoadingContent
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.FilterChip
@@ -96,24 +96,24 @@ fun PermissionsScreenHost(vm: PermissionsViewModel = hiltViewModel()) {
     var showFilterDialog by rememberSaveable { mutableStateOf(false) }
     var showSortDialog by rememberSaveable { mutableStateOf(false) }
 
-    state?.let {
-        PermissionsScreen(
-            state = it,
-            isPro = isPro,
-            onSearchChanged = { vm.onSearchInputChanged(it) },
-            onGroupClicked = { vm.toggleGroup(it) },
-            onPermClicked = { vm.onPermissionClicked(it) },
-            onExpandAll = { vm.expandAll() },
-            onCollapseAll = { vm.collapseAll() },
-            onRefresh = { vm.onRefresh() },
-            onSettings = { vm.goToSettings() },
-            onFilterClicked = { showFilterDialog = true },
-            onSortClicked = { showSortDialog = true },
-            onUpgrade = { vm.onUpgrade() },
-        )
-    }
+    val effectiveState = state ?: PermissionsViewModel.State.Loading
 
-    val readyState = state as? PermissionsViewModel.State.Ready
+    PermissionsScreen(
+        state = effectiveState,
+        isPro = isPro,
+        onSearchChanged = { vm.onSearchInputChanged(it) },
+        onGroupClicked = { vm.toggleGroup(it) },
+        onPermClicked = { vm.onPermissionClicked(it) },
+        onExpandAll = { vm.expandAll() },
+        onCollapseAll = { vm.collapseAll() },
+        onRefresh = { vm.onRefresh() },
+        onSettings = { vm.goToSettings() },
+        onFilterClicked = { showFilterDialog = true },
+        onSortClicked = { showSortDialog = true },
+        onUpgrade = { vm.onUpgrade() },
+    )
+
+    val readyState = effectiveState as? PermissionsViewModel.State.Ready
 
     if (showFilterDialog && readyState != null) {
         MultiChoiceFilterDialog(
@@ -287,12 +287,7 @@ fun PermissionsScreen(
 
             when (state) {
                 is PermissionsViewModel.State.Loading -> {
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        CircularProgressIndicator()
-                    }
+                    LoadingContent()
                 }
 
                 is PermissionsViewModel.State.Ready -> {


### PR DESCRIPTION
## Summary
- Extract shared `LoadingContent` composable that shows a spinner with a random Easter egg message (e.g. "Soon™", "Downloading more RAM")
- Previously only the app details screen showed these messages — now all loading screens use the shared component
- Fix permissions list showing a blank screen instead of a loading indicator during initial data load

## Test plan
- [ ] Launch app, switch between tabs — verify spinner + funny message appears on apps and permissions list
- [ ] Open app details and permission details — verify same loading behavior
- [ ] Check overview screen loading state
