### PR TITLE
Improve search bar appearance with icon and clear button

### DIFF
--- a/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsScreen.kt
@@ -1,5 +1,8 @@
 package eu.darken.myperm.apps.ui.list
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -28,7 +31,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -56,6 +58,7 @@ import eu.darken.myperm.R
 import eu.darken.myperm.common.compose.AppIcon
 import eu.darken.myperm.common.compose.Preview2
 import eu.darken.myperm.common.compose.PreviewWrapper
+import eu.darken.myperm.common.compose.SearchTextField
 import androidx.compose.runtime.collectAsState
 import eu.darken.myperm.common.error.ErrorEventHandler
 import eu.darken.myperm.common.navigation.NavigationEventHandler
@@ -138,11 +141,11 @@ fun AppsScreen(
                         }
                     }
                     IconButton(onClick = {
-                        isSearchActive = !isSearchActive
-                        if (!isSearchActive) {
+                        if (isSearchActive) {
                             searchQuery = ""
                             onSearchChanged(null)
                         }
+                        isSearchActive = !isSearchActive
                     }) {
                         Icon(Icons.Filled.Search, contentDescription = stringResource(R.string.apps_search_list_hint))
                     }
@@ -187,18 +190,18 @@ fun AppsScreen(
         }
     ) { innerPadding ->
         Column(modifier = Modifier.padding(innerPadding)) {
-            if (isSearchActive) {
-                OutlinedTextField(
-                    value = searchQuery,
-                    onValueChange = {
+            AnimatedVisibility(
+                visible = isSearchActive,
+                enter = expandVertically(),
+                exit = shrinkVertically(),
+            ) {
+                SearchTextField(
+                    query = searchQuery,
+                    onQueryChanged = {
                         searchQuery = it
                         onSearchChanged(it.ifBlank { null })
                     },
-                    placeholder = { Text(stringResource(R.string.apps_search_list_hint)) },
-                    singleLine = true,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 0.dp),
+                    placeholder = stringResource(R.string.apps_search_list_hint),
                 )
             }
 

--- a/app/src/main/java/eu/darken/myperm/common/compose/SearchTextField.kt
+++ b/app/src/main/java/eu/darken/myperm/common/compose/SearchTextField.kt
@@ -1,0 +1,72 @@
+package eu.darken.myperm.common.compose
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SearchTextField(
+    query: String,
+    onQueryChanged: (String) -> Unit,
+    placeholder: String,
+    modifier: Modifier = Modifier,
+) {
+    OutlinedTextField(
+        value = query,
+        onValueChange = onQueryChanged,
+        placeholder = { Text(placeholder) },
+        singleLine = true,
+        leadingIcon = {
+            Icon(Icons.Filled.Search, contentDescription = null)
+        },
+        trailingIcon = {
+            if (query.isNotBlank()) {
+                IconButton(onClick = { onQueryChanged("") }) {
+                    Icon(Icons.Filled.Close, contentDescription = null)
+                }
+            }
+        },
+        shape = RoundedCornerShape(50),
+        colors = OutlinedTextFieldDefaults.colors(
+            unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+            focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ),
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .height(52.dp),
+    )
+}
+
+@Preview2
+@Composable
+private fun SearchTextFieldPreview() = PreviewWrapper {
+    SearchTextField(
+        query = "",
+        onQueryChanged = {},
+        placeholder = "Search apps",
+    )
+}
+
+@Preview2
+@Composable
+private fun SearchTextFieldWithQueryPreview() = PreviewWrapper {
+    SearchTextField(
+        query = "Camera",
+        onQueryChanged = {},
+        placeholder = "Search apps",
+    )
+}

--- a/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsScreen.kt
@@ -1,6 +1,8 @@
 package eu.darken.myperm.permissions.ui.list
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
@@ -43,7 +45,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -73,6 +74,7 @@ import eu.darken.myperm.common.compose.PermissionIcon
 import eu.darken.myperm.common.compose.PermissionTagPill
 import eu.darken.myperm.common.compose.Preview2
 import eu.darken.myperm.common.compose.PreviewWrapper
+import eu.darken.myperm.common.compose.SearchTextField
 import eu.darken.myperm.common.compose.SingleChoiceSortDialog
 import eu.darken.myperm.common.compose.icon
 import androidx.compose.runtime.collectAsState
@@ -188,11 +190,11 @@ fun PermissionsScreen(
                         }
                     }
                     IconButton(onClick = {
-                        isSearchActive = !isSearchActive
-                        if (!isSearchActive) {
+                        if (isSearchActive) {
                             searchQuery = ""
                             onSearchChanged(null)
                         }
+                        isSearchActive = !isSearchActive
                     }) {
                         Icon(Icons.Filled.Search, contentDescription = stringResource(R.string.permissions_search_list_hint))
                     }
@@ -270,18 +272,18 @@ fun PermissionsScreen(
             }
 
             // Search bar
-            AnimatedVisibility(visible = isSearchActive) {
-                OutlinedTextField(
-                    value = searchQuery,
-                    onValueChange = {
+            AnimatedVisibility(
+                visible = isSearchActive,
+                enter = expandVertically(),
+                exit = shrinkVertically(),
+            ) {
+                SearchTextField(
+                    query = searchQuery,
+                    onQueryChanged = {
                         searchQuery = it
                         onSearchChanged(it.ifBlank { null })
                     },
-                    placeholder = { Text(stringResource(R.string.permissions_search_list_hint)) },
-                    singleLine = true,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 0.dp),
+                    placeholder = stringResource(R.string.permissions_search_list_hint),
                 )
             }
 

--- a/app/src/main/java/eu/darken/myperm/watcher/ui/dashboard/WatcherDashboardScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/watcher/ui/dashboard/WatcherDashboardScreen.kt
@@ -18,13 +18,11 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DoneAll
 import androidx.compose.material.icons.filled.FiberNew
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.NotificationsOff
 import androidx.compose.material.icons.filled.Refresh
@@ -42,9 +40,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -73,6 +68,7 @@ import eu.darken.myperm.apps.core.Pkg
 import eu.darken.myperm.common.compose.AppIcon
 import eu.darken.myperm.common.compose.LucideRadar
 import eu.darken.myperm.common.compose.Preview2
+import eu.darken.myperm.common.compose.SearchTextField
 import eu.darken.myperm.common.compose.PreviewWrapper
 import eu.darken.myperm.common.error.ErrorEventHandler
 import eu.darken.myperm.common.navigation.NavigationEventHandler
@@ -263,36 +259,13 @@ fun WatcherDashboardScreen(
                     enter = expandVertically(),
                     exit = shrinkVertically(),
                 ) {
-                    OutlinedTextField(
-                        value = searchQuery,
-                        onValueChange = {
+                    SearchTextField(
+                        query = searchQuery,
+                        onQueryChanged = {
                             searchQuery = it
                             onSearchChanged(it.ifBlank { null })
                         },
-                        placeholder = { Text(stringResource(R.string.watcher_search_hint)) },
-                        singleLine = true,
-                        leadingIcon = {
-                            Icon(Icons.Filled.Search, contentDescription = null)
-                        },
-                        trailingIcon = {
-                            if (searchQuery.isNotBlank()) {
-                                IconButton(onClick = {
-                                    searchQuery = ""
-                                    onSearchChanged(null)
-                                }) {
-                                    Icon(Icons.Filled.Close, contentDescription = null)
-                                }
-                            }
-                        },
-                        shape = RoundedCornerShape(50),
-                        colors = OutlinedTextFieldDefaults.colors(
-                            unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-                            focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-                        ),
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 4.dp)
-                            .height(52.dp),
+                        placeholder = stringResource(R.string.watcher_search_hint),
                     )
                 }
                 EnabledContent(


### PR DESCRIPTION
## What changed

Search bars on the apps, permissions, and watcher screens now have a polished appearance with a leading search icon, a trailing clear button (visible when text is entered), a pill shape, and a tinted background. Dismissing the search bar now consistently clears the search query on all screens, so the list is never silently filtered.

## Technical Context

- Extracted the existing styled search bar from `WatcherDashboardScreen` into a shared `SearchTextField` composable in `common/compose/` — no new design, just deduplication
- `AppsScreen` was missing `AnimatedVisibility` for the search bar and didn't clear the query on toggle-off; both are now fixed to match the other screens
- Standardized toggle-off ordering across all three screens (clear first, then flip state) for consistency
