### PR TITLE
Freemium watcher: let free users run watcher with gated features

### DIFF
--- a/app/src/main/java/eu/darken/myperm/settings/ui/watcher/WatcherSettingsScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/settings/ui/watcher/WatcherSettingsScreen.kt
@@ -131,22 +131,13 @@ fun WatcherSettingsScreen(
                 .padding(innerPadding)
                 .verticalScroll(rememberScrollState()),
         ) {
-            if (isPro) {
-                SettingsSwitchItem(
-                    icon = LucideRadar,
-                    title = stringResource(R.string.watcher_enabled_label),
-                    subtitle = stringResource(R.string.watcher_enabled_desc),
-                    checked = isWatcherEnabled,
-                    onCheckedChange = onWatcherEnabledChanged,
-                )
-            } else {
-                SettingsBaseItem(
-                    icon = Icons.TwoTone.Stars,
-                    title = stringResource(R.string.watcher_enabled_label),
-                    subtitle = stringResource(R.string.watcher_enabled_desc),
-                    onClick = onUpgrade,
-                )
-            }
+            SettingsSwitchItem(
+                icon = LucideRadar,
+                title = stringResource(R.string.watcher_enabled_label),
+                subtitle = stringResource(R.string.watcher_enabled_desc),
+                checked = isWatcherEnabled,
+                onCheckedChange = onWatcherEnabledChanged,
+            )
             SettingsDivider()
             SettingsBaseItem(
                 title = stringResource(R.string.watcher_scope_label),
@@ -164,21 +155,30 @@ fun WatcherSettingsScreen(
                 onIntervalChanged = onPollingIntervalChanged,
             )
             SettingsDivider()
-            SettingsSwitchItem(
-                icon = Icons.TwoTone.Notifications,
-                title = stringResource(R.string.watcher_settings_notifications_label),
-                subtitle = stringResource(R.string.watcher_settings_notifications_desc),
-                checked = isNotificationsEnabled,
-                onCheckedChange = onNotificationsEnabledChanged,
-            )
-            SettingsSwitchItem(
-                icon = Icons.TwoTone.Notifications,
-                title = stringResource(R.string.watcher_settings_notifications_only_gained_label),
-                subtitle = stringResource(R.string.watcher_settings_notifications_only_gained_desc),
-                checked = isNotifyOnlyOnGained,
-                onCheckedChange = onNotifyOnlyOnGainedChanged,
-                enabled = isNotificationsEnabled,
-            )
+            if (isPro) {
+                SettingsSwitchItem(
+                    icon = Icons.TwoTone.Notifications,
+                    title = stringResource(R.string.watcher_settings_notifications_label),
+                    subtitle = stringResource(R.string.watcher_settings_notifications_desc),
+                    checked = isNotificationsEnabled,
+                    onCheckedChange = onNotificationsEnabledChanged,
+                )
+                SettingsSwitchItem(
+                    icon = Icons.TwoTone.Notifications,
+                    title = stringResource(R.string.watcher_settings_notifications_only_gained_label),
+                    subtitle = stringResource(R.string.watcher_settings_notifications_only_gained_desc),
+                    checked = isNotifyOnlyOnGained,
+                    onCheckedChange = onNotifyOnlyOnGainedChanged,
+                    enabled = isNotificationsEnabled,
+                )
+            } else {
+                SettingsBaseItem(
+                    icon = Icons.TwoTone.Stars,
+                    title = stringResource(R.string.watcher_settings_notifications_pro_label),
+                    subtitle = stringResource(R.string.watcher_settings_notifications_desc),
+                    onClick = onUpgrade,
+                )
+            }
             SettingsDivider()
             SettingsBaseItem(
                 title = stringResource(R.string.watcher_settings_retention_label),

--- a/app/src/main/java/eu/darken/myperm/settings/ui/watcher/WatcherSettingsViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/settings/ui/watcher/WatcherSettingsViewModel.kt
@@ -41,10 +41,6 @@ class WatcherSettingsViewModel @Inject constructor(
     val reportCount: Flow<Int> = changeDao.getTotalCount()
 
     fun setWatcherEnabled(enabled: Boolean) = launch {
-        if (!upgradeRepo.upgradeInfo.value.isPro) {
-            navTo(Nav.Main.Upgrade)
-            return@launch
-        }
         log(TAG) { "Setting watcher enabled: $enabled" }
         generalSettings.isWatcherEnabled.value(enabled)
         watcherWorkScheduler.ensureScheduled()

--- a/app/src/main/java/eu/darken/myperm/watcher/core/WatcherDiffRunner.kt
+++ b/app/src/main/java/eu/darken/myperm/watcher/core/WatcherDiffRunner.kt
@@ -11,6 +11,7 @@ import eu.darken.myperm.common.room.entity.PermissionChangeEntity
 import eu.darken.myperm.common.room.entity.SnapshotPkgDeclaredPermEntity
 import eu.darken.myperm.common.room.entity.SnapshotPkgEntity
 import eu.darken.myperm.common.room.entity.SnapshotPkgPermEntity
+import eu.darken.myperm.common.upgrade.UpgradeRepo
 import eu.darken.myperm.settings.core.GeneralSettings
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -25,6 +26,7 @@ class WatcherDiffRunner @Inject constructor(
     private val changeDao: PermissionChangeDao,
     private val watcherNotifications: WatcherNotifications,
     private val generalSettings: GeneralSettings,
+    private val upgradeRepo: UpgradeRepo,
     private val json: Json,
 ) {
 
@@ -128,19 +130,20 @@ class WatcherDiffRunner @Inject constructor(
 
         log(TAG) { "Processing ${chain.pairs.size} new snapshot pair(s)" }
 
+        val isPro = upgradeRepo.upgradeInfo.value.isPro
         var totalReports = 0
         var totalNotified = 0
         val reportedPackages = mutableSetOf<Pair<String, Int>>()
 
         for (pair in chain.pairs) {
-            val (reports, notified) = diffSnapshotPair(pair, scope, reportedPackages)
+            val (reports, notified) = diffSnapshotPair(pair, scope, reportedPackages, isPro)
             totalReports += reports
             totalNotified += notified
             // Progressive update: advance after each pair so cancellation only re-processes the current pair
             generalSettings.lastDiffedSnapshotId.update { pair.newSnapshotId }
         }
 
-        if (totalNotified > 1) {
+        if (totalNotified > 1 && isPro) {
             watcherNotifications.postSummaryNotification(totalNotified)
         }
 
@@ -152,6 +155,7 @@ class WatcherDiffRunner @Inject constructor(
         pair: SnapshotPair,
         scope: WatcherScope,
         reportedPackages: MutableSet<Pair<String, Int>>,
+        isPro: Boolean,
     ): Pair<Int, Int> {
         var reportsCreated = 0
         var notifiedCount = 0
@@ -250,12 +254,16 @@ class WatcherDiffRunner @Inject constructor(
                 )
             )
 
-            val notified = watcherNotifications.postChangeNotification(
-                reportId = reportId,
-                appLabel = newPkg?.cachedLabel ?: oldPkg?.cachedLabel,
-                packageName = pkgName,
-                diff = diff,
-            )
+            val notified = if (isPro) {
+                watcherNotifications.postChangeNotification(
+                    reportId = reportId,
+                    appLabel = newPkg?.cachedLabel ?: oldPkg?.cachedLabel,
+                    packageName = pkgName,
+                    diff = diff,
+                )
+            } else {
+                false
+            }
 
             reportedPackages.add(key)
             reportsCreated++

--- a/app/src/main/java/eu/darken/myperm/watcher/ui/dashboard/WatcherDashboardScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/watcher/ui/dashboard/WatcherDashboardScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -132,6 +133,7 @@ fun WatcherDashboardScreenHost(vm: WatcherDashboardViewModel = hiltViewModel()) 
         onFilter = { showFilterSheet = true },
         onGrantNotificationPermission = onGrantNotificationPermission,
         onDisableNotifications = { vm.disableNotifications() },
+        onUpgrade = { vm.goToUpgrade() },
         useSettingsFallback = useSettingsFallback,
     )
 
@@ -158,6 +160,7 @@ fun WatcherDashboardScreen(
     onFilter: () -> Unit,
     onGrantNotificationPermission: () -> Unit = {},
     onDisableNotifications: () -> Unit = {},
+    onUpgrade: () -> Unit = {},
     useSettingsFallback: Boolean = false,
 ) {
     val isEnabled = state?.isWatcherEnabled ?: false
@@ -245,7 +248,6 @@ fun WatcherDashboardScreen(
                     .fillMaxSize()
                     .padding(innerPadding)
                     .padding(16.dp),
-                isPro = state?.isPro ?: false,
                 onToggle = onToggle,
             )
         } else {
@@ -272,7 +274,9 @@ fun WatcherDashboardScreen(
                     modifier = Modifier.fillMaxSize(),
                     reports = reports,
                     totalReportCount = state?.totalReportCount ?: 0,
+                    lockedReportCount = state?.lockedReportCount ?: 0,
                     onReportClicked = onReportClicked,
+                    onUpgrade = onUpgrade,
                     showNotificationPermissionCard = state?.showNotificationPermissionCard ?: false,
                     canRequestNotificationPermission = state?.canRequestNotificationPermission ?: false,
                     useSettingsFallback = useSettingsFallback,
@@ -287,7 +291,6 @@ fun WatcherDashboardScreen(
 @Composable
 private fun DisabledContent(
     modifier: Modifier = Modifier,
-    isPro: Boolean,
     onToggle: () -> Unit,
 ) {
     Column(modifier = modifier) {
@@ -323,24 +326,16 @@ private fun DisabledContent(
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSecondaryContainer,
                 )
-                if (isPro) {
-                    Text(
-                        text = stringResource(R.string.watcher_dashboard_manage_in_settings),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSecondaryContainer,
-                    )
-                }
+                Text(
+                    text = stringResource(R.string.watcher_dashboard_manage_in_settings),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
                 Button(
                     onClick = onToggle,
                     modifier = Modifier.align(Alignment.End),
                 ) {
-                    Text(
-                        text = if (isPro) {
-                            stringResource(R.string.watcher_enable_action)
-                        } else {
-                            stringResource(R.string.general_upgrade_action)
-                        }
-                    )
+                    Text(text = stringResource(R.string.watcher_enable_action))
                 }
             }
         }
@@ -352,7 +347,9 @@ private fun EnabledContent(
     modifier: Modifier = Modifier,
     reports: List<WatcherReportItem>,
     totalReportCount: Int,
+    lockedReportCount: Int = 0,
     onReportClicked: (WatcherReportItem) -> Unit,
+    onUpgrade: () -> Unit = {},
     showNotificationPermissionCard: Boolean = false,
     canRequestNotificationPermission: Boolean = false,
     useSettingsFallback: Boolean = false,
@@ -396,6 +393,15 @@ private fun EnabledContent(
                     onClick = { onReportClicked(item) },
                 )
                 HorizontalDivider()
+            }
+        }
+        if (lockedReportCount > 0) {
+            item(key = "upgrade_card") {
+                UpgradeCard(
+                    lockedReportCount = lockedReportCount,
+                    onUpgrade = onUpgrade,
+                    modifier = Modifier.padding(16.dp),
+                )
             }
         }
     }
@@ -458,6 +464,44 @@ private fun NotificationPermissionCard(
                         }
                     )
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun UpgradeCard(
+    lockedReportCount: Int,
+    onUpgrade: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        ),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = pluralStringResource(R.plurals.watcher_upgrade_card_title, lockedReportCount, lockedReportCount),
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+            Text(
+                text = stringResource(R.string.watcher_upgrade_card_body),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+            Button(
+                onClick = onUpgrade,
+                modifier = Modifier.align(Alignment.End),
+            ) {
+                Text(text = stringResource(R.string.general_upgrade_action))
             }
         }
     }

--- a/app/src/main/java/eu/darken/myperm/watcher/ui/dashboard/WatcherDashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/watcher/ui/dashboard/WatcherDashboardViewModel.kt
@@ -45,6 +45,7 @@ class WatcherDashboardViewModel @Inject constructor(
         val filterOptions: WatcherFilterOptions = WatcherFilterOptions(),
         val hasUnseen: Boolean = false,
         val totalReportCount: Int = 0,
+        val lockedReportCount: Int = 0,
     )
 
     private val notificationsAvailable = MutableStateFlow(capability.areNotificationsEnabled())
@@ -80,31 +81,32 @@ class WatcherDashboardViewModel @Inject constructor(
             .filterValues { items -> items.distinctBy { it.packageName }.size > 1 }
             .keys
 
-        val reports = filteredItems.map { item ->
+        val allReports = filteredItems.map { item ->
             item.copy(showPkgName = item.appLabel in duplicateLabels)
         }
+
+        val reports = if (!isPro && allReports.size > FREE_REPORT_LIMIT) {
+            allReports.take(FREE_REPORT_LIMIT)
+        } else {
+            allReports
+        }
+        val lockedCount = if (!isPro) (allReports.size - reports.size).coerceAtLeast(0) else 0
 
         State(
             isWatcherEnabled = isEnabled,
             isPro = isPro,
             reports = reports,
-            showNotificationPermissionCard = isEnabled && notificationsEnabled && !notifAvailable,
+            showNotificationPermissionCard = isEnabled && notificationsEnabled && !notifAvailable && isPro,
             canRequestNotificationPermission = capability.isRuntimePermissionDenied(),
             refreshPhase = phase,
             filterOptions = filterOpts,
-            hasUnseen = entities.any { !it.isSeen },
+            hasUnseen = reports.any { !it.isSeen },
             totalReportCount = allItems.size,
+            lockedReportCount = lockedCount,
         )
     }.asStateFlow(State())
 
     fun toggleWatcher() = launch {
-        val isPro = upgradeRepo.upgradeInfo.value.isPro
-        if (!isPro) {
-            log(TAG) { "Not pro, navigating to upgrade" }
-            navTo(Nav.Main.Upgrade)
-            return@launch
-        }
-
         val current = generalSettings.isWatcherEnabled.value()
         log(TAG) { "Toggling watcher: $current -> ${!current}" }
         generalSettings.isWatcherEnabled.value(!current)
@@ -112,8 +114,17 @@ class WatcherDashboardViewModel @Inject constructor(
     }
 
     fun onReportClicked(item: WatcherReportItem) = launch {
+        if (!upgradeRepo.upgradeInfo.value.isPro) {
+            log(TAG) { "Not pro, navigating to upgrade instead of detail" }
+            navTo(Nav.Main.Upgrade)
+            return@launch
+        }
         changeDao.markSeen(item.id)
         navTo(Nav.Watcher.ReportDetail(item.id))
+    }
+
+    fun goToUpgrade() {
+        navTo(Nav.Main.Upgrade)
     }
 
     fun refreshNow() = launch {
@@ -170,6 +181,7 @@ class WatcherDashboardViewModel @Inject constructor(
     }
 
     companion object {
+        private const val FREE_REPORT_LIMIT = 5
         private val TAG = logTag("Watcher", "Dashboard", "VM")
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -614,6 +614,12 @@
     <string name="watcher_filter_section_status">Status</string>
     <string name="watcher_filter_reset">Reset</string>
     <string name="watcher_reports_no_matches">No reports match your search or filters</string>
+    <plurals name="watcher_upgrade_card_title">
+        <item quantity="one">%d more report</item>
+        <item quantity="other">%d more reports</item>
+    </plurals>
+    <string name="watcher_upgrade_card_body">Upgrade to view all reports, details, and get notifications</string>
+    <string name="watcher_settings_notifications_pro_label">Notifications (Pro)</string>
 
     <string name="snapshot_sync_channel_name">Snapshot Sync</string>
     <string name="snapshot_sync_channel_description">Background app data synchronization</string>

--- a/app/src/test/java/eu/darken/myperm/watcher/core/WatcherDiffRunnerTest.kt
+++ b/app/src/test/java/eu/darken/myperm/watcher/core/WatcherDiffRunnerTest.kt
@@ -11,6 +11,7 @@ import eu.darken.myperm.common.room.entity.SnapshotPkgDeclaredPermEntity
 import eu.darken.myperm.common.room.entity.PkgType
 import eu.darken.myperm.common.room.entity.SnapshotPkgEntity
 import eu.darken.myperm.common.room.entity.SnapshotPkgPermEntity
+import eu.darken.myperm.common.upgrade.UpgradeRepo
 import eu.darken.myperm.settings.core.GeneralSettings
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
@@ -34,6 +35,7 @@ class WatcherDiffRunnerTest : BaseTest() {
     private val changeDao: PermissionChangeDao = mockk(relaxUnitFun = true)
     private val watcherNotifications: WatcherNotifications = mockk(relaxUnitFun = true)
     private val generalSettings: GeneralSettings = mockk()
+    private val upgradeRepo: UpgradeRepo = mockk()
     private val json = Json { ignoreUnknownKeys = true }
 
     private val isWatcherEnabled = mockDataStoreValue(true)
@@ -48,6 +50,13 @@ class WatcherDiffRunnerTest : BaseTest() {
         coEvery { changeDao.insert(any()) } returns 1L
         coEvery { changeDao.existsByPackageAndSnapshot(any(), any(), any()) } returns false
         coEvery { watcherNotifications.postChangeNotification(any(), any(), any(), any()) } returns true
+        every { upgradeRepo.upgradeInfo } returns kotlinx.coroutines.flow.MutableStateFlow(
+            object : UpgradeRepo.Info {
+                override val type = UpgradeRepo.Type.FOSS
+                override val isPro = true
+                override val upgradedAt = null
+            }
+        )
     }
 
     private fun createRunner() = WatcherDiffRunner(
@@ -57,6 +66,7 @@ class WatcherDiffRunnerTest : BaseTest() {
         changeDao = changeDao,
         watcherNotifications = watcherNotifications,
         generalSettings = generalSettings,
+        upgradeRepo = upgradeRepo,
         json = json,
     )
 


### PR DESCRIPTION
## Summary
- Free users can now enable the permission watcher and see real reports (capped at 5)
- Report details gated behind pro (tap navigates to upgrade screen)
- Notifications suppressed for free users
- Settings: enable switch available to all, notification settings show pro badge

## Test plan
- [ ] Install as free user, enable watcher, verify reports appear (max 5)
- [ ] Tap a report as free user, verify it navigates to upgrade
- [ ] Verify no notifications are sent for free users
- [ ] Upgrade to pro, verify full functionality (unlimited reports, details, notifications)
- [ ] Check settings screen: enable switch works for all, notification settings gated for free