### PR TITLE
General: Remove hasFragileUserData from manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,7 +15,6 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
-        android:hasFragileUserData="true"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity


### PR DESCRIPTION
## What changed

Removed the `hasFragileUserData="true"` attribute from the app manifest. Users will no longer see a "keep app data?" prompt when uninstalling. The app doesn't store user-created content that warrants preservation across uninstall.

## Technical Context

- The flag was added in 7ea6bac alongside a privacy policy update, likely as a precaution
- Permission Pilot reads system state and stores preferences/watcher snapshots — none of which are irreplaceable user data
- Removing the flag gives a cleaner uninstall experience