### PR TITLE
General: Add refresh button with progress indicator

### DIFF
--- a/app/src/main/java/eu/darken/myperm/apps/core/AppRepo.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/AppRepo.kt
@@ -21,7 +21,10 @@ import eu.darken.myperm.watcher.core.WatcherWorkScheduler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.flatMapLatest
@@ -86,6 +89,9 @@ class AppRepo @Inject constructor(
 
     // ── Sync / refresh ──────────────────────────────────────────────────
 
+    private val _isScanning = MutableStateFlow(false)
+    val isScanning: StateFlow<Boolean> = _isScanning.asStateFlow()
+
     private val refreshTrigger = MutableSharedFlow<TriggerReason>(extraBufferCapacity = 1)
 
     init {
@@ -100,10 +106,13 @@ class AppRepo @Inject constructor(
                 },
         ).onEach { reason ->
             try {
+                _isScanning.value = true
                 scanAndSave(reason)
                 enqueuePermissionWatcher()
             } catch (e: Exception) {
                 log(TAG, WARN) { "Failed to scan/save: ${e.asLog()}" }
+            } finally {
+                _isScanning.value = false
             }
         }.launchIn(appScope)
     }

--- a/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsScreen.kt
@@ -24,9 +24,11 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.shape.CircleShape
 import eu.darken.myperm.common.compose.LoadingContent
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -68,6 +70,7 @@ fun AppsScreenHost(vm: AppsViewModel = hiltViewModel()) {
     NavigationEventHandler(vm)
 
     val state by vm.state.collectAsState()
+    val isRefreshing by vm.isRefreshing.collectAsState()
     var showFilterSortSheet by rememberSaveable { mutableStateOf(false) }
     var showTagHelpDialog by rememberSaveable { mutableStateOf(false) }
 
@@ -78,6 +81,7 @@ fun AppsScreenHost(vm: AppsViewModel = hiltViewModel()) {
 
     AppsScreen(
         state = effectiveState,
+        isRefreshing = isRefreshing,
         hasActiveFilters = hasActiveFilters,
         onSearchChanged = { vm.onSearchInputChanged(it) },
         onAppClicked = { vm.onAppClicked(it) },
@@ -104,6 +108,7 @@ fun AppsScreenHost(vm: AppsViewModel = hiltViewModel()) {
 @Composable
 fun AppsScreen(
     state: AppsViewModel.State,
+    isRefreshing: Boolean = false,
     hasActiveFilters: Boolean = false,
     onSearchChanged: (String?) -> Unit,
     onAppClicked: (AppsViewModel.AppItem) -> Unit,
@@ -116,6 +121,17 @@ fun AppsScreen(
     var showOverflowMenu by rememberSaveable { mutableStateOf(false) }
 
     Scaffold(
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = { if (!isRefreshing) onRefresh() },
+            ) {
+                if (isRefreshing) {
+                    CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                } else {
+                    Icon(Icons.Filled.Refresh, contentDescription = stringResource(R.string.general_refresh_action))
+                }
+            }
+        },
         topBar = {
             TopAppBar(
                 title = {
@@ -168,11 +184,6 @@ fun AppsScreen(
                             expanded = showOverflowMenu,
                             onDismissRequest = { showOverflowMenu = false },
                         ) {
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.general_refresh_action)) },
-                                onClick = { showOverflowMenu = false; onRefresh() },
-                                leadingIcon = { Icon(Icons.Filled.Refresh, contentDescription = null) },
-                            )
                             DropdownMenuItem(
                                 text = { Text(stringResource(R.string.settings_page_label)) },
                                 onClick = { showOverflowMenu = false; onSettings() },

--- a/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsViewModel.kt
@@ -38,6 +38,8 @@ class AppsViewModel @Inject constructor(
         .map { it.isPro }
         .stateIn(vmScope, SharingStarted.Eagerly, upgradeRepo.upgradeInfo.value.isPro)
 
+    val isRefreshing: StateFlow<Boolean> = appRepo.isScanning
+
     private val searchTerm = MutableStateFlow<String?>(null)
     private val filterOptions = generalSettings.appsFilterOptions.flow
     private val sortOptions = generalSettings.appsSortOptions.flow

--- a/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewScreen.kt
@@ -26,6 +26,8 @@ import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.WifiOff
 import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -60,10 +62,12 @@ fun OverviewScreenHost(vm: OverviewViewModel = hiltViewModel()) {
     NavigationEventHandler(vm)
 
     val state by vm.state.collectAsState()
+    val isRefreshing by vm.isRefreshing.collectAsState()
 
     state?.let {
         OverviewScreen(
             state = it,
+            isRefreshing = isRefreshing,
             onRefresh = { vm.onRefresh() },
             onSettings = { vm.goToSettings() },
             onCategoryClick = { filters -> vm.onCategoryClicked(filters) },
@@ -74,11 +78,23 @@ fun OverviewScreenHost(vm: OverviewViewModel = hiltViewModel()) {
 @Composable
 fun OverviewScreen(
     state: OverviewViewModel.State,
+    isRefreshing: Boolean = false,
     onRefresh: () -> Unit,
     onSettings: () -> Unit,
     onCategoryClick: (Set<AppsFilterOptions.Filter>) -> Unit = {},
 ) {
     Scaffold(
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = { if (!isRefreshing) onRefresh() },
+            ) {
+                if (isRefreshing) {
+                    CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                } else {
+                    Icon(Icons.Filled.Refresh, contentDescription = stringResource(R.string.general_refresh_action))
+                }
+            }
+        },
         topBar = {
             TopAppBar(
                 title = {
@@ -92,9 +108,6 @@ fun OverviewScreen(
                     }
                 },
                 actions = {
-                    IconButton(onClick = onRefresh) {
-                        Icon(Icons.Filled.Refresh, contentDescription = stringResource(R.string.general_refresh_action))
-                    }
                     IconButton(onClick = onSettings) {
                         Icon(Icons.Filled.Settings, contentDescription = stringResource(R.string.settings_page_label))
                     }

--- a/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewViewModel.kt
@@ -10,6 +10,7 @@ import eu.darken.myperm.common.AndroidVersionCodes
 import eu.darken.myperm.common.BuildConfigWrap
 import eu.darken.myperm.common.BuildWrap
 import eu.darken.myperm.common.coroutine.DispatcherProvider
+import eu.darken.myperm.common.debug.logging.log
 import eu.darken.myperm.common.debug.logging.logTag
 import eu.darken.myperm.common.navigation.Nav
 import eu.darken.myperm.apps.core.AppInfo
@@ -21,6 +22,7 @@ import eu.darken.myperm.common.upgrade.UpgradeRepo
 import eu.darken.myperm.permissions.core.known.APerm
 import eu.darken.myperm.settings.core.GeneralSettings
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
@@ -79,6 +81,8 @@ class OverviewViewModel @Inject constructor(
         )
     }
 
+    val isRefreshing: StateFlow<Boolean> = appRepo.isScanning
+
     private val myUserHandleId = Process.myUserHandle().hashCode()
     private val storePkgNames = AKnownPkg.APP_STORES.map { it.id.pkgName }.toSet()
 
@@ -124,8 +128,9 @@ class OverviewViewModel @Inject constructor(
     private fun AppInfo.hasGrantedPermission(permissionId: String): Boolean =
         requestedPermissions.any { it.permissionId == permissionId && it.status.isGranted }
 
-    fun onRefresh() = launch {
-        // Trigger repo refresh via AppRepo
+    fun onRefresh() {
+        log(TAG) { "onRefresh()" }
+        appRepo.refresh()
     }
 
     fun onUpgrade() {

--- a/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsScreen.kt
@@ -34,9 +34,11 @@ import androidx.compose.material.icons.filled.UnfoldLess
 import androidx.compose.material.icons.filled.UnfoldMore
 import androidx.compose.material3.AlertDialog
 import eu.darken.myperm.common.compose.LoadingContent
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
@@ -86,6 +88,7 @@ fun PermissionsScreenHost(vm: PermissionsViewModel = hiltViewModel()) {
     NavigationEventHandler(vm)
 
     val state by vm.state.collectAsState()
+    val isRefreshing by vm.isRefreshing.collectAsState()
     var showFilterSortSheet by rememberSaveable { mutableStateOf(false) }
     var showTagHelpDialog by rememberSaveable { mutableStateOf(false) }
 
@@ -96,6 +99,7 @@ fun PermissionsScreenHost(vm: PermissionsViewModel = hiltViewModel()) {
 
     PermissionsScreen(
         state = effectiveState,
+        isRefreshing = isRefreshing,
         hasActiveFilters = hasActiveFilters,
         onSearchChanged = { vm.onSearchInputChanged(it) },
         onGroupClicked = { vm.toggleGroup(it) },
@@ -125,6 +129,7 @@ fun PermissionsScreenHost(vm: PermissionsViewModel = hiltViewModel()) {
 @Composable
 fun PermissionsScreen(
     state: PermissionsViewModel.State,
+    isRefreshing: Boolean = false,
     hasActiveFilters: Boolean = false,
     onSearchChanged: (String?) -> Unit,
     onGroupClicked: (PermissionGroup.Id) -> Unit,
@@ -140,6 +145,17 @@ fun PermissionsScreen(
     var showOverflowMenu by rememberSaveable { mutableStateOf(false) }
 
     Scaffold(
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = { if (!isRefreshing) onRefresh() },
+            ) {
+                if (isRefreshing) {
+                    CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                } else {
+                    Icon(Icons.Filled.Refresh, contentDescription = stringResource(R.string.general_refresh_action))
+                }
+            }
+        },
         topBar = {
             TopAppBar(
                 title = {
@@ -205,11 +221,6 @@ fun PermissionsScreen(
                                     leadingIcon = { Icon(Icons.Filled.UnfoldMore, contentDescription = null) },
                                 )
                             }
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.general_refresh_action)) },
-                                onClick = { showOverflowMenu = false; onRefresh() },
-                                leadingIcon = { Icon(Icons.Filled.Refresh, contentDescription = null) },
-                            )
                             DropdownMenuItem(
                                 text = { Text(stringResource(R.string.settings_page_label)) },
                                 onClick = { showOverflowMenu = false; onSettings() },

--- a/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsViewModel.kt
@@ -46,6 +46,8 @@ class PermissionsViewModel @Inject constructor(
         .map { it.isPro }
         .stateIn(vmScope, SharingStarted.Eagerly, upgradeRepo.upgradeInfo.value.isPro)
 
+    val isRefreshing: StateFlow<Boolean> = appRepo.isScanning
+
     private val searchTerm = MutableStateFlow<String?>(null)
     private val filterOptions = generalSettings.permissionsFilterOptions.flow
     private val sortOptions = generalSettings.permissionsSortOptions.flow
@@ -190,6 +192,7 @@ class PermissionsViewModel @Inject constructor(
     }
 
     fun onRefresh() {
+        log(TAG) { "onRefresh()" }
         appRepo.refresh()
     }
 


### PR DESCRIPTION
## What changed

The refresh action is now a floating button at the bottom of every main screen (Overview, Apps, Permissions) instead of being hidden in the overflow menu or toolbar. When a scan is running, the button shows a spinning indicator and ignores taps until the scan finishes. This also fixes the Overview screen where tapping refresh previously did nothing.

## Technical Context

- Adds `isScanning: StateFlow<Boolean>` to `AppRepo`, set `true`/`false` around the existing `scanAndSave()` call in a `finally` block — covers all trigger types (manual, package change, app launch, watcher)
- Each ViewModel exposes `isRefreshing` as a pass-through of `appRepo.isScanning` (separate StateFlow, not embedded in sealed State)
- FAB pattern matches the existing `WatcherDashboardScreen` implementation exactly: `CircularProgressIndicator(Modifier.size(24.dp))` when scanning, `Icons.Filled.Refresh` when idle, click guarded
- `OverviewViewModel.onRefresh()` had an empty body (`launch { // Trigger repo refresh via AppRepo }`) — now calls `appRepo.refresh()`
