### PR TITLE
Fix: Version changes require clean build to take effect

### DIFF
--- a/buildSrc/src/main/java/ProjectConfig.kt
+++ b/buildSrc/src/main/java/ProjectConfig.kt
@@ -13,16 +13,16 @@ object ProjectConfig {
     const val targetSdk = 36
 
     object Version {
-        val versionProperties = Properties().apply {
+        private val versionProperties get() = Properties().apply {
             load(FileInputStream(File("version.properties")))
         }
-        val major = versionProperties.getProperty("project.versioning.major").toInt()
-        val minor = versionProperties.getProperty("project.versioning.minor").toInt()
-        val patch = versionProperties.getProperty("project.versioning.patch").toInt()
-        val build = versionProperties.getProperty("project.versioning.build").toInt()
+        val major get() = versionProperties.getProperty("project.versioning.major").toInt()
+        val minor get() = versionProperties.getProperty("project.versioning.minor").toInt()
+        val patch get() = versionProperties.getProperty("project.versioning.patch").toInt()
+        val build get() = versionProperties.getProperty("project.versioning.build").toInt()
 
-        val name = "${major}.${minor}.${patch}-rc${build}"
-        val code = major * 10000000 + minor * 100000 + patch * 1000 + build * 10
+        val name get() = "${major}.${minor}.${patch}-rc${build}"
+        val code get() = major * 10000000 + minor * 100000 + patch * 1000 + build * 10
     }
 }
 


### PR DESCRIPTION
## What changed

Version property changes (in `version.properties`) are now picked up immediately on the next build, without needing to delete the `buildSrc/.gradle/` folder first.

## Technical Context

- `ProjectConfig.Version` used `val` (backed fields) initialized once at object creation — the Gradle daemon cached these across builds when `buildSrc` sources hadn't changed
- Changed to computed properties (`get()`) so `version.properties` is re-read each Gradle configuration phase
- The file is tiny so repeated reads during configuration have negligible cost
