### PR TITLE
General: Enable R8 code shrinking for smaller app size

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,8 +74,8 @@ android {
                 disable.add("ExtraTranslation")
                 fatal.add("StopShip")
             }
-            isMinifyEnabled = false
-            isShrinkResources = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
             proguardFiles(*customProguardRules.toList().toTypedArray())
         }
@@ -85,8 +85,8 @@ android {
                 disable.add("ExtraTranslation")
                 fatal.add("StopShip")
             }
-            isMinifyEnabled = false
-            isShrinkResources = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
             proguardFiles(*customProguardRules.toList().toTypedArray())
         }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -26,6 +26,7 @@ platform :android do
   	supply(
         track: 'beta',
         package_name: 'eu.darken.myperm',
+        mapping_paths: ['../app/build/outputs/mapping/gplayBeta/mapping.txt'],
         skip_upload_changelogs: 'false',
         skip_upload_apk: 'true',
         skip_upload_images: 'true',
@@ -40,6 +41,7 @@ platform :android do
     supply(
         track: 'beta',
         package_name: 'eu.darken.myperm',
+        mapping_paths: ['../app/build/outputs/mapping/gplayRelease/mapping.txt'],
         skip_upload_changelogs: 'false',
         skip_upload_apk: 'true',
         skip_upload_images: 'true',


### PR DESCRIPTION
## What changed

App downloads are now smaller. R8 code shrinking removes unused code and resources from beta and release builds. Obfuscation stays off since this is an open-source project.

Fastlane now uploads R8 mapping files to Play Console for accurate crash report line numbers.

## Technical Context

- Only `isMinifyEnabled` and `isShrinkResources` flipped to `true` for beta and release build types — debug stays unminified
- `-dontobfuscate` was already present in `app/proguard/proguard-rules.pro`, so class/method names remain readable in stacktraces
- Library consumer ProGuard rules (Kotlinx Serialization, Hilt, Room, Coil) are bundled with their AARs and applied automatically — no additional keep rules needed
- `mapping_paths` added to both Fastlane `supply` calls so Play Console can map line numbers accurately even though names aren't obfuscated
