### PR TITLE
Fix: All permissions showing as Other category in release builds

### DIFF
--- a/app/proguard/proguard-rules.pro
+++ b/app/proguard/proguard-rules.pro
@@ -1,1 +1,8 @@
 -dontobfuscate
+
+# Keep nested objects of sealed classes that use Kotlin reflection (::class.nestedClasses)
+# for runtime enumeration. R8 strips them as "unused" since the references are reflection-only.
+-keep class eu.darken.myperm.permissions.core.known.APerm$* { *; }
+-keep class eu.darken.myperm.permissions.core.known.APermGrp$* { *; }
+-keep class eu.darken.myperm.permissions.core.known.AExtraPerm$* { *; }
+-keep class eu.darken.myperm.apps.core.known.AKnownPkg$* { *; }


### PR DESCRIPTION
## What changed

Permission categories (Camera, Audio, Files, Location, etc.) now display correctly in release builds. Previously, enabling R8 code shrinking caused all 293 permissions to collapse into the "Other" category.

## Technical Context

- Four sealed classes (`APerm`, `APermGrp`, `AExtraPerm`, `AKnownPkg`) enumerate their nested object instances at runtime via Kotlin reflection (`::class.nestedClasses`)
- R8 strips these nested objects as "unused" because it cannot trace reflection-based references — the `@Keep` annotation on the sealed class itself does not cascade to nested classes
- Added wildcard `-keep` rules (`$*`) that automatically cover all current and future nested classes, so adding new permissions requires no ProGuard maintenance
- `AKnownPkg` (app store attribution) was also affected but failed silently
