### PR TITLE
Fix: Show retry button instead of infinite loading on scan failure

### DIFF
--- a/app/src/main/java/eu/darken/myperm/apps/core/AppRepo.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/AppRepo.kt
@@ -19,6 +19,7 @@ import eu.darken.myperm.common.room.entity.SnapshotEntity
 import eu.darken.myperm.common.room.entity.SnapshotPkgDeclaredPermEntity
 import eu.darken.myperm.common.room.entity.TriggerReason
 import eu.darken.myperm.watcher.core.WatcherWorkScheduler
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -72,7 +73,7 @@ class AppRepo @Inject constructor(
                 snapshotPkgDao.observeDeclaredPermCountsForSnapshot(snapshotId),
                 manifestHintRepo.hints,
             ) { pkgs, perms, declaredCounts, hints ->
-                if (pkgs.isEmpty()) return@combine AppDataState.NoSnapshot
+                if (pkgs.isEmpty()) return@combine AppDataState.Ready(emptyList())
                 val permsByPkg = perms.groupBy { Pair(it.pkgName, it.userHandleId) }
                 val declaredCountByPkg = declaredCounts.associateBy(
                     keySelector = { Pair(it.pkgName, it.userHandleId) },
@@ -97,6 +98,9 @@ class AppRepo @Inject constructor(
     private val _isScanning = MutableStateFlow(false)
     val isScanning: StateFlow<Boolean> = _isScanning.asStateFlow()
 
+    private val _scanError = MutableStateFlow<Throwable?>(null)
+    val scanError: StateFlow<Throwable?> = _scanError.asStateFlow()
+
     private val refreshTrigger = MutableSharedFlow<TriggerReason>(extraBufferCapacity = 1)
 
     init {
@@ -110,13 +114,31 @@ class AppRepo @Inject constructor(
                     if (index == 0) TriggerReason.APP_LAUNCH else TriggerReason.PACKAGE_CHANGE
                 },
         ).onEach { reason ->
+            _isScanning.value = true
             try {
-                _isScanning.value = true
-                scanAndSave(reason)
-                enqueuePermissionWatcher()
-                manifestHintRepo.enqueueHintScan()
-            } catch (e: Exception) {
-                log(TAG, WARN) { "Failed to scan/save: ${e.asLog()}" }
+                try {
+                    scanAndSave(reason)
+                    _scanError.value = null
+                } catch (c: CancellationException) {
+                    throw c
+                } catch (e: Exception) {
+                    log(TAG, WARN) { "Failed to scan/save: ${e.asLog()}" }
+                    _scanError.value = e
+                }
+                try {
+                    enqueuePermissionWatcher()
+                } catch (c: CancellationException) {
+                    throw c
+                } catch (e: Exception) {
+                    log(TAG, WARN) { "Watcher enqueue failed: ${e.asLog()}" }
+                }
+                try {
+                    manifestHintRepo.enqueueHintScan()
+                } catch (c: CancellationException) {
+                    throw c
+                } catch (e: Exception) {
+                    log(TAG, WARN) { "Hint scan enqueue failed: ${e.asLog()}" }
+                }
             } finally {
                 _isScanning.value = false
             }

--- a/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsScreen.kt
@@ -68,8 +68,11 @@ import coil.compose.AsyncImage
 import eu.darken.myperm.R
 import eu.darken.myperm.apps.core.Pkg
 import eu.darken.myperm.common.compose.AppIcon
+import eu.darken.myperm.common.compose.ErrorContent
 import eu.darken.myperm.common.compose.LoadingContent
 import eu.darken.myperm.common.compose.Pill
+import eu.darken.myperm.common.compose.RefreshErrorBanner
+import eu.darken.myperm.common.compose.toErrorDetail
 import eu.darken.myperm.common.compose.Preview2
 import eu.darken.myperm.common.compose.PreviewWrapper
 import eu.darken.myperm.common.compose.SearchTextField
@@ -273,18 +276,53 @@ fun AppsScreen(
                     LoadingContent()
                 }
 
+                is AppsViewModel.State.Error -> {
+                    ErrorContent(
+                        title = stringResource(R.string.general_load_error_title),
+                        detail = state.error.toErrorDetail(),
+                        onRetry = onRefresh,
+                    )
+                }
+
                 is AppsViewModel.State.Ready -> {
-                    LazyColumn(modifier = Modifier.fillMaxSize()) {
-                        items(state.items, key = { "${it.pkgName}:${it.userHandleId}" }) { item ->
-                            val isItemSelected = AppsViewModel.SelectionKey(item.pkgName, item.userHandleId) in selection
-                            AppListItem(
-                                item = item,
-                                isSelecting = isSelecting,
-                                isSelected = isItemSelected,
-                                onClick = { onAppClicked(item) },
-                                onLongClick = { onAppLongPressed(item) },
+                    Column(modifier = Modifier.fillMaxSize()) {
+                        state.refreshError?.let { error ->
+                            RefreshErrorBanner(
+                                title = stringResource(R.string.general_refresh_error_hint),
+                                detail = error.toErrorDetail(),
+                                onRetry = onRefresh,
+                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
                             )
-                            HorizontalDivider()
+                        }
+                        if (state.items.isEmpty()) {
+                            Box(
+                                modifier = Modifier.fillMaxSize(),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                Text(
+                                    text = stringResource(
+                                        if (searchQuery.isNotBlank()) R.string.apps_list_empty_search_message
+                                        else R.string.apps_list_empty_message
+                                    ),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.padding(24.dp),
+                                )
+                            }
+                        } else {
+                            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                                items(state.items, key = { "${it.pkgName}:${it.userHandleId}" }) { item ->
+                                    val isItemSelected = AppsViewModel.SelectionKey(item.pkgName, item.userHandleId) in selection
+                                    AppListItem(
+                                        item = item,
+                                        isSelecting = isSelecting,
+                                        isSelected = isItemSelected,
+                                        onClick = { onAppClicked(item) },
+                                        onLongClick = { onAppLongPressed(item) },
+                                    )
+                                    HorizontalDivider()
+                                }
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsViewModel.kt
@@ -95,18 +95,29 @@ class AppsViewModel @Inject constructor(
             val filterOptions: AppsFilterOptions = AppsFilterOptions(),
             val sortOptions: AppsSortOptions = AppsSortOptions(),
             val selection: Set<SelectionKey> = emptySet(),
+            val refreshError: Throwable? = null,
         ) : State()
+
+        data class Error(val error: Throwable) : State()
     }
 
-    val state = combine(
+    private val appDataWithLabelsAndError = combine(
         appDataWithLabels,
+        appRepo.scanError,
+    ) { appDataPair, scanError -> Triple(appDataPair.first, appDataPair.second, scanError) }
+
+    val state = combine(
+        appDataWithLabelsAndError,
         searchTerm,
         filterOptions,
         sortOptions,
         selectedItems,
-    ) { appDataPair, searchTerm, filterOptions, sortOptions, selection ->
-        val (appDataState, installerLabels) = appDataPair
-        val apps = (appDataState as? AppRepo.AppDataState.Ready)?.apps ?: return@combine State.Loading
+    ) { appDataTriple, searchTerm, filterOptions, sortOptions, selection ->
+        val (appDataState, installerLabels, scanError) = appDataTriple
+        val apps = (appDataState as? AppRepo.AppDataState.Ready)?.apps
+        if (apps == null) {
+            return@combine if (scanError != null) State.Error(scanError) else State.Loading
+        }
 
         val filtered = apps
             .filter { app -> filterOptions.matches(app) }
@@ -176,6 +187,7 @@ class AppsViewModel @Inject constructor(
             filterOptions = filterOptions,
             sortOptions = sortOptions,
             selection = selection,
+            refreshError = scanError,
         )
     }.asStateFlow()
 

--- a/app/src/main/java/eu/darken/myperm/common/compose/ErrorContent.kt
+++ b/app/src/main/java/eu/darken/myperm/common/compose/ErrorContent.kt
@@ -1,0 +1,136 @@
+package eu.darken.myperm.common.compose
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import eu.darken.myperm.R
+
+@Composable
+fun ErrorContent(
+    title: String,
+    detail: String?,
+    onRetry: (() -> Unit)?,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier.padding(24.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.ErrorOutline,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.error,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center,
+            )
+            if (!detail.isNullOrBlank()) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = detail,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                )
+            }
+            if (onRetry != null) {
+                Spacer(modifier = Modifier.height(16.dp))
+                Button(
+                    onClick = onRetry,
+                    contentPadding = PaddingValues(horizontal = 20.dp, vertical = 10.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Refresh,
+                        contentDescription = null,
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(text = stringResource(R.string.general_retry_action))
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Inline banner for refresh-after-Ready failures. State-shaped (not a snackbar) so it
+ * stays visible until the next successful scan clears it.
+ */
+@Composable
+fun RefreshErrorBanner(
+    title: String,
+    detail: String?,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.errorContainer,
+        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+        shape = RoundedCornerShape(8.dp),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.Filled.ErrorOutline,
+                contentDescription = null,
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                if (!detail.isNullOrBlank()) {
+                    Text(
+                        text = detail,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+            }
+            TextButton(onClick = onRetry) {
+                Text(text = stringResource(R.string.general_retry_action))
+            }
+        }
+    }
+}
+
+fun Throwable.toErrorDetail(): String {
+    val type = this::class.simpleName ?: "Error"
+    val msg = localizedMessage?.take(200)
+    return if (msg.isNullOrBlank()) type else "$type: $msg"
+}

--- a/app/src/main/java/eu/darken/myperm/export/ui/ExportViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/export/ui/ExportViewModel.kt
@@ -164,11 +164,24 @@ class ExportViewModel @Inject constructor(
     }
 
     private suspend fun regeneratePreview() {
+        // Abort preview if upstream data is in an Error state — otherwise we'd silently
+        // render an empty preview, which looks indistinguishable from "nothing selected".
+        val rawPermState = permissionRepo.state.first()
+        val scanError = appRepo.scanError.value
+        val appData = appRepo.appData.first()
+        if (rawPermState is PermissionRepo.State.Error ||
+            (scanError != null && appData is AppRepo.AppDataState.NoSnapshot)
+        ) {
+            log(TAG, WARN) { "Preview aborted: data source in error state" }
+            preview.value = null
+            isPreviewLoading.value = false
+            return
+        }
         isPreviewLoading.value = true
         val result = withContext(dispatcherProvider.IO) {
             runCatching {
-                val allApps = (appRepo.appData.first() as? AppRepo.AppDataState.Ready)?.apps ?: emptyList()
-                val allPerms = (permissionRepo.state.first() as? PermissionRepo.State.Ready)?.permissions ?: emptyList()
+                val allApps = (appData as? AppRepo.AppDataState.Ready)?.apps ?: emptyList()
+                val allPerms = (rawPermState as? PermissionRepo.State.Ready)?.permissions ?: emptyList()
                 val pro = isPro.value
 
                 when (val m = mode) {
@@ -259,10 +272,25 @@ class ExportViewModel @Inject constructor(
     fun onSafResult(uri: Uri?) = launch {
         if (uri == null) return@launch // User cancelled
 
+        // Block export when source data is in error; don't silently write an empty file.
+        val rawPermState = permissionRepo.state.first()
+        val scanError = appRepo.scanError.value
+        val appData = appRepo.appData.first()
+        if (rawPermState is PermissionRepo.State.Error) {
+            log(TAG, WARN) { "Export aborted: PermissionRepo in Error state" }
+            errorEvents.tryEmit(rawPermState.error)
+            return@launch
+        }
+        if (scanError != null && appData is AppRepo.AppDataState.NoSnapshot) {
+            log(TAG, WARN) { "Export aborted: initial app scan failed" }
+            errorEvents.tryEmit(scanError)
+            return@launch
+        }
+
         exportResult.value = ExportResult.InProgress
         val startMark = TimeSource.Monotonic.markNow()
 
-        val allApps = (appRepo.appData.first() as? AppRepo.AppDataState.Ready)?.apps ?: emptyList()
+        val allApps = (appData as? AppRepo.AppDataState.Ready)?.apps ?: emptyList()
         val allPerms = permissionRepo.permissions.first()
         val pro = isPro.value
 

--- a/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewScreen.kt
@@ -62,8 +62,11 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import eu.darken.myperm.R
 import eu.darken.myperm.apps.ui.list.AppsFilterOptions
+import eu.darken.myperm.common.compose.ErrorContent
 import eu.darken.myperm.common.compose.LoadingContent
 import eu.darken.myperm.common.compose.rememberFabVisibility
+import eu.darken.myperm.common.compose.toErrorDetail
+import eu.darken.myperm.common.compose.RefreshErrorBanner
 import eu.darken.myperm.common.compose.Preview2
 import eu.darken.myperm.common.compose.PreviewWrapper
 import eu.darken.myperm.common.error.ErrorEventHandler
@@ -138,22 +141,40 @@ fun OverviewScreen(
             )
         }
     ) { innerPadding ->
-        if (state.isLoading) {
-            LoadingContent(modifier = Modifier.padding(innerPadding))
-        } else {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(innerPadding)
-                    .verticalScroll(rememberScrollState())
-                    .padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                val summary = state.summaryInfo
-                val device = state.deviceInfo
-                if (summary != null) {
-                    HeroCard(summary, device)
-                    SummaryList(summary, onCategoryClick)
+        when {
+            state.scanError != null && state.summaryInfo == null -> {
+                ErrorContent(
+                    title = stringResource(R.string.general_load_error_title),
+                    detail = state.scanError.toErrorDetail(),
+                    onRetry = onRefresh,
+                    modifier = Modifier.padding(innerPadding),
+                )
+            }
+            state.isLoading -> {
+                LoadingContent(modifier = Modifier.padding(innerPadding))
+            }
+            else -> {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding)
+                        .verticalScroll(rememberScrollState())
+                        .padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    state.refreshError?.let { error ->
+                        RefreshErrorBanner(
+                            title = stringResource(R.string.general_refresh_error_hint),
+                            detail = error.toErrorDetail(),
+                            onRetry = onRefresh,
+                        )
+                    }
+                    val summary = state.summaryInfo
+                    val device = state.deviceInfo
+                    if (summary != null) {
+                        HeroCard(summary, device)
+                        SummaryList(summary, onCategoryClick)
+                    }
                 }
             }
         }

--- a/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewViewModel.kt
@@ -83,6 +83,8 @@ class OverviewViewModel @Inject constructor(
         val upgradeInfo: UpgradeRepo.Info? = null,
         val versionDesc: String = BuildConfigWrap.VERSION_DESCRIPTION,
         val isLoading: Boolean = true,
+        val scanError: Throwable? = null,
+        val refreshError: Throwable? = null,
     )
 
     private val deviceData: Flow<DeviceInfo> = flow {
@@ -108,12 +110,18 @@ class OverviewViewModel @Inject constructor(
             buildSummary(apps)
         }.onStart { emit(null) },
         upgradeRepo.upgradeInfo.map<UpgradeRepo.Info, UpgradeRepo.Info?> { it }.onStart { emit(null) },
-    ) { device, summary, upgrade ->
+        appRepo.scanError,
+    ) { device, summary, upgrade, scanError ->
+        val hasData = summary != null
         State(
             deviceInfo = device,
             summaryInfo = summary,
             upgradeInfo = upgrade,
-            isLoading = summary == null,
+            // Blocking: no data AND scan failed → error screen takes over.
+            scanError = if (!hasData) scanError else null,
+            // Non-blocking: have data AND latest refresh failed → inline banner.
+            refreshError = if (hasData) scanError else null,
+            isLoading = !hasData && scanError == null,
         )
     }.asStateFlow()
 

--- a/app/src/main/java/eu/darken/myperm/permissions/core/PermissionRepo.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/core/PermissionRepo.kt
@@ -11,6 +11,7 @@ import eu.darken.myperm.common.coroutine.AppScope
 import eu.darken.myperm.common.coroutine.DispatcherProvider
 import eu.darken.myperm.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.myperm.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.myperm.common.debug.logging.Logging.Priority.WARN
 import eu.darken.myperm.common.debug.logging.asLog
 import eu.darken.myperm.common.debug.logging.log
 import eu.darken.myperm.common.debug.logging.logTag
@@ -30,12 +31,12 @@ import eu.darken.myperm.permissions.core.features.SpecialAccess
 import eu.darken.myperm.permissions.core.known.AExtraPerm
 import eu.darken.myperm.permissions.core.known.APerm
 import eu.darken.myperm.permissions.core.known.APermGrp
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combineTransform
 import kotlinx.coroutines.flow.onStart
 import java.time.Instant
@@ -62,65 +63,78 @@ class PermissionRepo @Inject constructor(
 
     val state: Flow<State> = combineTransform(
         appRepo.appData,
-        refreshTrigger
-    ) { appDataState, _ ->
+        appRepo.scanError,
+        refreshTrigger,
+    ) { appDataState, scanError, _ ->
+        // Scan failed with no cached snapshot: cascade the error so permissions consumers
+        // see it too, instead of sitting on Loading forever.
+        if (scanError != null && appDataState is AppRepo.AppDataState.NoSnapshot) {
+            emit(State.Error(scanError))
+            return@combineTransform
+        }
+
         emit(State.Loading())
 
         val apps = (appDataState as? AppRepo.AppDataState.Ready)?.apps ?: return@combineTransform
 
-        val start = System.currentTimeMillis()
+        try {
+            val start = System.currentTimeMillis()
 
-        // Build indexes from cached app data
-        val permToApps = buildPermToAppsIndex(apps)
+            // Build indexes from cached app data
+            val permToApps = buildPermToAppsIndex(apps)
 
-        // Build declaring apps index from DB
-        val declaredPermToApps = buildDeclaredPermToAppsIndex(apps)
+            // Build declaring apps index from DB
+            val declaredPermToApps = buildDeclaredPermToAppsIndex(apps)
 
-        val mappedPermissions = mutableSetOf<BasePermission>()
+            val mappedPermissions = mutableSetOf<BasePermission>()
 
-        val fromAosp = measureTimedValue {
-            getPermissionsAOSP(permToApps, declaredPermToApps)
-        }.let {
-            log(TAG) { "Perf: ${it.value.size} permissions from AOSP in ${it.duration.inWholeMilliseconds}ms" }
-            it.value
+            val fromAosp = measureTimedValue {
+                getPermissionsAOSP(permToApps, declaredPermToApps)
+            }.let {
+                log(TAG) { "Perf: ${it.value.size} permissions from AOSP in ${it.duration.inWholeMilliseconds}ms" }
+                it.value
+            }
+            mappedPermissions.addAll(fromAosp)
+
+            val aospIds = fromAosp.map { it.id }.toSet()
+
+            val declared = measureTimedValue {
+                getPermissionsDeclared(permToApps, declaredPermToApps, aospIds)
+            }.let {
+                log(TAG) { "Perf: ${it.value.size} permissions declared by apps in ${it.duration.inWholeMilliseconds}ms" }
+                it.value
+            }
+            mappedPermissions.addAll(declared)
+
+            val extra = measureTimedValue {
+                getPermissionsExtra(permToApps)
+            }.let {
+                log(TAG) { "Perf: ${it.value.size} extra permissions in ${it.duration.inWholeMilliseconds}ms" }
+                it.value
+            }
+            mappedPermissions.addAll(extra)
+
+            val undeclared = measureTimedValue {
+                getUndeclaredPermissions(permToApps, declaredPermToApps, mappedPermissions)
+            }.let {
+                log(TAG) { "Perf: ${it.value.size} undeclared permissions in ${it.duration.inWholeMilliseconds}ms" }
+                it.value
+            }
+            mappedPermissions.addAll(undeclared)
+
+            val stop = System.currentTimeMillis()
+            log(TAG) { "Perf: Total permissions: ${mappedPermissions.size} in ${stop - start}ms" }
+
+            emit(State.Ready(permissions = mappedPermissions))
+        } catch (c: CancellationException) {
+            throw c
+        } catch (e: Exception) {
+            // Handle inside the transform so the flow stays alive; an outer .catch would
+            // complete the shared upstream and later refresh() calls couldn't re-run.
+            log(TAG, ERROR) { "Failed to generate permission data: ${e.asLog()}" }
+            emit(State.Error(e))
         }
-        mappedPermissions.addAll(fromAosp)
-
-        val aospIds = fromAosp.map { it.id }.toSet()
-
-        val declared = measureTimedValue {
-            getPermissionsDeclared(permToApps, declaredPermToApps, aospIds)
-        }.let {
-            log(TAG) { "Perf: ${it.value.size} permissions declared by apps in ${it.duration.inWholeMilliseconds}ms" }
-            it.value
-        }
-        mappedPermissions.addAll(declared)
-
-        val extra = measureTimedValue {
-            getPermissionsExtra(permToApps)
-        }.let {
-            log(TAG) { "Perf: ${it.value.size} extra permissions in ${it.duration.inWholeMilliseconds}ms" }
-            it.value
-        }
-        mappedPermissions.addAll(extra)
-
-        val undeclared = measureTimedValue {
-            getUndeclaredPermissions(permToApps, declaredPermToApps, mappedPermissions)
-        }.let {
-            log(TAG) { "Perf: ${it.value.size} undeclared permissions in ${it.duration.inWholeMilliseconds}ms" }
-            it.value
-        }
-        mappedPermissions.addAll(undeclared)
-
-        val stop = System.currentTimeMillis()
-        log(TAG) { "Perf: Total permissions: ${mappedPermissions.size} in ${stop - start}ms" }
-
-        emit(State.Ready(permissions = mappedPermissions))
     }
-        .catch {
-            log(TAG, ERROR) { "Failed to generate permission data: ${it.asLog()}" }
-            throw it
-        }
         .onStart { emit(State.Loading()) }
         .shareLatest(scope = appScope, started = SharingStarted.Lazily)
 
@@ -171,14 +185,20 @@ class PermissionRepo @Inject constructor(
         permToApps: Map<String, List<PermissionAppRef>>,
         declaredPermToApps: Map<String, List<PermissionAppRef>>,
     ): Collection<BasePermission> {
-        return (ipcFunnel.packageManager.getAllPermissionGroups(0) + listOf(null))
+        // getAllPermissionGroups is the platform-level query. A failure here means we
+        // can't enumerate system permissions reliably — bubble it up so the caller
+        // emits State.Error rather than returning silently-partial data.
+        val groups = ipcFunnel.packageManager.getAllPermissionGroups(0) + listOf(null)
+        return groups
             .mapNotNull { permissionGroup ->
                 val name = permissionGroup?.name
                 log(TAG, VERBOSE) { "Querying permission group $name" }
                 try {
                     ipcFunnel.packageManager.queryPermissionsByGroup(name, 0)
-                } catch (e: PackageManager.NameNotFoundException) {
-                    log(TAG) { "Failed to retrieve permission group $permissionGroup: $e" }
+                } catch (c: CancellationException) {
+                    throw c
+                } catch (e: Exception) {
+                    log(TAG, WARN) { "Failed to retrieve permission group $permissionGroup: ${e.asLog()}" }
                     null
                 }
             }
@@ -195,14 +215,19 @@ class PermissionRepo @Inject constructor(
         declaredPermToApps.keys
             .filter { Permission.Id(it) !in aospIds }
             .map { permId ->
-                val permInfo = ipcFunnel.packageManager.getPermissionInfo2(
-                    Permission.Id(permId),
-                    PackageManager.GET_META_DATA,
-                )
+                val id = Permission.Id(permId)
+                val permInfo = try {
+                    ipcFunnel.packageManager.getPermissionInfo2(id, PackageManager.GET_META_DATA)
+                } catch (c: CancellationException) {
+                    throw c
+                } catch (e: Exception) {
+                    log(TAG, WARN) { "getPermissionInfo2 failed for $id: ${e.asLog()}" }
+                    null
+                }
                 if (permInfo != null) {
                     permInfo.toDeclaredPermission(permToApps, declaredPermToApps)
                 } else {
-                    Permission.Id(permId).toUnusedPermission(permToApps)
+                    id.toUnusedPermission(permToApps)
                 }
             }
             .distinctBy { it.id }
@@ -240,7 +265,14 @@ class PermissionRepo @Inject constructor(
             .map { Permission.Id(it) }
             .filter { it !in mappedIds }
             .map { id ->
-                val info = ipcFunnel.packageManager.getPermissionInfo2(id, PackageManager.GET_META_DATA)
+                val info = try {
+                    ipcFunnel.packageManager.getPermissionInfo2(id, PackageManager.GET_META_DATA)
+                } catch (c: CancellationException) {
+                    throw c
+                } catch (e: Exception) {
+                    log(TAG, WARN) { "getPermissionInfo2 failed for $id: ${e.asLog()}" }
+                    null
+                }
                 when {
                     info != null -> info.toDeclaredPermission(permToApps, declaredPermToApps)
                     else -> id.toUnusedPermission(permToApps)
@@ -302,6 +334,11 @@ class PermissionRepo @Inject constructor(
         data class Ready(
             val updatedAt: Instant = Instant.now(),
             val permissions: Collection<BasePermission>,
+        ) : State()
+
+        data class Error(
+            val error: Throwable,
+            val at: Instant = Instant.now(),
         ) : State()
     }
 

--- a/app/src/main/java/eu/darken/myperm/permissions/core/PermissionRepoExtensions.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/core/PermissionRepoExtensions.kt
@@ -1,9 +1,32 @@
 package eu.darken.myperm.permissions.core
 
+import eu.darken.myperm.common.debug.logging.Logging.Priority.WARN
+import eu.darken.myperm.common.debug.logging.asLog
+import eu.darken.myperm.common.debug.logging.log
+import eu.darken.myperm.common.debug.logging.logTag
 import eu.darken.myperm.permissions.core.container.BasePermission
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filterIsInstance
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
 
+private val TAG = logTag("Permissions", "Repo", "Ext")
+
+/**
+ * Permissions as a flat flow.
+ *
+ * On [PermissionRepo.State.Error] we emit [emptyList] (and log) rather than letting the
+ * flow stall — callers would otherwise hang on `.first()` / `combine` indefinitely.
+ * Loading is skipped (no emission), preserving the pre-existing "wait for Ready" semantics
+ * across refreshes. The full error surface lives on the repo's [PermissionRepo.state]
+ * flow for callers that need to distinguish error from empty.
+ */
 val PermissionRepo.permissions: Flow<Collection<BasePermission>>
-    get() = state.filterIsInstance<PermissionRepo.State.Ready>().map { it.permissions }
+    get() = state.mapNotNull { state ->
+        when (state) {
+            is PermissionRepo.State.Ready -> state.permissions
+            is PermissionRepo.State.Error -> {
+                log(TAG, WARN) { "permissions flow: upstream in Error, emitting empty. ${state.error.asLog()}" }
+                emptyList()
+            }
+            is PermissionRepo.State.Loading -> null
+        }
+    }

--- a/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsScreen.kt
@@ -45,7 +45,10 @@ import androidx.compose.material3.Checkbox
 import androidx.compose.material3.TriStateCheckbox
 import androidx.compose.ui.state.ToggleableState
 import androidx.compose.material3.AlertDialog
+import eu.darken.myperm.common.compose.ErrorContent
 import eu.darken.myperm.common.compose.LoadingContent
+import eu.darken.myperm.common.compose.RefreshErrorBanner
+import eu.darken.myperm.common.compose.toErrorDetail
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -313,7 +316,23 @@ fun PermissionsScreen(
                     LoadingContent()
                 }
 
+                is PermissionsViewModel.State.Error -> {
+                    ErrorContent(
+                        title = stringResource(R.string.general_load_error_title),
+                        detail = state.error.toErrorDetail(),
+                        onRetry = onRefresh,
+                    )
+                }
+
                 is PermissionsViewModel.State.Ready -> {
+                    state.refreshError?.let { error ->
+                        RefreshErrorBanner(
+                            title = stringResource(R.string.general_refresh_error_hint),
+                            detail = error.toErrorDetail(),
+                            onRetry = onRefresh,
+                            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                        )
+                    }
                     if (state.listData.isEmpty()) {
                         Box(
                             modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsViewModel.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
@@ -55,12 +56,27 @@ class PermissionsViewModel @Inject constructor(
     private val expandedGroups = MutableStateFlow(mapOf<PermissionGroup.Id, Boolean>())
     private val selectedPermissions = MutableStateFlow<Set<Permission.Id>>(emptySet())
 
-    private val permDataWithLabels = permissionRepo.state.map { state ->
-        val perms = (state as? PermissionRepo.State.Ready)?.permissions
-        if (perms == null) {
-            state to emptyMap()
+    private data class RepoSnapshot(
+        val current: PermissionRepo.State,
+        val lastReady: PermissionRepo.State.Ready?,
+    )
+
+    // Preserve the last Ready state across intermediate Loading/Error emissions so that the
+    // UI doesn't blank back to a spinner on every refresh. Applied only to the repo stream
+    // (before combining with search/filter/selection) so those inputs stay live.
+    private val repoSnapshots = permissionRepo.state.scan(
+        RepoSnapshot(PermissionRepo.State.Loading(), null)
+    ) { acc, next ->
+        val lastReady = if (next is PermissionRepo.State.Ready) next else acc.lastReady
+        RepoSnapshot(next, lastReady)
+    }
+
+    private val permDataWithLabels = repoSnapshots.map { snap ->
+        val ready = snap.lastReady
+        if (ready == null) {
+            snap to emptyMap()
         } else {
-            state to perms.associate { it.id to it.getLabel(context) }
+            snap to ready.permissions.associate { it.id to it.getLabel(context) }
         }
     }
 
@@ -94,7 +110,10 @@ class PermissionsViewModel @Inject constructor(
             val sortOptions: PermsSortOptions = PermsSortOptions(),
             val selection: Set<Permission.Id> = emptySet(),
             val groupPerms: Map<PermissionGroup.Id, List<Permission.Id>> = emptyMap(),
+            val refreshError: Throwable? = null,
         ) : State()
+
+        data class Error(val error: Throwable) : State()
     }
 
     val state = combine(
@@ -105,9 +124,17 @@ class PermissionsViewModel @Inject constructor(
         combine(sortOptions, selectedPermissions) { s, sel -> s to sel },
     ) { permDataPair, expGroups, searchTerm, filterOptions, sortAndSel ->
         val (sortOptions, selection) = sortAndSel
-        val (permissionRepoState, permLabelMap) = permDataPair
-        val permissions = (permissionRepoState as? PermissionRepo.State.Ready)?.permissions
-            ?: return@combine State.Loading
+        val (snap, permLabelMap) = permDataPair
+        val ready = snap.lastReady
+        if (ready == null) {
+            // No prior Ready — surface Error blockingly, else stay Loading.
+            return@combine when (val c = snap.current) {
+                is PermissionRepo.State.Error -> State.Error(c.error)
+                else -> State.Loading
+            }
+        }
+        val permissions = ready.permissions
+        val refreshError = (snap.current as? PermissionRepo.State.Error)?.error
 
         val filtered = permissions
             .filter { perm -> filterOptions.matches(perm) }
@@ -196,6 +223,7 @@ class PermissionsViewModel @Inject constructor(
             sortOptions = sortOptions,
             selection = selection,
             groupPerms = groupPermsMap,
+            refreshError = refreshError,
         )
     }.asStateFlow()
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,10 @@
     <string name="label_help">Help</string>
 
     <string name="general_error_label">Error</string>
+    <string name="general_load_error_title">Couldn\'t load data</string>
+    <string name="general_load_error_hint">Something went wrong while scanning your installed apps.</string>
+    <string name="general_refresh_error_hint">Refresh failed.</string>
+    <string name="general_retry_action">Retry</string>
 
     <string name="general_share_action">Share</string>
     <string name="general_done_action">Done</string>
@@ -151,6 +155,8 @@
     <string name="apps_list_updated_label">Updated %1$s</string>
     <string name="apps_list_installer_sideloaded_label">Manually installed</string>
     <string name="apps_list_installer_preinstalled_label">Pre-installed</string>
+    <string name="apps_list_empty_message">No apps to show.</string>
+    <string name="apps_list_empty_search_message">No apps match your search.</string>
     <string name="general_refresh_action">Refresh</string>
     <string name="general_expand_all_action">Expand all</string>
     <string name="general_collapse_all_action">Collapse all</string>

--- a/app/src/test/java/eu/darken/myperm/apps/core/AppRepoTest.kt
+++ b/app/src/test/java/eu/darken/myperm/apps/core/AppRepoTest.kt
@@ -9,7 +9,9 @@ import eu.darken.myperm.apps.core.manifest.ManifestHintRepo
 import eu.darken.myperm.common.room.PermPilotDatabase
 import eu.darken.myperm.common.room.dao.SnapshotDao
 import eu.darken.myperm.common.room.dao.SnapshotPkgDao
-import kotlinx.coroutines.flow.flowOf
+import eu.darken.myperm.apps.core.manifest.ManifestHintEntity
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.every
@@ -19,6 +21,9 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import org.junit.jupiter.api.BeforeEach
@@ -104,5 +109,67 @@ class AppRepoTest : BaseTest() {
                 any<OneTimeWorkRequest>(),
             )
         }
+    }
+
+    @Test
+    fun `initial scan failure sets scanError`() = runTest2(autoCancel = true) {
+        val scanFailure = RuntimeException("simulated scan failure")
+        coEvery { appSourcer.scanPackages() } throws scanFailure
+
+        val repo = createAppRepo(this)
+        advanceTimeBy(100)
+
+        repo.scanError.value shouldBe scanFailure
+        repo.isScanning.value shouldBe false
+    }
+
+    @Test
+    fun `watcher enqueue failure does not set scanError`() = runTest2(autoCancel = true) {
+        // Scan succeeds, but the watcher enqueue step throws. scanError must stay null —
+        // only scanAndSave() failures count.
+        coEvery { appSourcer.scanPackages() } returns emptyList()
+        every { workManager.enqueueUniqueWork(any<String>(), any<ExistingWorkPolicy>(), any<OneTimeWorkRequest>()) } throws
+                IllegalStateException("watcher enqueue blew up")
+
+        val repo = createAppRepo(this)
+        advanceTimeBy(100)
+
+        repo.scanError.value shouldBe null
+        repo.isScanning.value shouldBe false
+    }
+
+    @Test
+    fun `successful scan after failure clears scanError`() = runTest2(autoCancel = true) {
+        val failure = RuntimeException("first scan boom")
+        var callCount = 0
+        coEvery { appSourcer.scanPackages() } answers {
+            callCount++
+            if (callCount == 1) throw failure else emptyList()
+        }
+
+        val repo = createAppRepo(this)
+        advanceTimeBy(100)
+        repo.scanError.value shouldBe failure
+
+        repo.refresh()
+        advanceTimeBy(100)
+        repo.scanError.value shouldBe null
+    }
+
+    @Test
+    fun `appData emits Ready(empty) when snapshot exists with zero pkgs`() = runTest2(autoCancel = true) {
+        // Locks in the §6 fix: an empty snapshot is a completed scan, not an un-loaded state.
+        // Previously this path emitted NoSnapshot and the UI showed "infinite loading".
+        every { snapshotDao.observeLatestSnapshotId() } returns flowOf("snap-1")
+        every { snapshotPkgDao.observePkgsForSnapshot("snap-1") } returns flowOf(emptyList())
+        every { snapshotPkgDao.observePermsForSnapshot("snap-1") } returns flowOf(emptyList())
+        every { snapshotPkgDao.observeDeclaredPermCountsForSnapshot("snap-1") } returns flowOf(emptyList())
+        every { manifestHintRepo.hints } returns MutableStateFlow(emptyMap<Pkg.Name, ManifestHintEntity>())
+
+        val repo = createAppRepo(this)
+
+        val state = repo.appData.first()
+        state.shouldBeInstanceOf<AppRepo.AppDataState.Ready>()
+        state.apps shouldBe emptyList()
     }
 }

--- a/app/src/test/java/eu/darken/myperm/permissions/core/PermissionRepoExtensionsTest.kt
+++ b/app/src/test/java/eu/darken/myperm/permissions/core/PermissionRepoExtensionsTest.kt
@@ -1,0 +1,60 @@
+package eu.darken.myperm.permissions.core
+
+import eu.darken.myperm.permissions.core.container.BasePermission
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelper.BaseTest
+
+class PermissionRepoExtensionsTest : BaseTest() {
+
+    @Test
+    fun `permissions flow emits Ready permissions unchanged`() = runTest {
+        val repo: PermissionRepo = mockk()
+        val permission: BasePermission = mockk()
+        every { repo.state } returns flowOf(
+            PermissionRepo.State.Ready(permissions = listOf(permission)),
+        )
+
+        val emissions = repo.permissions.toList()
+
+        emissions shouldBe listOf(listOf(permission))
+    }
+
+    @Test
+    fun `permissions flow emits emptyList on Error (does not hang)`() = runTest {
+        // Guards downstream consumers (AppDetails, PermissionDetails, Export, IconFetcher)
+        // from hanging on .first() / combine when the upstream is in an Error state.
+        val repo: PermissionRepo = mockk()
+        every { repo.state } returns flowOf(
+            PermissionRepo.State.Error(error = RuntimeException("boom")),
+        )
+
+        val emissions = repo.permissions.toList()
+
+        emissions shouldBe listOf(emptyList())
+    }
+
+    @Test
+    fun `permissions flow skips Loading emissions (preserves pre-existing wait-for-Ready semantics)`() = runTest {
+        val repo: PermissionRepo = mockk()
+        val permission: BasePermission = mockk()
+        every { repo.state } returns flowOf(
+            PermissionRepo.State.Loading(),
+            PermissionRepo.State.Ready(permissions = listOf(permission)),
+            PermissionRepo.State.Loading(),
+            PermissionRepo.State.Ready(permissions = listOf(permission, mockk())),
+        )
+
+        val emissions = repo.permissions.toList()
+
+        // Loading emissions are skipped; Ready emissions pass through.
+        emissions.size shouldBe 2
+        emissions[0] shouldBe listOf(permission)
+        emissions[1].size shouldBe 2
+    }
+}

--- a/app/src/test/java/eu/darken/myperm/permissions/core/PermissionRepoTest.kt
+++ b/app/src/test/java/eu/darken/myperm/permissions/core/PermissionRepoTest.kt
@@ -1,0 +1,57 @@
+package eu.darken.myperm.permissions.core
+
+import eu.darken.myperm.apps.core.AppRepo
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.TestScope
+import org.junit.jupiter.api.Test
+import testhelper.BaseTest
+import testhelper.coroutine.TestDispatcherProvider
+import testhelper.coroutine.runTest2
+
+class PermissionRepoTest : BaseTest() {
+
+    private fun createRepo(scope: TestScope, appRepo: AppRepo): PermissionRepo = PermissionRepo(
+        context = mockk(relaxed = true),
+        appScope = scope,
+        dispatcherProvider = TestDispatcherProvider(),
+        appRepo = appRepo,
+        ipcFunnel = mockk(relaxed = true),
+    )
+
+    @Test
+    fun `scanError with NoSnapshot emits State Error (cascades AppRepo failure)`() = runTest2(autoCancel = true) {
+        // This is the central bug fix: a failed initial scan must reach PermissionRepo
+        // consumers as State.Error, not as perpetual Loading. The flow emits Loading first
+        // via onStart, then Error from the combineTransform — we skip the initial Loading.
+        val appRepo: AppRepo = mockk()
+        val scanFailure = RuntimeException("scan boom")
+        every { appRepo.appData } returns flowOf(AppRepo.AppDataState.NoSnapshot)
+        every { appRepo.scanError } returns MutableStateFlow(scanFailure)
+
+        val repo = createRepo(this, appRepo)
+        val errorState = repo.state.filter { it !is PermissionRepo.State.Loading }.first()
+
+        errorState.shouldBeInstanceOf<PermissionRepo.State.Error>()
+    }
+
+    @Test
+    fun `no scanError with NoSnapshot stays in Loading (scan still running)`() = runTest2(autoCancel = true) {
+        val appRepo: AppRepo = mockk()
+        every { appRepo.appData } returns flowOf(AppRepo.AppDataState.NoSnapshot)
+        every { appRepo.scanError } returns MutableStateFlow(null)
+
+        val repo = createRepo(this, appRepo)
+        // With no data and no error, the stream only emits Loading — no Ready, no Error.
+        // Take the first two emissions and assert both are Loading.
+        val emissions = repo.state.take(2).toList()
+        emissions.forEach { it.shouldBeInstanceOf<PermissionRepo.State.Loading>() }
+    }
+}


### PR DESCRIPTION
## What changed

When something went wrong while loading app or permission data, the main
screens (Overview, Apps, Permissions) could get stuck on the loading spinner
forever with no error message. Now you see a clear error with a Retry button.
When a refresh fails after data has already loaded, the existing data stays
visible and a small banner at the top lets you retry.

## Technical Context

**Root cause** — three independent paths all produced the same silent spinner:
- `AppRepo.init()` swallowed scan failures (WARN-logged, but RELEASE builds
  don't persist WARN unless the user is recording). No snapshot saved →
  `appData` stays on `NoSnapshot` forever.
- `PermissionRepo.state` used an outer `.catch { throw }` on a `shareLatest`-
  shared flow, which completes the upstream on any exception — subsequent
  `refresh()` calls couldn't re-run it. The root `getAllPermissionGroups()`
  call was unguarded, so any OEM binder error hit this path.
- All three main screens rendered `LoadingContent()` for `State.Loading` with
  no error branch, no retry, and no empty state.

**Approach**
- `AppRepo` now exposes `scanError: StateFlow<Throwable?>`, populated only
  from `scanAndSave()` failures. Watcher/hint scheduling failures are tracked
  separately so they don't masquerade as scan failures.
- `PermissionRepo.state` observes `scanError` and cascades it as `State.Error`
  when there's no cached snapshot. Aggregation errors are caught inside the
  `combineTransform` lambda (not via an outer operator) so the shared flow
  stays alive and retry works. `CancellationException` is rethrown.
- Blocking `ErrorContent` only when there's no cached data; otherwise keep
  showing last data with an inline banner.
- A `scan { }` operator preserves the last `Ready` repo state through
  intermediate `Loading`/`Error` emissions — refresh doesn't blank the UI.
- `AppRepo.appData` no longer emits `NoSnapshot` for an empty scan result
  (`pkgs.isEmpty() → Ready(emptyList())`).
- `PermissionRepoExtensions.permissions` maps `Error → emptyList` (with log)
  so `AppDetailsViewModel`, `PermissionDetailsViewModel`, and
  `UsesPermissionIconFetcher` don't hang on `.first()`. `ExportViewModel`
  reads the raw state and aborts on Error so export doesn't silently emit
  empty.

**Review guidance**
- The outer `.catch` removal from `PermissionRepo.state` is the key
  correctness fix — an outer `.catch` on a `shareLatest`-shared flow
  completes the upstream permanently.
- `PermissionsViewModel` uses a `RepoSnapshot(current, lastReady)` pattern —
  the `scan` is applied to the repo stream BEFORE combining with
  search/filter/selection so those stay responsive during refresh.
- Tests cover `scanError` cascade, zero-packages → `Ready(empty)`, watcher
  failure not counted as `scanError`, and `Error → emptyList` in the
  extension.

Closes #349
