### PR TITLE
Permissions: Add 'Open settings' button for special permissions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -107,6 +107,7 @@ android {
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
+            isReturnDefaultValues = true
         }
     }
 

--- a/app/src/debug/java/eu/darken/myperm/screenshots/ScreenshotContent.kt
+++ b/app/src/debug/java/eu/darken/myperm/screenshots/ScreenshotContent.kt
@@ -141,6 +141,7 @@ internal fun PermissionDetailsContent() = PreviewWrapper {
         onFilterClicked = {},
         onPermissionHelpClicked = {},
         onStatusHelpClicked = {},
+        onOpenSettingsClicked = {},
     )
 }
 

--- a/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsEvents.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsEvents.kt
@@ -1,10 +1,8 @@
 package eu.darken.myperm.apps.ui.details
 
 import eu.darken.myperm.apps.core.Pkg
-import eu.darken.myperm.permissions.core.features.PermissionAction
 
 sealed class AppDetailsEvents {
     data class ShowAppSystemDetails(val pkg: Pkg) : AppDetailsEvents()
-    data class PermissionEvent(val permAction: PermissionAction) : AppDetailsEvents()
     data class ShowFilterDialog(val options: AppDetailsFilterOptions) : AppDetailsEvents()
 }

--- a/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
@@ -63,6 +64,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import android.widget.Toast
 import eu.darken.myperm.R
 import eu.darken.myperm.apps.core.Pkg
 import eu.darken.myperm.apps.core.features.UsesPermission
@@ -75,13 +77,22 @@ import eu.darken.myperm.common.compose.LabeledOption
 import eu.darken.myperm.common.compose.MultiChoiceFilterDialog
 import eu.darken.myperm.common.compose.Preview2
 import eu.darken.myperm.common.compose.PreviewWrapper
+import eu.darken.myperm.common.compose.findActivity
 import androidx.compose.runtime.collectAsState
+import eu.darken.myperm.common.debug.logging.Logging.Priority.WARN
+import eu.darken.myperm.common.debug.logging.asLog
+import eu.darken.myperm.common.debug.logging.log
+import eu.darken.myperm.common.debug.logging.logTag
 import eu.darken.myperm.common.error.ErrorEventHandler
 import eu.darken.myperm.common.navigation.Nav
 import eu.darken.myperm.common.navigation.NavigationEventHandler
+import eu.darken.myperm.permissions.core.Permission
+import eu.darken.myperm.permissions.core.features.PermissionAction
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
+
+private val TAG = logTag("AppDetails", "Screen")
 
 @Composable
 fun AppDetailsScreenHost(
@@ -94,6 +105,7 @@ fun AppDetailsScreenHost(
     NavigationEventHandler(vm)
 
     val state by vm.state.collectAsState()
+    val context = LocalContext.current
 
     val effectiveState = state ?: AppDetailsViewModel.State(
         label = route.appLabel ?: route.pkgName,
@@ -115,6 +127,18 @@ fun AppDetailsScreenHost(
         },
         onInstallerClicked = { vm.onInstallerClicked(it) },
         onManifestClicked = { vm.onManifestClicked() },
+        onOpenPermissionSettings = { permId ->
+            val pkg = effectiveState.pkg
+            val activity = context.findActivity()
+            val launched = activity?.let { act ->
+                runCatching { PermissionAction.launchSettings(act, permId, pkg) }
+                    .onFailure { err -> log(TAG, WARN) { "launchSettings failed: ${err.asLog()}" } }
+                    .isSuccess
+            } ?: false
+            if (!launched) {
+                Toast.makeText(context, R.string.permissions_details_open_settings_error, Toast.LENGTH_SHORT).show()
+            }
+        },
     )
 }
 
@@ -131,6 +155,7 @@ fun AppDetailsScreen(
     onFilter: (Set<AppDetailsFilterOptions.Filter>) -> Unit,
     onInstallerClicked: (Pkg.Name) -> Unit,
     onManifestClicked: () -> Unit = {},
+    onOpenPermissionSettings: (Permission.Id) -> Unit = {},
 ) {
     var showFilterDialog by rememberSaveable { mutableStateOf(false) }
     var showPermHelpDialog by rememberSaveable { mutableStateOf(false) }
@@ -413,6 +438,7 @@ fun AppDetailsScreen(
                     PermissionRow(
                         item = perm,
                         onClick = { onPermClicked(perm) },
+                        onOpenSettings = { onOpenPermissionSettings(perm.permId) },
                     )
                     HorizontalDivider(
                         modifier = Modifier.padding(start = PermRowHPadding + PermRowIconSize + PermRowIconGap),
@@ -763,7 +789,9 @@ private val PermRowIconGap = 8.dp
 private fun PermissionRow(
     item: AppDetailsViewModel.PermItem,
     onClick: () -> Unit,
+    onOpenSettings: () -> Unit = {},
 ) {
+    val canOpenSettings = PermissionAction.canLaunchSettings(item.permId)
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -830,6 +858,24 @@ private fun PermissionRow(
                             .semantics { contentDescription = declaredDesc },
                     )
                 }
+            }
+        }
+
+        if (canOpenSettings) {
+            val labelForA11y = item.permLabel ?: item.permId.value
+            IconButton(
+                onClick = onOpenSettings,
+                modifier = Modifier.size(32.dp),
+            ) {
+                Icon(
+                    Icons.Filled.Settings,
+                    contentDescription = stringResource(
+                        R.string.permissions_details_open_settings_content_description_x,
+                        labelForA11y,
+                    ),
+                    modifier = Modifier.size(18.dp),
+                    tint = MaterialTheme.colorScheme.primary,
+                )
             }
         }
     }

--- a/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsEvents.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsEvents.kt
@@ -2,7 +2,6 @@ package eu.darken.myperm.apps.ui.list
 
 import eu.darken.myperm.apps.core.Pkg
 import eu.darken.myperm.permissions.core.Permission
-import eu.darken.myperm.permissions.core.features.PermissionAction
 
 sealed class AppsEvents {
     data class ShowFilterDialog(val options: AppsFilterOptions) : AppsEvents()
@@ -12,6 +11,4 @@ sealed class AppsEvents {
     data class ShowPermissionSnackbar(val permission: Permission) : AppsEvents()
 
     data class ShowAppSystemDetails(val pkg: Pkg) : AppsEvents()
-
-    data class PermissionEvent(val permAction: PermissionAction) : AppsEvents()
 }

--- a/app/src/main/java/eu/darken/myperm/common/compose/ContextExt.kt
+++ b/app/src/main/java/eu/darken/myperm/common/compose/ContextExt.kt
@@ -1,0 +1,14 @@
+package eu.darken.myperm.common.compose
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+
+fun Context.findActivity(): Activity? {
+    var ctx: Context? = this
+    while (ctx is ContextWrapper) {
+        if (ctx is Activity) return ctx
+        ctx = ctx.baseContext
+    }
+    return null
+}

--- a/app/src/main/java/eu/darken/myperm/permissions/core/features/PermissionAction.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/core/features/PermissionAction.kt
@@ -48,115 +48,175 @@ sealed class PermissionAction {
 
     data class SpecialAccess(override val permission: Permission, override val pkg: Pkg?) : PermissionAction() {
         override fun execute(activity: Activity) {
-            val intent = when (permission.id) {
-                APerm.SYSTEM_ALERT_WINDOW.id -> Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION).apply {
-                    pkg?.let { data = it.packageName.toPackageUri() }
-                }
-                APerm.PACKAGE_USAGE_STATS.id -> Intent(Settings.ACTION_USAGE_ACCESS_SETTINGS).apply {
-                    pkg?.let { data = it.packageName.toPackageUri() }
-                }
-                APerm.REQUEST_COMPANION_USE_DATA_IN_BACKGROUND.id -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                    Intent(Settings.ACTION_IGNORE_BACKGROUND_DATA_RESTRICTIONS_SETTINGS).apply {
-                        pkg?.let { data = it.packageName.toPackageUri() }
-                    }
-                } else null
-                APerm.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS.id -> Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
-                    pkg?.let { data = it.packageName.toPackageUri() }
-                }
-                APerm.MANAGE_EXTERNAL_STORAGE.id -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                    if (pkg != null) {
-                        Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION).apply {
-                            data = pkg.packageName.toPackageUri()
-                        }
-                    } else {
-                        Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION)
-                    }
-                } else null
-                APerm.WRITE_SETTINGS.id -> Intent(Settings.ACTION_MANAGE_WRITE_SETTINGS).apply {
-                    pkg?.let { data = it.packageName.toPackageUri() }
-                }
-                APerm.MANAGE_MEDIA.id -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                    Intent(Settings.ACTION_REQUEST_MANAGE_MEDIA).apply {
-                        pkg?.let { data = it.packageName.toPackageUri() }
-                    }
-                } else null
-                APerm.SCHEDULE_EXACT_ALARM.id -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                    Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM).apply {
-                        pkg?.let { data = it.packageName.toPackageUri() }
-                    }
-                } else null
-                // We don't have specific intents for these
-//                APerm.MANAGE_ONGOING_CALLS.id -> Intent(Settings.)
-//                APerm.INSTANT_APP_FOREGROUND_SERVICE.id -> Intent(Settings.)
-//               APerm.LOADER_USAGE_STATS.id -> Intent().apply {
-//
-//               }
-                APerm.SMS_FINANCIAL_TRANSACTIONS.id -> Intent().apply {
-                    component = ComponentName(
-                        "com.android.settings",
-                        "com.android.settings.Settings\$PremiumSmsAccessActivity"
-                    )
-                }
-                APerm.USE_ICC_AUTH_WITH_DEVICE_IDENTIFIER.id -> Intent().apply {
-                    component = ComponentName(
-                        "com.android.settings",
-                        "com.android.settings.Settings\$IccLockSettingsActivity"
-                    )
-                }
-                APerm.ACCESS_NOTIFICATION_POLICY.id -> Intent().apply {
-                    component = ComponentName(
-                        "com.android.settings",
-                        "com.android.settings.Settings\$ZenAccessSettingsActivity"
-                    )
-                }
-                APerm.ACCESS_NOTIFICATIONS.id -> Intent().apply {
-                    component = ComponentName(
-                        "com.android.settings",
-                        "com.android.settings.Settings\$NotificationAccessSettingsActivity"
-                    )
-                }
-                AExtraPerm.PICTURE_IN_PICTURE.id -> Intent().apply {
-                    component = ComponentName(
-                        "com.android.settings",
-                        "com.android.settings.Settings\$PictureInPictureSettingsActivity"
-                    )
-                }
-                APerm.BIND_ACCESSIBILITY_SERVICE.id -> Intent().apply {
-                    component = ComponentName(
-                        "com.android.settings",
-                        "com.android.settings.Settings\$AccessibilitySettingsActivity"
-                    )
-                }
-                APerm.BIND_DEVICE_ADMIN.id -> Intent().apply {
-                    component = ComponentName(
-                        "com.android.settings",
-                        "com.android.settings.DeviceAdminSettings"
-                    )
-                }
-                APerm.REQUEST_INSTALL_PACKAGES.id -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    Intent(Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES).apply {
-                        pkg?.let { data = it.packageName.toPackageUri() }
-                    }
-                } else null
-                else -> null
-            }
-
-            val resolvedIntent = intent?.resolveToActivity(activity)?.apply {
-                pkg?.let { data = it.packageName.toPackageUri() }
-            } ?: pkg?.let {
-                // Fallback to App Info
-                Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
-                    .resolveToActivity(activity)
-                    ?.apply { data = it.packageName.toPackageUri() }
-            } ?: throw IllegalArgumentException("No action available for ${permission.id.value}")
-
-            activity.startActivity(resolvedIntent)
+            launchSettings(activity, permission.id, pkg)
         }
     }
 
     data class None(override val permission: Permission, override val pkg: Pkg?) : PermissionAction() {
         override fun execute(activity: Activity) {
             Toast.makeText(activity, R.string.permissions_action_none_msg, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    companion object {
+
+        val launchableSpecialIds: Set<Permission.Id> = setOf(
+            APerm.SYSTEM_ALERT_WINDOW.id,
+            APerm.PACKAGE_USAGE_STATS.id,
+            APerm.REQUEST_COMPANION_USE_DATA_IN_BACKGROUND.id,
+            APerm.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS.id,
+            APerm.MANAGE_EXTERNAL_STORAGE.id,
+            APerm.WRITE_SETTINGS.id,
+            APerm.MANAGE_MEDIA.id,
+            APerm.SCHEDULE_EXACT_ALARM.id,
+            APerm.SMS_FINANCIAL_TRANSACTIONS.id,
+            APerm.USE_ICC_AUTH_WITH_DEVICE_IDENTIFIER.id,
+            APerm.ACCESS_NOTIFICATION_POLICY.id,
+            APerm.ACCESS_NOTIFICATIONS.id,
+            AExtraPerm.PICTURE_IN_PICTURE.id,
+            APerm.BIND_ACCESSIBILITY_SERVICE.id,
+            APerm.BIND_DEVICE_ADMIN.id,
+            APerm.REQUEST_INSTALL_PACKAGES.id,
+        )
+
+        fun canLaunchSettings(permId: Permission.Id, apiLevel: Int = Build.VERSION.SDK_INT): Boolean =
+            permId in launchableSpecialIds && buildSpecialIntents(permId, pkg = null, apiLevel).isNotEmpty()
+
+        fun launchSettings(activity: Activity, permId: Permission.Id, pkg: Pkg? = null) {
+            val candidates = buildSpecialIntents(permId, pkg, Build.VERSION.SDK_INT)
+            val resolved = candidates.firstNotNullOfOrNull { it.resolveToActivity(activity) }?.apply {
+                pkg?.let { data = it.packageName.toPackageUri() }
+            } ?: pkg?.let {
+                Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+                    .resolveToActivity(activity)
+                    ?.apply { data = it.packageName.toPackageUri() }
+            } ?: throw IllegalStateException("No launcher available for ${permId.value}")
+            activity.startActivity(resolved)
+        }
+
+        internal fun buildSpecialIntents(
+            permId: Permission.Id,
+            pkg: Pkg?,
+            apiLevel: Int,
+        ): List<Intent> = when (permId) {
+            APerm.SYSTEM_ALERT_WINDOW.id -> listOf(
+                Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION).apply {
+                    pkg?.let { data = it.packageName.toPackageUri() }
+                }
+            )
+            APerm.PACKAGE_USAGE_STATS.id -> listOf(
+                Intent(Settings.ACTION_USAGE_ACCESS_SETTINGS).apply {
+                    pkg?.let { data = it.packageName.toPackageUri() }
+                }
+            )
+            APerm.REQUEST_COMPANION_USE_DATA_IN_BACKGROUND.id -> if (apiLevel >= Build.VERSION_CODES.N) {
+                listOf(
+                    Intent(Settings.ACTION_IGNORE_BACKGROUND_DATA_RESTRICTIONS_SETTINGS).apply {
+                        pkg?.let { data = it.packageName.toPackageUri() }
+                    }
+                )
+            } else emptyList()
+            APerm.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS.id -> listOf(
+                Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
+                    pkg?.let { data = it.packageName.toPackageUri() }
+                }
+            )
+            APerm.MANAGE_EXTERNAL_STORAGE.id -> if (apiLevel >= Build.VERSION_CODES.R) {
+                if (pkg != null) {
+                    listOf(
+                        Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION).apply {
+                            data = pkg.packageName.toPackageUri()
+                        }
+                    )
+                } else {
+                    listOf(Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION))
+                }
+            } else emptyList()
+            APerm.WRITE_SETTINGS.id -> listOf(
+                Intent(Settings.ACTION_MANAGE_WRITE_SETTINGS).apply {
+                    pkg?.let { data = it.packageName.toPackageUri() }
+                }
+            )
+            APerm.MANAGE_MEDIA.id -> if (apiLevel >= Build.VERSION_CODES.S) {
+                listOf(
+                    Intent(Settings.ACTION_REQUEST_MANAGE_MEDIA).apply {
+                        pkg?.let { data = it.packageName.toPackageUri() }
+                    }
+                )
+            } else emptyList()
+            APerm.SCHEDULE_EXACT_ALARM.id -> if (apiLevel >= Build.VERSION_CODES.S) {
+                listOf(
+                    Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM).apply {
+                        pkg?.let { data = it.packageName.toPackageUri() }
+                    }
+                )
+            } else emptyList()
+            APerm.SMS_FINANCIAL_TRANSACTIONS.id -> listOf(
+                Intent().apply {
+                    component = ComponentName(
+                        "com.android.settings",
+                        "com.android.settings.Settings\$PremiumSmsAccessActivity"
+                    )
+                }
+            )
+            APerm.USE_ICC_AUTH_WITH_DEVICE_IDENTIFIER.id -> listOf(
+                Intent().apply {
+                    component = ComponentName(
+                        "com.android.settings",
+                        "com.android.settings.Settings\$IccLockSettingsActivity"
+                    )
+                }
+            )
+            APerm.ACCESS_NOTIFICATION_POLICY.id -> listOf(
+                Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS),
+                Intent().apply {
+                    component = ComponentName(
+                        "com.android.settings",
+                        "com.android.settings.Settings\$ZenAccessSettingsActivity"
+                    )
+                },
+            )
+            APerm.ACCESS_NOTIFICATIONS.id -> listOf(
+                Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS),
+                Intent().apply {
+                    component = ComponentName(
+                        "com.android.settings",
+                        "com.android.settings.Settings\$NotificationAccessSettingsActivity"
+                    )
+                },
+            )
+            AExtraPerm.PICTURE_IN_PICTURE.id -> listOf(
+                Intent().apply {
+                    component = ComponentName(
+                        "com.android.settings",
+                        "com.android.settings.Settings\$PictureInPictureSettingsActivity"
+                    )
+                }
+            )
+            APerm.BIND_ACCESSIBILITY_SERVICE.id -> listOf(
+                Intent().apply {
+                    component = ComponentName(
+                        "com.android.settings",
+                        "com.android.settings.Settings\$AccessibilitySettingsActivity"
+                    )
+                }
+            )
+            APerm.BIND_DEVICE_ADMIN.id -> listOf(
+                Intent().apply {
+                    component = ComponentName(
+                        "com.android.settings",
+                        "com.android.settings.DeviceAdminSettings"
+                    )
+                }
+            )
+            APerm.REQUEST_INSTALL_PACKAGES.id -> if (apiLevel >= Build.VERSION_CODES.O) {
+                listOf(
+                    Intent(Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES).apply {
+                        pkg?.let { data = it.packageName.toPackageUri() }
+                    }
+                )
+            } else emptyList()
+            else -> emptyList()
         }
     }
 }

--- a/app/src/main/java/eu/darken/myperm/permissions/core/known/APerm.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/core/known/APerm.kt
@@ -222,7 +222,7 @@ sealed class APerm(val id: Permission.Id) {
         override val labelRes: Int = R.string.permission_premium_sms_services_label
         override val descriptionRes: Int = R.string.permission_premium_sms_services_description
         override val groupIds: Set<PermissionGroup.Id> = grpIds(APermGrp.Messaging)
-        override val tags = setOf(ManifestDoc)
+        override val tags = setOf(ManifestDoc, SpecialAccess)
     }
 
     object SEND_RESPOND_VIA_MESSAGE : APerm("android.permission.SEND_RESPOND_VIA_MESSAGE") {
@@ -529,7 +529,7 @@ sealed class APerm(val id: Permission.Id) {
         override val labelRes: Int = R.string.permission_appear_on_top_label
         override val descriptionRes: Int = R.string.permission_appear_on_top_description
         override val groupIds: Set<PermissionGroup.Id> = grpIds(APermGrp.Apps)
-        override val tags = setOf(ManifestDoc, Highlighted)
+        override val tags = setOf(ManifestDoc, Highlighted, SpecialAccess)
     }
 
     object ACCESS_NOTIFICATION_POLICY : APerm("android.permission.ACCESS_NOTIFICATION_POLICY") {
@@ -542,7 +542,7 @@ sealed class APerm(val id: Permission.Id) {
         override val labelRes: Int = R.string.permission_modify_system_settings_label
         override val descriptionRes: Int = R.string.permission_modify_system_settings_description
         override val groupIds: Set<PermissionGroup.Id> = grpIds(APermGrp.Apps)
-        override val tags = setOf(ManifestDoc)
+        override val tags = setOf(ManifestDoc, SpecialAccess)
     }
 
     object ACCESS_NOTIFICATIONS : APerm("android.permission.ACCESS_NOTIFICATIONS") {
@@ -561,7 +561,7 @@ sealed class APerm(val id: Permission.Id) {
     object SCHEDULE_EXACT_ALARM : APerm("android.permission.SCHEDULE_EXACT_ALARM") {
         override val labelRes: Int = R.string.permission_alarms_and_reminders_label
         override val descriptionRes: Int = R.string.permission_alarms_and_reminders_description
-        override val tags = setOf(ManifestDoc)
+        override val tags = setOf(ManifestDoc, SpecialAccess)
     }
 
     object PACKAGE_USAGE_STATS : APerm("android.permission.PACKAGE_USAGE_STATS") {
@@ -1023,7 +1023,7 @@ sealed class APerm(val id: Permission.Id) {
     }
 
     object USE_ICC_AUTH_WITH_DEVICE_IDENTIFIER : APerm("android.permission.USE_ICC_AUTH_WITH_DEVICE_IDENTIFIER") {
-        override val tags = setOf(ManifestDoc)
+        override val tags = setOf(ManifestDoc, SpecialAccess)
     }
 
     object USE_SIP : APerm("android.permission.USE_SIP") {

--- a/app/src/main/java/eu/darken/myperm/permissions/ui/details/PermissionDetailsEvents.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/details/PermissionDetailsEvents.kt
@@ -1,10 +1,8 @@
 package eu.darken.myperm.permissions.ui.details
 
 import eu.darken.myperm.apps.core.Pkg
-import eu.darken.myperm.permissions.core.features.PermissionAction
 
 sealed class PermissionDetailsEvents {
     data class ShowAppSystemDetails(val pkg: Pkg) : PermissionDetailsEvents()
-    data class PermissionEvent(val permAction: PermissionAction) : PermissionDetailsEvents()
     data class ShowFilterDialog(val options: PermissionDetailsFilterOptions) : PermissionDetailsEvents()
 }

--- a/app/src/main/java/eu/darken/myperm/permissions/ui/details/PermissionDetailsScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/details/PermissionDetailsScreen.kt
@@ -19,9 +19,11 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.HelpOutline
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -42,11 +44,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import android.widget.Toast
 import eu.darken.myperm.R
 import eu.darken.myperm.apps.core.Pkg
 import eu.darken.myperm.apps.core.features.UsesPermission
@@ -61,11 +65,20 @@ import eu.darken.myperm.common.compose.Pill
 import eu.darken.myperm.common.compose.SystemPill
 import eu.darken.myperm.common.compose.Preview2
 import eu.darken.myperm.common.compose.PreviewWrapper
+import eu.darken.myperm.common.compose.findActivity
+import eu.darken.myperm.common.debug.logging.Logging.Priority.WARN
+import eu.darken.myperm.common.debug.logging.asLog
+import eu.darken.myperm.common.debug.logging.log
+import eu.darken.myperm.common.debug.logging.logTag
 import eu.darken.myperm.common.error.ErrorEventHandler
 import eu.darken.myperm.common.navigation.Nav
 import eu.darken.myperm.common.navigation.NavigationEventHandler
+import eu.darken.myperm.permissions.core.Permission
 import eu.darken.myperm.permissions.core.ProtectionFlag
 import eu.darken.myperm.permissions.core.ProtectionType
+import eu.darken.myperm.permissions.core.features.PermissionAction
+
+private val TAG = logTag("PermissionDetails", "Screen")
 
 @Composable
 fun PermissionDetailsScreenHost(
@@ -78,6 +91,7 @@ fun PermissionDetailsScreenHost(
     NavigationEventHandler(vm)
 
     val state by vm.state.collectAsState()
+    val context = LocalContext.current
 
     var showFilterDialog by rememberSaveable { mutableStateOf(false) }
     var showPermissionHelpDialog by rememberSaveable { mutableStateOf(false) }
@@ -91,6 +105,18 @@ fun PermissionDetailsScreenHost(
             onFilterClicked = { showFilterDialog = true },
             onPermissionHelpClicked = { showPermissionHelpDialog = true },
             onStatusHelpClicked = { showStatusHelpDialog = true },
+            onOpenSettingsClicked = {
+                val permId = it.permission?.id ?: Permission.Id(it.permissionId)
+                val activity = context.findActivity()
+                val launched = activity?.let { act ->
+                    runCatching { PermissionAction.launchSettings(act, permId, pkg = null) }
+                        .onFailure { err -> log(TAG, WARN) { "launchSettings failed: ${err.asLog()}" } }
+                        .isSuccess
+                } ?: false
+                if (!launched) {
+                    Toast.makeText(context, R.string.permissions_details_open_settings_error, Toast.LENGTH_SHORT).show()
+                }
+            },
         )
     }
 
@@ -124,7 +150,10 @@ fun PermissionDetailsScreen(
     onFilterClicked: () -> Unit,
     onPermissionHelpClicked: () -> Unit,
     onStatusHelpClicked: () -> Unit,
+    onOpenSettingsClicked: () -> Unit,
 ) {
+    val permId = state.permission?.id ?: Permission.Id(state.permissionId)
+    val canOpenSettings = PermissionAction.canLaunchSettings(permId)
     Scaffold(
         topBar = {
             TopAppBar(
@@ -231,6 +260,21 @@ fun PermissionDetailsScreen(
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
+                            }
+
+                            if (canOpenSettings) {
+                                FilledTonalButton(
+                                    onClick = onOpenSettingsClicked,
+                                    modifier = Modifier.fillMaxWidth(),
+                                ) {
+                                    Icon(
+                                        Icons.AutoMirrored.Filled.OpenInNew,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(18.dp),
+                                    )
+                                    Spacer(modifier = Modifier.size(8.dp))
+                                    Text(stringResource(R.string.permissions_details_open_settings_action))
+                                }
                             }
 
                             if (state.totalUserCount > 0) {
@@ -633,6 +677,7 @@ private fun PermissionDetailsScreenPreview() = PreviewWrapper {
         onFilterClicked = {},
         onPermissionHelpClicked = {},
         onStatusHelpClicked = {},
+        onOpenSettingsClicked = {},
     )
 }
 
@@ -646,5 +691,6 @@ private fun PermissionDetailsScreenLoadingPreview() = PreviewWrapper {
         onFilterClicked = {},
         onPermissionHelpClicked = {},
         onStatusHelpClicked = {},
+        onOpenSettingsClicked = {},
     )
 }

--- a/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionListEvent.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionListEvent.kt
@@ -1,11 +1,7 @@
 package eu.darken.myperm.permissions.ui.list
 
-import eu.darken.myperm.permissions.core.features.PermissionAction
-
 sealed class PermissionListEvent {
     data class ShowFilterDialog(val options: PermsFilterOptions) : PermissionListEvent()
 
     data class ShowSortDialog(val options: PermsSortOptions) : PermissionListEvent()
-
-    data class PermissionEvent(val permAction: PermissionAction) : PermissionListEvent()
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -172,6 +172,9 @@
     <string name="installed_at_x">First installed: %s</string>
     <string name="apps_sort_install_source_label">Install source</string>
     <string name="permissions_action_none_msg">No action available for this permission</string>
+    <string name="permissions_details_open_settings_action">Open system settings</string>
+    <string name="permissions_details_open_settings_content_description_x">Open system settings for %1$s</string>
+    <string name="permissions_details_open_settings_error">Could not open settings for this permission</string>
     <string name="apps_filter_profile_secondary_label">Managed profile(s)</string>
     <string name="apps_filter_battery_optimization_label">Custom battery</string>
     <string name="apps_filter_accessibility_label">Accessibility</string>

--- a/app/src/test/java/eu/darken/myperm/permissions/core/features/PermissionActionTest.kt
+++ b/app/src/test/java/eu/darken/myperm/permissions/core/features/PermissionActionTest.kt
@@ -1,0 +1,143 @@
+package eu.darken.myperm.permissions.core.features
+
+import android.os.Build
+import eu.darken.myperm.permissions.core.Permission
+import eu.darken.myperm.permissions.core.known.APerm
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelper.BaseTest
+
+class PermissionActionTest : BaseTest() {
+
+    @Test
+    fun `every launchableSpecialId produces a non-empty intent list on API 34`() {
+        PermissionAction.launchableSpecialIds.forEach { id ->
+            withClue(id) {
+                PermissionAction.buildSpecialIntents(id, pkg = null, apiLevel = 34).shouldNotBeEmpty()
+            }
+        }
+    }
+
+    @Test
+    fun `canLaunchSettings is true for every launchableSpecialId on API 34`() {
+        PermissionAction.launchableSpecialIds.forEach { id ->
+            withClue(id) {
+                PermissionAction.canLaunchSettings(id, apiLevel = 34) shouldBe true
+            }
+        }
+    }
+
+    @Test
+    fun `canLaunchSettings is false for tagged-but-unsupported special permissions`() {
+        val tagDriftFalsePositives = listOf(
+            APerm.CHANGE_WIFI_STATE.id,
+            APerm.TURN_SCREEN_ON.id,
+            APerm.INTERACT_ACROSS_PROFILES.id,
+            APerm.LOADER_USAGE_STATS.id,
+            APerm.USE_FULL_SCREEN_INTENT.id,
+        )
+        tagDriftFalsePositives.forEach { id ->
+            withClue(id) {
+                PermissionAction.canLaunchSettings(id, apiLevel = 34) shouldBe false
+            }
+        }
+    }
+
+    @Test
+    fun `canLaunchSettings is false for arbitrary runtime permissions`() {
+        val runtimeIds = listOf(
+            Permission.Id("android.permission.CAMERA"),
+            Permission.Id("android.permission.READ_CONTACTS"),
+            Permission.Id("android.permission.ACCESS_FINE_LOCATION"),
+            Permission.Id("com.example.unknown.permission"),
+        )
+        runtimeIds.forEach { id ->
+            withClue(id) {
+                PermissionAction.canLaunchSettings(id, apiLevel = 34) shouldBe false
+            }
+        }
+    }
+
+    @Test
+    fun `MANAGE_EXTERNAL_STORAGE is gated behind R`() {
+        PermissionAction
+            .buildSpecialIntents(APerm.MANAGE_EXTERNAL_STORAGE.id, pkg = null, apiLevel = Build.VERSION_CODES.Q)
+            .shouldBeEmpty()
+        PermissionAction
+            .buildSpecialIntents(APerm.MANAGE_EXTERNAL_STORAGE.id, pkg = null, apiLevel = Build.VERSION_CODES.R)
+            .shouldHaveSize(1)
+    }
+
+    @Test
+    fun `MANAGE_MEDIA is gated behind S`() {
+        PermissionAction
+            .buildSpecialIntents(APerm.MANAGE_MEDIA.id, pkg = null, apiLevel = Build.VERSION_CODES.R)
+            .shouldBeEmpty()
+        PermissionAction
+            .buildSpecialIntents(APerm.MANAGE_MEDIA.id, pkg = null, apiLevel = Build.VERSION_CODES.S)
+            .shouldHaveSize(1)
+    }
+
+    @Test
+    fun `SCHEDULE_EXACT_ALARM is gated behind S`() {
+        PermissionAction
+            .buildSpecialIntents(APerm.SCHEDULE_EXACT_ALARM.id, pkg = null, apiLevel = Build.VERSION_CODES.R)
+            .shouldBeEmpty()
+        PermissionAction
+            .buildSpecialIntents(APerm.SCHEDULE_EXACT_ALARM.id, pkg = null, apiLevel = Build.VERSION_CODES.S)
+            .shouldHaveSize(1)
+    }
+
+    @Test
+    fun `REQUEST_INSTALL_PACKAGES is gated behind O`() {
+        PermissionAction
+            .buildSpecialIntents(APerm.REQUEST_INSTALL_PACKAGES.id, pkg = null, apiLevel = Build.VERSION_CODES.N)
+            .shouldBeEmpty()
+        PermissionAction
+            .buildSpecialIntents(APerm.REQUEST_INSTALL_PACKAGES.id, pkg = null, apiLevel = Build.VERSION_CODES.O)
+            .shouldHaveSize(1)
+    }
+
+    @Test
+    fun `REQUEST_COMPANION_USE_DATA_IN_BACKGROUND is gated behind N`() {
+        PermissionAction
+            .buildSpecialIntents(APerm.REQUEST_COMPANION_USE_DATA_IN_BACKGROUND.id, pkg = null, apiLevel = Build.VERSION_CODES.M)
+            .shouldBeEmpty()
+        PermissionAction
+            .buildSpecialIntents(APerm.REQUEST_COMPANION_USE_DATA_IN_BACKGROUND.id, pkg = null, apiLevel = Build.VERSION_CODES.N)
+            .shouldHaveSize(1)
+    }
+
+    @Test
+    fun `DND has a 2-entry fallback chain (public action plus private component)`() {
+        // Index 0 is public Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS;
+        // index 1 is the ZenAccessSettingsActivity component fallback.
+        // Intent content is verified by code review — the android.jar stubs used by unit tests
+        // return default values for getAction()/component, so we assert the shape only.
+        PermissionAction.buildSpecialIntents(
+            APerm.ACCESS_NOTIFICATION_POLICY.id,
+            pkg = null,
+            apiLevel = 34,
+        ) shouldHaveSize 2
+    }
+
+    @Test
+    fun `notification-listener has a 2-entry fallback chain`() {
+        PermissionAction.buildSpecialIntents(
+            APerm.ACCESS_NOTIFICATIONS.id,
+            pkg = null,
+            apiLevel = 34,
+        ) shouldHaveSize 2
+    }
+
+    private inline fun withClue(context: Any?, block: () -> Unit) {
+        try {
+            block()
+        } catch (e: AssertionError) {
+            throw AssertionError("For $context: ${e.message}", e)
+        }
+    }
+}


### PR DESCRIPTION
## What changed

Permissions that are managed through a dedicated system settings page — Do Not Disturb access, display-over-other-apps (overlay), usage access, modify system settings, all-files access, schedule exact alarms, accessibility services, device admin, notification listener, and a few others — now expose a direct way to reach that page from within the app.

- **Permission details**: a prominent "Open system settings" button sits in the overview card.
- **App details**: each matching permission row gets a trailing gear icon that opens the same system page, pre-focused on the current app where the platform intent supports it (overlay, usage access, all-files, etc.).

Do Not Disturb is what surfaced the gap — there was no way to reach that system page from within the app — but the fix applies to the whole category.

## Technical Context

- The intent construction in `PermissionAction.SpecialAccess.execute()` was already complete but had no UI caller — neither details screen ever invoked it. The gap is closed by wiring a new `canLaunchSettings` check into both screens and calling `launchSettings` directly from the Compose layer (same pattern already used in `WatcherDashboardScreen`).
- Visibility is driven by **actual intent capability, not the `SpecialAccess` tag** — the tag set in `APerm.kt` had drifted from the intent map in both directions. Permissions with a concrete launcher but no tag (`SYSTEM_ALERT_WINDOW`, `WRITE_SETTINGS`, `SCHEDULE_EXACT_ALARM`, `SMS_FINANCIAL_TRANSACTIONS`, `USE_ICC_AUTH_WITH_DEVICE_IDENTIFIER`) now have the tag. Permissions with the tag but no launcher (`CHANGE_WIFI_STATE`, `TURN_SCREEN_ON`, `INTERACT_ACROSS_PROFILES`, `LOADER_USAGE_STATS`, `USE_FULL_SCREEN_INTENT`) correctly do not show the button via the capability check, avoiding an `IllegalArgumentException` they would have hit through tag-based gating.
- **DND and notification-listener** intents now use a two-entry fallback chain: the public `Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS` / `ACTION_NOTIFICATION_LISTENER_SETTINGS` first, then the private `$ZenAccessSettingsActivity` / `$NotificationAccessSettingsActivity` component as backup. The private component is fragile on some OEM ROMs; preferring the public action should make the button work on more devices.
- Removed four dead `PermissionEvent` sealed-class entries (never emitted, never collected).
- **Known limitation** (pre-existing, not introduced here): `launchSettings` uses plain `startActivity`, targeting the current user rather than the app's profile. Affects per-app intents in work-profile scenarios.
- Enabled `isReturnDefaultValues = true` in `testOptions` so the new unit test can construct `Intent` without Android framework mocking. Existing tests are unaffected — they use explicit `mockkStatic` where framework behavior matters.

## Review guidance

- `PermissionAction.kt` is the bulk of the change: a mechanical extract of the `when(permission.id)` block into `buildSpecialIntents` plus three companion helpers. Per-permission intent construction is preserved verbatim.
- `PermissionActionTest.kt` enforces that `launchableSpecialIds` never drifts from the `when`-cases again.
