### PR TITLE
Fix: Further reduce OOM crashes and ANRs from memory pressure

### DIFF
--- a/app/src/main/java/eu/darken/myperm/apps/core/AppRepo.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/AppRepo.kt
@@ -173,10 +173,29 @@ class AppRepo @Inject constructor(
         val snapshotId = UUID.randomUUID().toString()
         log(TAG) { "saveSnapshot($snapshotId, reason=$reason, pkgs=${pkgs.size})" }
 
-        // Map + insert in chunks. Labels are resolved per-chunk (outside the DB insert)
-        // to cap peak memory at ~50 packages worth of transient Resources objects.
-        val txStart = System.currentTimeMillis()
         val pkgList = pkgs.toList()
+
+        // Resolve labels BEFORE the transaction. loadLabel() triggers PackageManager IPC
+        // and Resources loading; holding the DB write lock during that blocks every
+        // concurrent reader. We chunk the work to keep peak transient allocations bounded
+        // (~50 Resources objects at a time).
+        val labelStart = System.currentTimeMillis()
+        val resolvedLabels: Map<Pkg.Id, String> = buildMap {
+            for (chunk in pkgList.chunked(50)) {
+                for (pkg in chunk) {
+                    val label = try {
+                        pkg.getLabel(context)
+                    } catch (e: Exception) {
+                        log(TAG, WARN) { "Failed to pre-resolve label for ${pkg.id}: $e" }
+                        null
+                    }
+                    put(pkg.id, label ?: pkg.id.pkgName.value)
+                }
+            }
+        }
+        log(TAG) { "Perf: saveSnapshot() label resolution in ${System.currentTimeMillis() - labelStart}ms" }
+
+        val txStart = System.currentTimeMillis()
         database.inTransaction {
             snapshotDao.insertSnapshot(
                 SnapshotEntity(
@@ -188,16 +207,9 @@ class AppRepo @Inject constructor(
                 )
             )
             for (chunk in pkgList.chunked(50)) {
-                // Pre-resolve labels for this chunk before mapping to entities.
-                // loadLabel() triggers IPC + resource loading, so keep it outside entity mapping.
-                for (pkg in chunk) {
-                    try {
-                        pkg.getLabel(context)
-                    } catch (e: Exception) {
-                        log(TAG, WARN) { "Failed to pre-resolve label for ${pkg.id}: $e" }
-                    }
+                val entities = chunk.map {
+                    snapshotMapper.toEntities(snapshotId, it, resolvedLabels.getValue(it.id))
                 }
-                val entities = chunk.map { snapshotMapper.toEntities(snapshotId, it) }
                 snapshotPkgDao.insertPkgs(entities.map { it.pkg })
                 snapshotPkgDao.insertPermissions(entities.flatMap { it.permissions })
                 snapshotPkgDao.insertDeclaredPermissions(entities.flatMap { it.declaredPermissions })

--- a/app/src/main/java/eu/darken/myperm/apps/core/SnapshotMapper.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/SnapshotMapper.kt
@@ -1,7 +1,5 @@
 package eu.darken.myperm.apps.core
 
-import android.content.Context
-import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.myperm.apps.core.container.BasePkg
 import eu.darken.myperm.apps.core.container.PrimaryProfilePkg
 import eu.darken.myperm.apps.core.container.SecondaryProfilePkg
@@ -20,13 +18,12 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class SnapshotMapper @Inject constructor(
-    @ApplicationContext private val context: Context,
-) {
+class SnapshotMapper @Inject constructor() {
 
     fun toEntities(
         snapshotId: String,
         pkg: BasePkg,
+        resolvedLabel: String,
     ): PkgEntities {
         val userHandleId = pkg.userHandle.hashCode()
 
@@ -48,7 +45,7 @@ class SnapshotMapper @Inject constructor(
             batteryOptimization = pkg.batteryOptimization,
             installerPkgName = pkg.installerInfo.installingPkg?.id?.pkgName,
             applicationFlags = pkg.applicationInfo?.flags ?: 0,
-            cachedLabel = pkg.getLabel(context) ?: pkg.id.pkgName.value,
+            cachedLabel = resolvedLabel,
             twinCount = pkg.twins.size,
             siblingCount = pkg.siblings.size,
             hasAccessibilityServices = pkg.accessibilityServices.isNotEmpty(),

--- a/app/src/main/java/eu/darken/myperm/apps/core/manifest/ApkManifestReader.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/manifest/ApkManifestReader.kt
@@ -1,5 +1,6 @@
 package eu.darken.myperm.apps.core.manifest
 
+import androidx.annotation.VisibleForTesting
 import eu.darken.myperm.common.debug.logging.Logging.Priority.WARN
 import eu.darken.myperm.common.debug.logging.log
 import eu.darken.myperm.common.debug.logging.logTag
@@ -8,11 +9,20 @@ import org.xmlpull.v1.XmlPullParser
 import org.xmlpull.v1.XmlPullParserFactory
 import java.io.File
 import java.io.StringReader
+import java.util.zip.ZipFile
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class ApkManifestReader @Inject constructor() {
+
+    internal data class HeapInfo(val maxHeap: Long, val freeHeap: Long)
+
+    @VisibleForTesting
+    internal var heapInfoProvider: () -> HeapInfo = {
+        val rt = Runtime.getRuntime()
+        HeapInfo(maxHeap = rt.maxMemory(), freeHeap = rt.maxMemory() - (rt.totalMemory() - rt.freeMemory()))
+    }
 
     fun readManifest(apkPath: String): ManifestData {
         val apkFile = File(apkPath)
@@ -29,13 +39,66 @@ class ApkManifestReader @Inject constructor() {
             )
         }
 
-        val runtime = Runtime.getRuntime()
-        val freeHeap = runtime.maxMemory() - (runtime.totalMemory() - runtime.freeMemory())
-        if (freeHeap < runtime.maxMemory() * 0.15) {
-            log(TAG, WARN) { "Skipping manifest parse for $apkPath: low memory (${freeHeap / 1024}KB free)" }
+        // Entry gate: require 20% of max heap free. Reactive — the real protection is the
+        // post-preflight byte budget below, which sizes against actual parse cost.
+        val entryHeap = heapInfoProvider()
+        if (entryHeap.freeHeap < entryHeap.maxHeap * FREE_HEAP_ENTRY_RATIO) {
+            log(TAG, WARN) { "Skipping manifest parse for $apkPath: low memory (${entryHeap.freeHeap / 1024}KB free)" }
             return ManifestData(
                 rawXml = RawXmlResult.Unavailable(UnavailableReason.LOW_MEMORY),
                 queries = QueriesResult.Error(IllegalStateException("Low memory")),
+            )
+        }
+
+        // Preflight: size the zip entries the parser will read. apk-parser loads both
+        // resources.arsc and AndroidManifest.xml via a ByteArrayOutputStream.grow cycle,
+        // which peaks around 3× the growing buffer (old + new + JVM overhead).
+        val (arscSize, manifestSize) = try {
+            ZipFile(apkFile).use { zip ->
+                val arscEntry = zip.getEntry("resources.arsc")
+                val manifestEntry = zip.getEntry("AndroidManifest.xml")
+                val arscSize: Long = arscEntry?.size?.takeIf { it >= 0L } ?: -1L
+                val manifestSize: Long = manifestEntry?.size?.takeIf { it >= 0L } ?: -1L
+                arscSize to manifestSize
+            }
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Zip preflight failed for $apkPath: $e" }
+            return ManifestData(
+                rawXml = RawXmlResult.Unavailable(UnavailableReason.MALFORMED_APK),
+                queries = QueriesResult.Error(e),
+            )
+        }
+
+        if (arscSize < 0L || manifestSize < 0L) {
+            log(TAG, WARN) { "Missing/unknown zip entry sizes for $apkPath (arsc=$arscSize, manifest=$manifestSize)" }
+            return ManifestData(
+                rawXml = RawXmlResult.Unavailable(UnavailableReason.MALFORMED_APK),
+                queries = QueriesResult.Error(IllegalStateException("Malformed APK: missing entry sizes")),
+            )
+        }
+
+        val estimatedPeak: Long = arscSize * 3L + manifestSize * 2L + PARSE_SLACK_BYTES
+        val postPreflightHeap = heapInfoProvider()
+        val budgetCeiling: Long = (postPreflightHeap.maxHeap * BUDGET_MAX_HEAP_RATIO).toLong()
+        if (estimatedPeak > budgetCeiling) {
+            log(TAG, WARN) {
+                "Skipping oversized APK $apkPath: estimatedPeak=${estimatedPeak / 1024}KB > budget=${budgetCeiling / 1024}KB"
+            }
+            return ManifestData(
+                rawXml = RawXmlResult.Unavailable(UnavailableReason.APK_TOO_LARGE),
+                queries = QueriesResult.Error(IllegalStateException("APK too large: estimatedPeak=$estimatedPeak")),
+            )
+        }
+
+        // Re-check free heap against the sized budget — if something consumed heap between
+        // the entry gate and here, bail before we trigger the doubling allocation.
+        if (postPreflightHeap.freeHeap < estimatedPeak + PARSE_SLACK_BYTES) {
+            log(TAG, WARN) {
+                "Insufficient heap for manifest parse $apkPath: free=${postPreflightHeap.freeHeap / 1024}KB, need=${(estimatedPeak + PARSE_SLACK_BYTES) / 1024}KB"
+            }
+            return ManifestData(
+                rawXml = RawXmlResult.Unavailable(UnavailableReason.LOW_MEMORY),
+                queries = QueriesResult.Error(IllegalStateException("Insufficient heap for parse")),
             )
         }
 
@@ -139,6 +202,9 @@ class ApkManifestReader @Inject constructor() {
 
     companion object {
         private const val ANDROID_NS = "http://schemas.android.com/apk/res/android"
+        private const val FREE_HEAP_ENTRY_RATIO = 0.20
+        private const val BUDGET_MAX_HEAP_RATIO = 0.25
+        private const val PARSE_SLACK_BYTES = 2L * 1024 * 1024 // 2 MB safety margin
         private val TAG = logTag("Apps", "Manifest", "Reader")
     }
 }

--- a/app/src/main/java/eu/darken/myperm/apps/core/manifest/ManifestCache.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/manifest/ManifestCache.kt
@@ -12,6 +12,15 @@ import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/**
+ * Two-tier on-disk cache:
+ * - `<pkg>.json` — full manifest including raw XML, used by the manifest viewer.
+ * - `<pkg>.queries.json` — queries projection only, used by the hint scanner.
+ *
+ * Corruption in one file does not evict the valid sibling. On a queries-only miss we
+ * lazily backfill the sibling from the full cache if it is present and version-valid
+ * (prevents a reparse storm after upgrade to a version that writes both files).
+ */
 @Singleton
 class ManifestCache @Inject constructor(
     @ApplicationContext private val context: Context,
@@ -20,18 +29,19 @@ class ManifestCache @Inject constructor(
     private val cacheDir: File
         get() = File(context.cacheDir, "manifests").also { it.mkdirs() }
 
+    /** Full cache read. Returns null on miss, version mismatch, or corruption. */
     fun get(
         pkgName: Pkg.Name,
         versionCode: Long,
         lastUpdateTime: Long,
     ): ManifestData? {
-        val file = cacheFile(pkgName)
+        val file = fullCacheFile(pkgName)
         if (!file.exists()) return null
 
         return try {
             val cached = json.decodeFromString<CachedManifest>(file.readText())
             if (cached.versionCode != versionCode || cached.lastUpdateTime != lastUpdateTime) {
-                log(TAG) { "Cache stale for $pkgName: version/time mismatch" }
+                log(TAG) { "Full cache stale for $pkgName: version/time mismatch" }
                 file.delete()
                 return null
             }
@@ -41,8 +51,62 @@ class ManifestCache @Inject constructor(
                     ?: QueriesResult.Error(IllegalStateException("Queries not cached")),
             )
         } catch (e: Exception) {
-            log(TAG, WARN) { "Failed to read cache for $pkgName: $e" }
+            log(TAG, WARN) { "Failed to read full cache for $pkgName: $e" }
             file.delete()
+            null
+        }
+    }
+
+    /**
+     * Queries-only cache read. Never deserializes raw XML. Falls back to backfilling from
+     * the full cache if the sibling is missing but the full file is present and valid.
+     */
+    fun getQueries(
+        pkgName: Pkg.Name,
+        versionCode: Long,
+        lastUpdateTime: Long,
+    ): QueriesInfo? {
+        val siblingFile = queriesCacheFile(pkgName)
+        if (siblingFile.exists()) {
+            try {
+                val cached = json.decodeFromString<CachedQueries>(siblingFile.readText())
+                if (cached.versionCode != versionCode || cached.lastUpdateTime != lastUpdateTime) {
+                    log(TAG) { "Queries cache stale for $pkgName: version/time mismatch" }
+                    siblingFile.delete()
+                } else {
+                    return cached.queries
+                }
+            } catch (e: Exception) {
+                log(TAG, WARN) { "Failed to read queries cache for $pkgName: $e" }
+                siblingFile.delete()
+                // fall through to backfill attempt
+            }
+        }
+
+        // Lazy backfill from the full cache, if available and version-valid. Avoids a
+        // reparse storm on upgrade when only the old full `.json` files exist.
+        val fullFile = fullCacheFile(pkgName)
+        if (!fullFile.exists()) return null
+        return try {
+            val cached = json.decodeFromString<CachedManifest>(fullFile.readText())
+            if (cached.versionCode != versionCode || cached.lastUpdateTime != lastUpdateTime) {
+                return null
+            }
+            val queries = cached.queries ?: return null
+            // Write the sibling so future reads skip the rawXml deserialization.
+            try {
+                siblingFile.writeText(
+                    json.encodeToString(
+                        CachedQueries.serializer(),
+                        CachedQueries(versionCode, lastUpdateTime, queries),
+                    )
+                )
+            } catch (e: Exception) {
+                log(TAG, WARN) { "Failed to backfill queries cache for $pkgName: $e" }
+            }
+            queries
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Failed to backfill-read full cache for $pkgName: $e" }
             null
         }
     }
@@ -63,15 +127,26 @@ class ManifestCache @Inject constructor(
                 rawXml = rawXml,
                 queries = queries,
             )
-            cacheFile(pkgName).writeText(json.encodeToString(CachedManifest.serializer(), cached))
+            fullCacheFile(pkgName).writeText(json.encodeToString(CachedManifest.serializer(), cached))
         } catch (e: Exception) {
-            log(TAG, WARN) { "Failed to write cache for $pkgName: $e" }
+            log(TAG, WARN) { "Failed to write full cache for $pkgName: $e" }
+        }
+
+        if (queries != null) {
+            try {
+                val siblingPayload = CachedQueries(versionCode, lastUpdateTime, queries)
+                queriesCacheFile(pkgName).writeText(
+                    json.encodeToString(CachedQueries.serializer(), siblingPayload)
+                )
+            } catch (e: Exception) {
+                log(TAG, WARN) { "Failed to write queries cache for $pkgName: $e" }
+            }
         }
     }
 
-    private fun cacheFile(pkgName: Pkg.Name): File {
-        return File(cacheDir, "${pkgName.value}.json")
-    }
+    private fun fullCacheFile(pkgName: Pkg.Name): File = File(cacheDir, "${pkgName.value}.json")
+
+    private fun queriesCacheFile(pkgName: Pkg.Name): File = File(cacheDir, "${pkgName.value}.queries.json")
 
     @Serializable
     private data class CachedManifest(
@@ -79,6 +154,13 @@ class ManifestCache @Inject constructor(
         val lastUpdateTime: Long,
         val rawXml: String,
         val queries: QueriesInfo?,
+    )
+
+    @Serializable
+    private data class CachedQueries(
+        val versionCode: Long,
+        val lastUpdateTime: Long,
+        val queries: QueriesInfo,
     )
 
     companion object {

--- a/app/src/main/java/eu/darken/myperm/apps/core/manifest/ManifestData.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/manifest/ManifestData.kt
@@ -16,4 +16,23 @@ sealed class QueriesResult {
     data class Error(val error: Throwable) : QueriesResult()
 }
 
-enum class UnavailableReason { APK_NOT_FOUND, APK_NOT_READABLE, PKG_NOT_FOUND, LOW_MEMORY }
+/**
+ * Narrow outcome for callers that only need the `<queries>` projection and must not retain
+ * the raw manifest XML. Keeps the memory-cache footprint bounded and lets us distinguish
+ * transient failures (LOW_MEMORY, generic Failure) that should be retried from stable ones
+ * (APK_TOO_LARGE, PKG_NOT_FOUND) that can be cached.
+ */
+sealed interface QueriesOutcome {
+    data class Success(val info: QueriesInfo) : QueriesOutcome
+    data class Unavailable(val reason: UnavailableReason) : QueriesOutcome
+    data class Failure(val error: Throwable) : QueriesOutcome
+}
+
+enum class UnavailableReason {
+    APK_NOT_FOUND,
+    APK_NOT_READABLE,
+    PKG_NOT_FOUND,
+    LOW_MEMORY,
+    APK_TOO_LARGE,
+    MALFORMED_APK,
+}

--- a/app/src/main/java/eu/darken/myperm/apps/core/manifest/ManifestHintRepo.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/manifest/ManifestHintRepo.kt
@@ -60,7 +60,7 @@ class ManifestHintRepo @Inject constructor(
         }
     }
 
-    suspend fun runScan(apps: List<AppInfo>) {
+    suspend fun runScan(apps: List<AppInfo>) = try {
         val existingByPkg = manifestHintDao.getAll().associateBy { it.pkgName }
         val pending = apps.distinctBy { it.pkgName }.toMutableList()
         val total = pending.size
@@ -70,6 +70,7 @@ class ManifestHintRepo @Inject constructor(
         log(TAG) { "Starting scan of $total unique packages" }
 
         val newHints = mutableListOf<ManifestHintEntity>()
+        val counts = OutcomeCounts()
 
         while (pending.isNotEmpty()) {
             val priorityPkg = priorityQueue.poll()
@@ -89,39 +90,55 @@ class ManifestHintRepo @Inject constructor(
             }
 
             _currentlyScanning.value = nextApp.pkgName
-            val manifestData = manifestRepo.getManifest(nextApp.pkgName)
+            val outcome = manifestRepo.getQueriesFor(nextApp.pkgName)
 
-            // Skip hint upsert on transient failures (LOW_MEMORY/OOM) to avoid persisting false "no queries"
-            if (manifestData.rawXml is RawXmlResult.Unavailable &&
-                (manifestData.rawXml as RawXmlResult.Unavailable).reason == UnavailableReason.LOW_MEMORY
-            ) {
-                scanned++
-                _scanProgress.value = ScanProgress(total, scanned)
-                continue
-            }
+            when (outcome) {
+                is QueriesOutcome.Success -> {
+                    counts.success++
+                    val flags = manifestHintScanner.evaluate(outcome.info)
+                    newHints.add(
+                        ManifestHintEntity(
+                            pkgName = nextApp.pkgName,
+                            versionCode = nextApp.versionCode,
+                            lastUpdateTime = lastUpdateTime,
+                            hasActionMainQuery = flags.hasActionMainQuery,
+                            packageQueryCount = flags.packageQueryCount,
+                            intentQueryCount = flags.intentQueryCount,
+                            providerQueryCount = flags.providerQueryCount,
+                            scannedAt = System.currentTimeMillis(),
+                        )
+                    )
 
-            val queriesInfo = when (val q = manifestData.queries) {
-                is QueriesResult.Success -> q.info
-                is QueriesResult.Error -> QueriesInfo()
-            }
+                    // Upsert in batches of 20 so hints become visible incrementally
+                    if (newHints.size >= 20) {
+                        manifestHintDao.upsertHints(newHints)
+                        newHints.clear()
+                    }
+                }
 
-            val flags = manifestHintScanner.evaluate(queriesInfo)
-            val hint = ManifestHintEntity(
-                pkgName = nextApp.pkgName,
-                versionCode = nextApp.versionCode,
-                lastUpdateTime = lastUpdateTime,
-                hasActionMainQuery = flags.hasActionMainQuery,
-                packageQueryCount = flags.packageQueryCount,
-                intentQueryCount = flags.intentQueryCount,
-                providerQueryCount = flags.providerQueryCount,
-                scannedAt = System.currentTimeMillis(),
-            )
-            newHints.add(hint)
+                is QueriesOutcome.Unavailable -> {
+                    when (outcome.reason) {
+                        UnavailableReason.LOW_MEMORY -> counts.lowMemory++
+                        UnavailableReason.APK_TOO_LARGE -> counts.apkTooLarge++
+                        UnavailableReason.MALFORMED_APK,
+                        UnavailableReason.APK_NOT_FOUND,
+                        UnavailableReason.APK_NOT_READABLE,
+                        UnavailableReason.PKG_NOT_FOUND -> counts.failure++
+                    }
+                    // If a prior scan succeeded for an older version, that stale hint must not
+                    // outlive the new (unreadable) app. Delete so the UI falls back to the
+                    // "queued/no data" state instead of showing old flags.
+                    if (existing != null) {
+                        manifestHintDao.deleteByPkgName(nextApp.pkgName)
+                    }
+                }
 
-            // Upsert in batches of 20 so hints become visible incrementally
-            if (newHints.size >= 20) {
-                manifestHintDao.upsertHints(newHints)
-                newHints.clear()
+                is QueriesOutcome.Failure -> {
+                    counts.failure++
+                    if (existing != null) {
+                        manifestHintDao.deleteByPkgName(nextApp.pkgName)
+                    }
+                }
             }
 
             scanned++
@@ -133,10 +150,21 @@ class ManifestHintRepo @Inject constructor(
         }
 
         manifestHintDao.pruneStale()
+
+        log(TAG) {
+            "Scan complete: $scanned packages — success=${counts.success} lowMemory=${counts.lowMemory} " +
+                "apkTooLarge=${counts.apkTooLarge} failure=${counts.failure}"
+        }
+    } finally {
         _currentlyScanning.value = null
         _scanProgress.value = null
+    }
 
-        log(TAG) { "Scan complete: $scanned packages processed" }
+    private class OutcomeCounts {
+        var success = 0
+        var lowMemory = 0
+        var apkTooLarge = 0
+        var failure = 0
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/myperm/apps/core/manifest/ManifestRepo.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/manifest/ManifestRepo.kt
@@ -5,10 +5,16 @@ import android.content.pm.PackageManager
 import android.os.Build
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.myperm.apps.core.Pkg
+import eu.darken.myperm.common.coroutine.AppScope
 import eu.darken.myperm.common.coroutine.DispatcherProvider
 import eu.darken.myperm.common.debug.logging.log
 import eu.darken.myperm.common.debug.logging.logTag
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -19,48 +25,127 @@ class ManifestRepo @Inject constructor(
     private val apkManifestReader: ApkManifestReader,
     private val manifestCache: ManifestCache,
     private val dispatcherProvider: DispatcherProvider,
+    @AppScope private val appScope: CoroutineScope,
     @ApplicationContext private val context: Context,
 ) {
-    private val semaphore = Semaphore(2)
-    private val memoryCache = object : LinkedHashMap<String, ManifestData>(30, 0.75f, true) {
-        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, ManifestData>?) = size > 30
+    // Single-permit so two 40MB parses never overlap. Single-flight below deduplicates
+    // concurrent callers for the same package so this isn't a throughput problem.
+    private val semaphore = Semaphore(1)
+
+    // Memory cache holds only the query projection — raw XML is NOT retained in memory.
+    // Keyed by (pkg, versionCode, lastUpdate) so app updates auto-invalidate.
+    // Transient failures (LOW_MEMORY, Failure) are never cached so they're retried.
+    private val memoryCache = object : LinkedHashMap<ParseCacheKey, QueriesOutcome>(MEMORY_CACHE_SIZE, 0.75f, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<ParseCacheKey, QueriesOutcome>?) =
+            size > MEMORY_CACHE_SIZE
     }
 
-    suspend fun getManifest(pkgName: Pkg.Name): ManifestData = withContext(dispatcherProvider.IO) {
-        val cacheKey = pkgName.value
+    private val inFlightMutex = Mutex()
+    private val inFlight = HashMap<ParseCacheKey, Deferred<ManifestData>>()
 
-        synchronized(memoryCache) { memoryCache[cacheKey] }?.let {
-            log(TAG) { "Memory cache hit for $pkgName" }
+    /**
+     * Full manifest — used by the manifest viewer. Returns raw XML.
+     * Goes through the single-flight parse path so a concurrent scanner call shares the work.
+     * Does not populate the memory cache with raw XML (the viewer re-reads from disk).
+     */
+    suspend fun getManifest(pkgName: Pkg.Name): ManifestData = withContext(dispatcherProvider.IO) {
+        val appMeta = resolveAppMeta(pkgName) ?: return@withContext ManifestData(
+            rawXml = RawXmlResult.Unavailable(UnavailableReason.PKG_NOT_FOUND),
+            queries = QueriesResult.Error(IllegalStateException("Package not found: $pkgName")),
+        )
+        val key = ParseCacheKey(pkgName.value, appMeta.versionCode, appMeta.lastUpdateTime)
+
+        manifestCache.get(pkgName, appMeta.versionCode, appMeta.lastUpdateTime)?.let {
+            log(TAG) { "Full cache hit for $pkgName" }
             return@withContext it
         }
 
-        val appMeta = resolveAppMeta(pkgName)
-        if (appMeta == null) {
-            log(TAG) { "Package not found: $pkgName" }
-            return@withContext ManifestData(
-                rawXml = RawXmlResult.Unavailable(UnavailableReason.PKG_NOT_FOUND),
-                queries = QueriesResult.Error(IllegalStateException("Package not found: $pkgName")),
-            )
+        val data = parseOrAwait(key, appMeta.sourceDir, pkgName, appMeta.versionCode, appMeta.lastUpdateTime)
+        data
+    }
+
+    /**
+     * Queries-only — used by the background hint scanner. Never retains raw XML on this path.
+     * Memory cache holds only the [QueriesOutcome]. Disk cache (if hit) is read as the
+     * queries-only sibling, no raw XML deserialization.
+     */
+    suspend fun getQueriesFor(pkgName: Pkg.Name): QueriesOutcome = withContext(dispatcherProvider.IO) {
+        val appMeta = resolveAppMeta(pkgName) ?: return@withContext QueriesOutcome.Unavailable(UnavailableReason.PKG_NOT_FOUND)
+        val key = ParseCacheKey(pkgName.value, appMeta.versionCode, appMeta.lastUpdateTime)
+
+        synchronized(memoryCache) { memoryCache[key] }?.let {
+            log(TAG) { "Queries memory cache hit for $pkgName" }
+            return@withContext it
         }
 
-        manifestCache.get(pkgName, appMeta.versionCode, appMeta.lastUpdateTime)?.let { cached ->
-            log(TAG) { "Disk cache hit for $pkgName" }
-            synchronized(memoryCache) { memoryCache[cacheKey] = cached }
-            return@withContext cached
+        manifestCache.getQueries(pkgName, appMeta.versionCode, appMeta.lastUpdateTime)?.let { queries ->
+            log(TAG) { "Queries disk cache hit for $pkgName" }
+            val outcome = QueriesOutcome.Success(queries)
+            synchronized(memoryCache) { memoryCache[key] = outcome }
+            return@withContext outcome
         }
 
-        semaphore.withPermit {
-            // Double-check memory cache after acquiring permit
-            synchronized(memoryCache) { memoryCache[cacheKey] }?.let { return@withPermit it }
+        val data = parseOrAwait(key, appMeta.sourceDir, pkgName, appMeta.versionCode, appMeta.lastUpdateTime)
+        toOutcomeAndCache(key, data)
+    }
 
-            log(TAG) { "Parsing APK for $pkgName at ${appMeta.sourceDir}" }
-            val result = apkManifestReader.readManifest(appMeta.sourceDir)
-            // Only cache successful parses — transient failures (LOW_MEMORY) should be retried
-            if (result.rawXml is RawXmlResult.Success) {
-                manifestCache.put(pkgName, appMeta.versionCode, appMeta.lastUpdateTime, result)
-                synchronized(memoryCache) { memoryCache[cacheKey] = result }
-            }
-            result
+    /**
+     * Shared single-flight entry. Callers for the same [key] join the same deferred —
+     * we only open and parse the APK once, and each caller takes what they need.
+     */
+    private suspend fun parseOrAwait(
+        key: ParseCacheKey,
+        sourceDir: String,
+        pkgName: Pkg.Name,
+        versionCode: Long,
+        lastUpdateTime: Long,
+    ): ManifestData {
+        val deferred: Deferred<ManifestData> = inFlightMutex.withLock {
+            inFlight[key] ?: appScope.async(dispatcherProvider.IO) {
+                try {
+                    semaphore.withPermit {
+                        log(TAG) { "Parsing APK for $pkgName at $sourceDir" }
+                        val result = apkManifestReader.readManifest(sourceDir)
+                        if (result.rawXml is RawXmlResult.Success) {
+                            manifestCache.put(pkgName, versionCode, lastUpdateTime, result)
+                        }
+                        result
+                    }
+                } finally {
+                    inFlightMutex.withLock { inFlight.remove(key) }
+                }
+            }.also { inFlight[key] = it }
+        }
+        return deferred.await()
+    }
+
+    private fun toOutcomeAndCache(key: ParseCacheKey, data: ManifestData): QueriesOutcome {
+        val outcome = toOutcome(data)
+        if (shouldMemoryCache(outcome)) {
+            synchronized(memoryCache) { memoryCache[key] = outcome }
+        }
+        return outcome
+    }
+
+    private fun toOutcome(data: ManifestData): QueriesOutcome = when (val q = data.queries) {
+        is QueriesResult.Success -> QueriesOutcome.Success(q.info)
+        is QueriesResult.Error -> when (val raw = data.rawXml) {
+            is RawXmlResult.Unavailable -> QueriesOutcome.Unavailable(raw.reason)
+            is RawXmlResult.Error -> QueriesOutcome.Failure(raw.error)
+            is RawXmlResult.Success -> QueriesOutcome.Failure(q.error)
+        }
+    }
+
+    private fun shouldMemoryCache(outcome: QueriesOutcome): Boolean = when (outcome) {
+        is QueriesOutcome.Success -> true
+        is QueriesOutcome.Failure -> false                   // transient, let it retry
+        is QueriesOutcome.Unavailable -> when (outcome.reason) {
+            UnavailableReason.LOW_MEMORY -> false            // transient
+            UnavailableReason.APK_NOT_FOUND,
+            UnavailableReason.APK_NOT_READABLE,
+            UnavailableReason.PKG_NOT_FOUND,
+            UnavailableReason.APK_TOO_LARGE,
+            UnavailableReason.MALFORMED_APK -> true          // stable until app updates
         }
     }
 
@@ -82,7 +167,10 @@ class ManifestRepo @Inject constructor(
 
     private data class AppMeta(val versionCode: Long, val lastUpdateTime: Long, val sourceDir: String)
 
+    private data class ParseCacheKey(val pkg: String, val versionCode: Long, val lastUpdate: Long)
+
     companion object {
+        private const val MEMORY_CACHE_SIZE = 30
         private val TAG = logTag("Apps", "Manifest", "Repo")
     }
 }

--- a/app/src/main/java/eu/darken/myperm/common/debug/recording/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/myperm/common/debug/recording/core/RecorderModule.kt
@@ -40,13 +40,17 @@ class RecorderModule @Inject constructor(
     private val installId: InstallId,
 ) {
 
-    private val triggerFile = try {
-        File(context.getExternalFilesDir(null), FORCE_FILE)
-    } catch (e: Exception) {
-        File(
-            Environment.getExternalStorageDirectory(),
-            "/Android/data/${BuildConfigWrap.APPLICATION_ID}/files/$FORCE_FILE"
-        )
+    // Lazy to keep Hilt construction off the filesystem — getExternalFilesDir()
+    // does mkdirs and can ANR on main thread during App.onCreate on slow devices.
+    private val triggerFile: File by lazy {
+        try {
+            File(context.getExternalFilesDir(null), FORCE_FILE)
+        } catch (e: Exception) {
+            File(
+                Environment.getExternalStorageDirectory(),
+                "/Android/data/${BuildConfigWrap.APPLICATION_ID}/files/$FORCE_FILE"
+            )
+        }
     }
 
     @Volatile
@@ -152,10 +156,12 @@ class RecorderModule @Inject constructor(
         return sessionDir
     }
 
-    internal val externalLogDir: File? = try {
-        context.getExternalFilesDir(null)?.let { File(it, "debug/logs") }
-    } catch (e: Exception) {
-        null
+    internal val externalLogDir: File? by lazy {
+        try {
+            context.getExternalFilesDir(null)?.let { File(it, "debug/logs") }
+        } catch (e: Exception) {
+            null
+        }
     }
 
     internal val cacheLogDir: File = File(context.cacheDir, "debug/logs")

--- a/app/src/main/java/eu/darken/myperm/common/room/dao/ManifestHintDao.kt
+++ b/app/src/main/java/eu/darken/myperm/common/room/dao/ManifestHintDao.kt
@@ -3,6 +3,7 @@ package eu.darken.myperm.common.room.dao
 import androidx.room.Dao
 import androidx.room.Query
 import androidx.room.Upsert
+import eu.darken.myperm.apps.core.Pkg
 import eu.darken.myperm.apps.core.manifest.ManifestHintEntity
 import kotlinx.coroutines.flow.Flow
 
@@ -17,6 +18,9 @@ interface ManifestHintDao {
 
     @Upsert
     suspend fun upsertHints(hints: List<ManifestHintEntity>)
+
+    @Query("DELETE FROM manifest_hints WHERE pkgName = :pkgName")
+    suspend fun deleteByPkgName(pkgName: Pkg.Name)
 
     @Query(
         """DELETE FROM manifest_hints WHERE pkgName NOT IN (

--- a/app/src/test/java/eu/darken/myperm/apps/core/AppRepoSaveSnapshotTest.kt
+++ b/app/src/test/java/eu/darken/myperm/apps/core/AppRepoSaveSnapshotTest.kt
@@ -131,7 +131,7 @@ class AppRepoSaveSnapshotTest : BaseTest() {
             )
         }
 
-        coEvery { snapshotMapper.toEntities(any(), pkg) } returns SnapshotMapper.PkgEntities(
+        coEvery { snapshotMapper.toEntities(any(), pkg, any()) } returns SnapshotMapper.PkgEntities(
             pkg = pkgEntity.copy(snapshotId = ""), // snapshotId is set dynamically
             permissions = permEntities.map { it.copy(snapshotId = "") },
             declaredPermissions = declaredPermEntities.map { it.copy(snapshotId = "") },
@@ -237,6 +237,72 @@ class AppRepoSaveSnapshotTest : BaseTest() {
         val totalPkgs = capturedPkgs.flatten()
         totalPkgs.size shouldBe 2
     }
+
+    @Test
+    fun `labels resolve before the transaction and mapper receives resolved label`() =
+        runTest2(autoCancel = true) {
+            val repo = createAppRepo(this)
+            settleInit()
+
+            // Gate: flip to true when database.inTransaction is entered. After that point,
+            // any call to pkg.getLabel() indicates a regression (label resolution leaked
+            // back into the transaction).
+            val inTransaction = java.util.concurrent.atomic.AtomicBoolean(false)
+            @Suppress("UNCHECKED_CAST")
+            coEvery { database.inTransaction(any<suspend () -> Any?>()) } coAnswers {
+                inTransaction.set(true)
+                val block = firstArg<suspend () -> Any?>()
+                val result = block()
+                inTransaction.set(false)
+                result
+            }
+
+            val pkg = mockk<BasePkg>(relaxed = true)
+            every { pkg.id } returns Pkg.Id(Pkg.Name("single.pkg"))
+            every { pkg.getLabel(any()) } answers {
+                if (inTransaction.get()) {
+                    error("pkg.getLabel() must not be called inside database.inTransaction")
+                }
+                "Resolved Label"
+            }
+            val capturedLabel = slot<String>()
+            coEvery {
+                snapshotMapper.toEntities(any(), pkg, capture(capturedLabel))
+            } returns SnapshotMapper.PkgEntities(
+                pkg = SnapshotPkgEntity(
+                    snapshotId = "",
+                    pkgName = Pkg.Name("single.pkg"),
+                    userHandleId = 0,
+                    pkgType = PkgType.PRIMARY,
+                    versionName = "1.0",
+                    versionCode = 1L,
+                    sharedUserId = null,
+                    apiTargetLevel = 33,
+                    apiCompileLevel = null,
+                    apiMinimumLevel = null,
+                    isSystemApp = false,
+                    installedAt = null,
+                    updatedAt = null,
+                    internetAccess = InternetAccess.UNKNOWN,
+                    batteryOptimization = BatteryOptimization.UNKNOWN,
+                    installerPkgName = null,
+                    applicationFlags = 0,
+                    cachedLabel = "Resolved Label",
+                    twinCount = 0,
+                    siblingCount = 0,
+                    hasAccessibilityServices = false,
+                    hasDeviceAdmin = false,
+                    allInstallerPkgNames = null,
+                ),
+                permissions = emptyList(),
+                declaredPermissions = emptyList(),
+            )
+
+            coEvery { appSourcer.scanPackages() } returns listOf(pkg)
+            repo.scanAndSave(TriggerReason.MANUAL_REFRESH)
+
+            capturedLabel.captured shouldBe "Resolved Label"
+        }
 
     @Test
     fun `scanAndSave works with fewer packages than chunk size`() = runTest2(autoCancel = true) {

--- a/app/src/test/java/eu/darken/myperm/apps/core/manifest/ApkManifestReaderTest.kt
+++ b/app/src/test/java/eu/darken/myperm/apps/core/manifest/ApkManifestReaderTest.kt
@@ -1,0 +1,139 @@
+package eu.darken.myperm.apps.core.manifest
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import testhelper.BaseTest
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+class ApkManifestReaderTest : BaseTest() {
+
+    private fun ApkManifestReader.setHeap(maxHeap: Long, freeHeap: Long) {
+        heapInfoProvider = { ApkManifestReader.HeapInfo(maxHeap = maxHeap, freeHeap = freeHeap) }
+    }
+
+    private fun writeApk(
+        parent: File,
+        name: String = "fake.apk",
+        arscBytes: ByteArray? = ByteArray(16),
+        manifestBytes: ByteArray? = ByteArray(16),
+    ): File {
+        val apk = File(parent, name)
+        ZipOutputStream(apk.outputStream()).use { zip ->
+            if (arscBytes != null) {
+                zip.putNextEntry(ZipEntry("resources.arsc"))
+                zip.write(arscBytes)
+                zip.closeEntry()
+            }
+            if (manifestBytes != null) {
+                zip.putNextEntry(ZipEntry("AndroidManifest.xml"))
+                zip.write(manifestBytes)
+                zip.closeEntry()
+            }
+        }
+        return apk
+    }
+
+    @Test
+    fun `returns APK_NOT_FOUND when file missing`() {
+        val reader = ApkManifestReader()
+        val result = reader.readManifest("/does/not/exist.apk")
+
+        val raw = result.rawXml.shouldBeInstanceOf<RawXmlResult.Unavailable>()
+        raw.reason shouldBe UnavailableReason.APK_NOT_FOUND
+    }
+
+    @Test
+    fun `returns LOW_MEMORY when entry heap gate fails`(@TempDir tempDir: File) {
+        val apk = writeApk(tempDir)
+        val reader = ApkManifestReader().also {
+            // freeHeap = 10% of max < 20% entry threshold
+            it.setHeap(maxHeap = 100_000_000L, freeHeap = 10_000_000L)
+        }
+
+        val result = reader.readManifest(apk.absolutePath)
+
+        val raw = result.rawXml.shouldBeInstanceOf<RawXmlResult.Unavailable>()
+        raw.reason shouldBe UnavailableReason.LOW_MEMORY
+    }
+
+    @Test
+    fun `returns MALFORMED_APK when resources_arsc missing`(@TempDir tempDir: File) {
+        val apk = writeApk(tempDir, arscBytes = null)
+        val reader = ApkManifestReader().also {
+            it.setHeap(maxHeap = 512_000_000L, freeHeap = 500_000_000L)
+        }
+
+        val result = reader.readManifest(apk.absolutePath)
+
+        val raw = result.rawXml.shouldBeInstanceOf<RawXmlResult.Unavailable>()
+        raw.reason shouldBe UnavailableReason.MALFORMED_APK
+    }
+
+    @Test
+    fun `returns MALFORMED_APK when AndroidManifest_xml missing`(@TempDir tempDir: File) {
+        val apk = writeApk(tempDir, manifestBytes = null)
+        val reader = ApkManifestReader().also {
+            it.setHeap(maxHeap = 512_000_000L, freeHeap = 500_000_000L)
+        }
+
+        val result = reader.readManifest(apk.absolutePath)
+
+        val raw = result.rawXml.shouldBeInstanceOf<RawXmlResult.Unavailable>()
+        raw.reason shouldBe UnavailableReason.MALFORMED_APK
+    }
+
+    @Test
+    fun `returns MALFORMED_APK for non-zip file`(@TempDir tempDir: File) {
+        val notApk = File(tempDir, "not_an_apk.apk").apply { writeText("definitely not a zip") }
+        val reader = ApkManifestReader().also {
+            it.setHeap(maxHeap = 512_000_000L, freeHeap = 500_000_000L)
+        }
+
+        val result = reader.readManifest(notApk.absolutePath)
+
+        val raw = result.rawXml.shouldBeInstanceOf<RawXmlResult.Unavailable>()
+        raw.reason shouldBe UnavailableReason.MALFORMED_APK
+    }
+
+    @Test
+    fun `returns APK_TOO_LARGE when estimated peak exceeds budget`(@TempDir tempDir: File) {
+        // Synthesize a zip where resources.arsc is 30 MB. With budget = maxHeap * 0.25
+        // and maxHeap = 100 MB, budget is 25 MB. arscSize * 3 = 90 MB > 25 MB → reject.
+        val oversizedArsc = ByteArray(30 * 1024 * 1024) { 0 }
+        val apk = writeApk(tempDir, arscBytes = oversizedArsc)
+        val reader = ApkManifestReader().also {
+            it.setHeap(maxHeap = 100_000_000L, freeHeap = 95_000_000L)
+        }
+
+        val result = reader.readManifest(apk.absolutePath)
+
+        val raw = result.rawXml.shouldBeInstanceOf<RawXmlResult.Unavailable>()
+        raw.reason shouldBe UnavailableReason.APK_TOO_LARGE
+    }
+
+    @Test
+    fun `returns LOW_MEMORY on post-preflight heap check`(@TempDir tempDir: File) {
+        // Budget check passes but second heap check fails.
+        // arscSize * 3 + manifestSize * 2 + slack must be LESS than maxHeap * 0.25 AND
+        // MORE than the mocked freeHeap.
+        val smallArsc = ByteArray(2 * 1024 * 1024)        // 2 MB
+        val smallManifest = ByteArray(512 * 1024)         // 0.5 MB
+        val apk = writeApk(tempDir, arscBytes = smallArsc, manifestBytes = smallManifest)
+
+        // estimatedPeak ≈ 2*3 + 0.5*2 + 2 = 9 MB
+        // maxHeap * 0.25 = 40 MB → budget OK
+        // freeHeap = 8 MB < estimatedPeak + slack (9 + 2 = 11 MB) → LOW_MEMORY
+        val reader = ApkManifestReader().also {
+            it.setHeap(maxHeap = 160_000_000L, freeHeap = 8 * 1024 * 1024L)
+        }
+
+        val result = reader.readManifest(apk.absolutePath)
+
+        val raw = result.rawXml.shouldBeInstanceOf<RawXmlResult.Unavailable>()
+        raw.reason shouldBe UnavailableReason.LOW_MEMORY
+    }
+}

--- a/app/src/test/java/eu/darken/myperm/apps/core/manifest/ManifestCacheTest.kt
+++ b/app/src/test/java/eu/darken/myperm/apps/core/manifest/ManifestCacheTest.kt
@@ -1,0 +1,138 @@
+package eu.darken.myperm.apps.core.manifest
+
+import android.content.Context
+import eu.darken.myperm.apps.core.Pkg
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotContain
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import testhelper.BaseTest
+import java.io.File
+
+class ManifestCacheTest : BaseTest() {
+
+    @TempDir
+    lateinit var cacheRoot: File
+
+    private val json = Json {
+        encodeDefaults = true
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
+
+    private lateinit var context: Context
+    private lateinit var cache: ManifestCache
+
+    private val pkg = Pkg.Name("com.example.app")
+    private val versionCode = 42L
+    private val lastUpdate = 1_700_000_000_000L
+
+    @BeforeEach
+    fun setup() {
+        context = mockk(relaxed = true)
+        every { context.cacheDir } returns cacheRoot
+        cache = ManifestCache(context, json)
+    }
+
+    private fun manifestsDir(): File = File(cacheRoot, "manifests").also { it.mkdirs() }
+    private fun fullFile(): File = File(manifestsDir(), "${pkg.value}.json")
+    private fun queriesFile(): File = File(manifestsDir(), "${pkg.value}.queries.json")
+
+    private fun sampleData(queries: QueriesInfo? = QueriesInfo(packageQueries = listOf("com.other"))): ManifestData =
+        ManifestData(
+            rawXml = RawXmlResult.Success("<manifest/>"),
+            queries = queries?.let { QueriesResult.Success(it) }
+                ?: QueriesResult.Error(IllegalStateException("no queries")),
+        )
+
+    @Test
+    fun `getQueries returns null on complete miss`() {
+        cache.getQueries(pkg, versionCode, lastUpdate) shouldBe null
+    }
+
+    @Test
+    fun `put writes both files and getQueries prefers sibling`() {
+        val queries = QueriesInfo(packageQueries = listOf("com.target"))
+        cache.put(pkg, versionCode, lastUpdate, sampleData(queries))
+
+        fullFile().exists() shouldBe true
+        queriesFile().exists() shouldBe true
+
+        val result = cache.getQueries(pkg, versionCode, lastUpdate).shouldNotBeNull()
+        result.packageQueries shouldBe listOf("com.target")
+    }
+
+    @Test
+    fun `getQueries sibling file never contains rawXml`() {
+        val queries = QueriesInfo(packageQueries = listOf("com.target"))
+        cache.put(pkg, versionCode, lastUpdate, sampleData(queries))
+
+        // The sibling file must NOT include rawXml — that's the whole point of the split.
+        queriesFile().readText().shouldNotContain("rawXml")
+    }
+
+    @Test
+    fun `getQueries backfills sibling from existing full cache`() {
+        // Simulate pre-upgrade state: only the full cache file exists (no sibling).
+        val queries = QueriesInfo(packageQueries = listOf("com.existing"))
+        cache.put(pkg, versionCode, lastUpdate, sampleData(queries))
+        queriesFile().delete()
+        queriesFile().exists() shouldBe false
+
+        val result = cache.getQueries(pkg, versionCode, lastUpdate).shouldNotBeNull()
+        result.packageQueries shouldBe listOf("com.existing")
+
+        // Sibling should have been written as a side effect of the backfill.
+        queriesFile().exists() shouldBe true
+        queriesFile().readText().shouldNotContain("rawXml")
+    }
+
+    @Test
+    fun `getQueries returns null when sibling stale and full absent`() {
+        // Write stale sibling.
+        queriesFile().writeText("""{"versionCode":1,"lastUpdateTime":1,"queries":{"packageQueries":[]}}""")
+
+        cache.getQueries(pkg, versionCode, lastUpdate) shouldBe null
+        // Stale sibling should be cleaned up.
+        queriesFile().exists() shouldBe false
+    }
+
+    @Test
+    fun `corrupt sibling does not evict valid full file`() {
+        cache.put(pkg, versionCode, lastUpdate, sampleData())
+        queriesFile().writeText("{not valid json")
+
+        // getQueries should fall back to backfilling from full, NOT delete full.
+        cache.getQueries(pkg, versionCode, lastUpdate).shouldNotBeNull()
+        fullFile().exists() shouldBe true
+    }
+
+    @Test
+    fun `corrupt full does not evict valid sibling`() {
+        cache.put(pkg, versionCode, lastUpdate, sampleData())
+        fullFile().writeText("{not valid json")
+
+        // Full read returns null and deletes corrupted full …
+        cache.get(pkg, versionCode, lastUpdate) shouldBe null
+        fullFile().exists() shouldBe false
+        // … but the sibling is untouched and still serves queries.
+        queriesFile().exists() shouldBe true
+        cache.getQueries(pkg, versionCode, lastUpdate).shouldNotBeNull()
+    }
+
+    @Test
+    fun `stale full cache deletes full but not sibling`() {
+        cache.put(pkg, versionCode, lastUpdate, sampleData())
+
+        // Caller asks for a different version — stale.
+        val result = cache.get(pkg, versionCode = versionCode + 1, lastUpdateTime = lastUpdate)
+        result shouldBe null
+        fullFile().exists() shouldBe false
+        queriesFile().exists() shouldBe true
+    }
+}

--- a/app/src/test/java/eu/darken/myperm/apps/core/manifest/ManifestHintRepoTest.kt
+++ b/app/src/test/java/eu/darken/myperm/apps/core/manifest/ManifestHintRepoTest.kt
@@ -1,0 +1,181 @@
+package eu.darken.myperm.apps.core.manifest
+
+import androidx.work.WorkManager
+import eu.darken.myperm.apps.core.AppInfo
+import eu.darken.myperm.apps.core.Pkg
+import eu.darken.myperm.apps.core.PermissionUse
+import eu.darken.myperm.apps.core.features.BatteryOptimization
+import eu.darken.myperm.apps.core.features.InternetAccess
+import eu.darken.myperm.common.room.dao.ManifestHintDao
+import eu.darken.myperm.common.room.entity.PkgType
+import io.kotest.matchers.nulls.shouldBeNull
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelper.BaseTest
+import testhelper.coroutine.runTest2
+import java.time.Instant
+
+class ManifestHintRepoTest : BaseTest() {
+
+    private lateinit var manifestHintDao: ManifestHintDao
+    private lateinit var manifestRepo: ManifestRepo
+    private lateinit var manifestHintScanner: ManifestHintScanner
+    private lateinit var workManager: WorkManager
+    private lateinit var appScope: CoroutineScope
+
+    @BeforeEach
+    fun setup() {
+        manifestHintDao = mockk(relaxed = true)
+        manifestRepo = mockk(relaxed = true)
+        manifestHintScanner = mockk(relaxed = true)
+        workManager = mockk(relaxed = true)
+        appScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher())
+
+        every { manifestHintDao.observeAll() } returns emptyFlow()
+        coEvery { manifestHintDao.getAll() } returns emptyList()
+        coEvery { manifestHintDao.upsertHints(any()) } just Runs
+        coEvery { manifestHintDao.deleteByPkgName(any()) } just Runs
+        coEvery { manifestHintDao.pruneStale() } just Runs
+        every { manifestHintScanner.evaluate(any()) } returns ManifestHintScanner.Flags(
+            hasActionMainQuery = false,
+            packageQueryCount = 0,
+            intentQueryCount = 0,
+            providerQueryCount = 0,
+        )
+    }
+
+    @AfterEach
+    fun teardown() {
+        appScope.cancel()
+    }
+
+    private fun buildRepo() = ManifestHintRepo(
+        appScope = appScope,
+        manifestHintDao = manifestHintDao,
+        manifestRepo = manifestRepo,
+        manifestHintScanner = manifestHintScanner,
+        workManager = workManager,
+    )
+
+    private fun appInfo(pkgName: String, versionCode: Long = 1L, lastUpdate: Long = 1_000L) = AppInfo(
+        pkgName = Pkg.Name(pkgName),
+        userHandleId = 0,
+        label = pkgName,
+        versionName = "1.0",
+        versionCode = versionCode,
+        isSystemApp = false,
+        installerPkgName = null,
+        apiTargetLevel = 33,
+        apiCompileLevel = null,
+        apiMinimumLevel = null,
+        internetAccess = InternetAccess.UNKNOWN,
+        batteryOptimization = BatteryOptimization.UNKNOWN,
+        installedAt = null,
+        updatedAt = Instant.ofEpochMilli(lastUpdate),
+        requestedPermissions = emptyList<PermissionUse>(),
+        declaredPermissionCount = 0,
+        pkgType = PkgType.PRIMARY,
+        twinCount = 0,
+        siblingCount = 0,
+        hasAccessibilityServices = false,
+        hasDeviceAdmin = false,
+        allInstallerPkgNames = emptyList(),
+        sharedUserId = null,
+        hasManifestFlags = null,
+    )
+
+    @Test
+    fun `Success outcome upserts hint`() = runTest2(autoCancel = true) {
+        val pkgName = Pkg.Name("com.foo")
+        coEvery { manifestRepo.getQueriesFor(pkgName) } returns QueriesOutcome.Success(QueriesInfo())
+
+        buildRepo().runScan(listOf(appInfo("com.foo")))
+
+        coVerify(atLeast = 1) { manifestHintDao.upsertHints(any()) }
+        coVerify(exactly = 0) { manifestHintDao.deleteByPkgName(any()) }
+    }
+
+    @Test
+    fun `APK_TOO_LARGE with existing version-mismatched hint deletes stale entry`() = runTest2(autoCancel = true) {
+        val pkgName = Pkg.Name("com.stale")
+        val staleHint = ManifestHintEntity(
+            pkgName = pkgName,
+            versionCode = 1L,            // old version
+            lastUpdateTime = 900L,
+            hasActionMainQuery = true,
+            packageQueryCount = 5,
+            intentQueryCount = 0,
+            providerQueryCount = 0,
+            scannedAt = 0L,
+        )
+        coEvery { manifestHintDao.getAll() } returns listOf(staleHint)
+        coEvery { manifestRepo.getQueriesFor(pkgName) } returns QueriesOutcome.Unavailable(UnavailableReason.APK_TOO_LARGE)
+
+        // New scan sees a different versionCode — the old hint must be evicted.
+        buildRepo().runScan(listOf(appInfo("com.stale", versionCode = 2L, lastUpdate = 2_000L)))
+
+        coVerify(exactly = 1) { manifestHintDao.deleteByPkgName(pkgName) }
+        coVerify(exactly = 0) { manifestHintDao.upsertHints(any()) }
+    }
+
+    @Test
+    fun `LOW_MEMORY with no existing hint is a no-op`() = runTest2(autoCancel = true) {
+        val pkgName = Pkg.Name("com.clean")
+        coEvery { manifestHintDao.getAll() } returns emptyList()
+        coEvery { manifestRepo.getQueriesFor(pkgName) } returns QueriesOutcome.Unavailable(UnavailableReason.LOW_MEMORY)
+
+        buildRepo().runScan(listOf(appInfo("com.clean")))
+
+        coVerify(exactly = 0) { manifestHintDao.deleteByPkgName(any()) }
+        coVerify(exactly = 0) { manifestHintDao.upsertHints(any()) }
+    }
+
+    @Test
+    fun `Failure outcome with existing mismatched hint deletes stale entry`() = runTest2(autoCancel = true) {
+        val pkgName = Pkg.Name("com.boom")
+        val staleHint = ManifestHintEntity(
+            pkgName = pkgName,
+            versionCode = 1L,
+            lastUpdateTime = 900L,
+            hasActionMainQuery = true,
+            packageQueryCount = 3,
+            intentQueryCount = 0,
+            providerQueryCount = 0,
+            scannedAt = 0L,
+        )
+        coEvery { manifestHintDao.getAll() } returns listOf(staleHint)
+        coEvery { manifestRepo.getQueriesFor(pkgName) } returns QueriesOutcome.Failure(RuntimeException("parser"))
+
+        buildRepo().runScan(listOf(appInfo("com.boom", versionCode = 2L, lastUpdate = 2_000L)))
+
+        coVerify(exactly = 1) { manifestHintDao.deleteByPkgName(pkgName) }
+    }
+
+    @Test
+    fun `exception during scan clears scan state`() = runTest2(autoCancel = true) {
+        val pkgName = Pkg.Name("com.throws")
+        coEvery { manifestRepo.getQueriesFor(pkgName) } throws RuntimeException("boom")
+
+        val repo = buildRepo()
+        try {
+            repo.runScan(listOf(appInfo("com.throws")))
+        } catch (_: RuntimeException) {
+            // expected — runScan doesn't swallow here, finally still runs.
+        }
+
+        repo.currentlyScanning.value.shouldBeNull()
+        repo.scanProgress.value.shouldBeNull()
+    }
+}

--- a/app/src/test/java/eu/darken/myperm/apps/core/manifest/ManifestRepoTest.kt
+++ b/app/src/test/java/eu/darken/myperm/apps/core/manifest/ManifestRepoTest.kt
@@ -1,0 +1,198 @@
+package eu.darken.myperm.apps.core.manifest
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import eu.darken.myperm.apps.core.Pkg
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import testhelper.BaseTest
+import testhelper.coroutine.TestDispatcherProvider
+import java.io.File
+
+class ManifestRepoTest : BaseTest() {
+
+    @TempDir
+    lateinit var cacheRoot: File
+
+    private val pkg = Pkg.Name("com.example.app")
+    private val versionCode = 42L
+    private val lastUpdate = 1_700_000_000_000L
+    private val apkPath = "/data/app/com.example.app-1/base.apk"
+
+    private lateinit var context: Context
+    private lateinit var packageManager: PackageManager
+    private lateinit var apkReader: ApkManifestReader
+    private lateinit var cache: ManifestCache
+
+    private val json = Json {
+        encodeDefaults = true
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
+
+    private fun successData(pkgQueries: List<String> = listOf("com.other")): ManifestData = ManifestData(
+        rawXml = RawXmlResult.Success("<manifest/>"),
+        queries = QueriesResult.Success(QueriesInfo(packageQueries = pkgQueries)),
+    )
+
+    @BeforeEach
+    fun setup() {
+        context = mockk(relaxed = true)
+        every { context.cacheDir } returns cacheRoot
+
+        packageManager = mockk(relaxed = true)
+        every { context.packageManager } returns packageManager
+
+        stubPackageInfo(versionCode, lastUpdate)
+
+        apkReader = mockk()
+        cache = ManifestCache(context, json)
+    }
+
+    @Suppress("DEPRECATION")
+    private fun stubPackageInfo(versionCode: Long, lastUpdate: Long) {
+        // JVM unit tests run against the Android stub jar: setLongVersionCode is a no-op
+        // and Build.VERSION.SDK_INT returns the default 0. So resolveAppMeta falls through
+        // to `pi.versionCode.toLong()` (the public int field), which we set directly.
+        val appInfo = ApplicationInfo().apply { sourceDir = apkPath }
+        val packageInfo = PackageInfo().apply {
+            this.packageName = pkg.value
+            this.versionCode = versionCode.toInt()
+            this.lastUpdateTime = lastUpdate
+            this.applicationInfo = appInfo
+        }
+        every { packageManager.getPackageInfo(pkg.value, 0) } returns packageInfo
+    }
+
+    /**
+     * Builds a ManifestRepo whose IO dispatcher and appScope share [scope]'s TestScheduler,
+     * so [runTest]'s scheduler fully drives the repo's internal async work.
+     */
+    private fun buildRepo(scope: TestScope): ManifestRepo {
+        val sharedDispatcher = UnconfinedTestDispatcher(scope.testScheduler)
+        val dispatcherProvider = TestDispatcherProvider(sharedDispatcher)
+        return ManifestRepo(
+            apkManifestReader = apkReader,
+            manifestCache = cache,
+            dispatcherProvider = dispatcherProvider,
+            appScope = scope as CoroutineScope,
+            context = context,
+        )
+    }
+
+    @Test
+    fun `getQueriesFor returns Success and memory-caches the projection`() = runTest {
+        every { apkReader.readManifest(apkPath) } returns successData(pkgQueries = listOf("com.target"))
+        val repo = buildRepo(this)
+
+        val outcome = repo.getQueriesFor(pkg).shouldBeInstanceOf<QueriesOutcome.Success>()
+        outcome.info.packageQueries shouldBe listOf("com.target")
+
+        // Second call hits memory cache.
+        repo.getQueriesFor(pkg).shouldBeInstanceOf<QueriesOutcome.Success>()
+        verify(exactly = 1) { apkReader.readManifest(apkPath) }
+    }
+
+    @Test
+    fun `memory cache entry never references raw XML`() = runTest {
+        every { apkReader.readManifest(apkPath) } returns successData()
+        val repo = buildRepo(this)
+
+        repo.getQueriesFor(pkg)
+
+        val cacheField = ManifestRepo::class.java.getDeclaredField("memoryCache").apply { isAccessible = true }
+        @Suppress("UNCHECKED_CAST")
+        val map = cacheField.get(repo) as Map<Any?, Any?>
+        map.isEmpty() shouldBe false
+        map.values.forEach { value ->
+            (value is QueriesOutcome).shouldBeTrue()
+            val text = value.toString()
+            (!text.contains("rawXml") && !text.contains("<manifest")).shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `cache invalidates when versionCode changes`() = runTest {
+        every { apkReader.readManifest(apkPath) } returns successData()
+        val repo = buildRepo(this)
+
+        repo.getQueriesFor(pkg)
+
+        // Simulate an app update — new versionCode means a new cache key and a new disk entry.
+        stubPackageInfo(versionCode = versionCode + 1, lastUpdate = lastUpdate)
+        repo.getQueriesFor(pkg)
+
+        verify(exactly = 2) { apkReader.readManifest(apkPath) }
+    }
+
+    @Test
+    fun `LOW_MEMORY outcome is not memory-cached`() = runTest {
+        every { apkReader.readManifest(apkPath) } returns ManifestData(
+            rawXml = RawXmlResult.Unavailable(UnavailableReason.LOW_MEMORY),
+            queries = QueriesResult.Error(IllegalStateException("low")),
+        )
+        val repo = buildRepo(this)
+
+        repo.getQueriesFor(pkg).shouldBeInstanceOf<QueriesOutcome.Unavailable>()
+        repo.getQueriesFor(pkg).shouldBeInstanceOf<QueriesOutcome.Unavailable>()
+
+        verify(exactly = 2) { apkReader.readManifest(apkPath) }
+    }
+
+    @Test
+    fun `Failure outcome is not memory-cached`() = runTest {
+        every { apkReader.readManifest(apkPath) } returns ManifestData(
+            rawXml = RawXmlResult.Error(RuntimeException("parser boom")),
+            queries = QueriesResult.Error(RuntimeException("parser boom")),
+        )
+        val repo = buildRepo(this)
+
+        repo.getQueriesFor(pkg).shouldBeInstanceOf<QueriesOutcome.Failure>()
+        repo.getQueriesFor(pkg).shouldBeInstanceOf<QueriesOutcome.Failure>()
+
+        verify(exactly = 2) { apkReader.readManifest(apkPath) }
+    }
+
+    @Test
+    fun `APK_TOO_LARGE outcome is memory-cached`() = runTest {
+        every { apkReader.readManifest(apkPath) } returns ManifestData(
+            rawXml = RawXmlResult.Unavailable(UnavailableReason.APK_TOO_LARGE),
+            queries = QueriesResult.Error(IllegalStateException("too large")),
+        )
+        val repo = buildRepo(this)
+
+        repo.getQueriesFor(pkg).shouldBeInstanceOf<QueriesOutcome.Unavailable>()
+        repo.getQueriesFor(pkg).shouldBeInstanceOf<QueriesOutcome.Unavailable>()
+
+        // Stable until the app updates — avoid reparsing.
+        verify(exactly = 1) { apkReader.readManifest(apkPath) }
+    }
+
+    @Test
+    fun `getManifest and getQueriesFor share single parse for same key`() = runTest {
+        every { apkReader.readManifest(apkPath) } returns successData(pkgQueries = listOf("com.shared"))
+        val repo = buildRepo(this)
+
+        val a = async { repo.getQueriesFor(pkg) }
+        val b = async { repo.getManifest(pkg) }
+        a.await()
+        b.await()
+
+        verify(exactly = 1) { apkReader.readManifest(apkPath) }
+    }
+}

--- a/app/src/test/java/eu/darken/myperm/common/debug/recording/core/RecorderModuleTest.kt
+++ b/app/src/test/java/eu/darken/myperm/common/debug/recording/core/RecorderModuleTest.kt
@@ -10,6 +10,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -64,6 +65,30 @@ class RecorderModuleTest {
             dispatcherProvider = dispatcherProvider,
             installId = installId,
         )
+    }
+
+    @Test
+    fun `construction does not touch getExternalFilesDir`() {
+        // Paused dispatcher so init's launchIn schedules but does not run. This simulates
+        // production where the init coroutines run on Dispatchers.Default (off the main
+        // thread that Hilt injection happens on). Only the synchronous constructor path
+        // is under test here.
+        val pausedScope = CoroutineScope(SupervisorJob() + StandardTestDispatcher())
+        val strictContext = mockk<Context>(relaxed = true)
+        every { strictContext.getExternalFilesDir(null) } throws AssertionError(
+            "getExternalFilesDir must not be called on the construction path"
+        )
+        every { strictContext.cacheDir } returns cacheDir
+
+        // Must not throw — both triggerFile and externalLogDir are `by lazy`, and the
+        // DynamicStateFlow start-value provider is only invoked when the flow is collected.
+        RecorderModule(
+            context = strictContext,
+            appScope = pausedScope,
+            dispatcherProvider = TestDispatcherProvider(StandardTestDispatcher()),
+            installId = installId,
+        )
+        pausedScope.cancel()
     }
 
     @Test


### PR DESCRIPTION
## What changed

A second round of mitigations for the out-of-memory crashes and application-not-responding reports still visible on 2.0.3-rc0 (user-perceived crash rate ~1.2%, ANR rate ~1.4%). Three independent paths are addressed:

- **Startup ANR on Samsung devices.** The debug log recorder no longer touches the filesystem during Hilt injection — `getExternalFilesDir()` was blocking the main thread inside `App.onCreate` because it auto-creates directories.
- **UI stalls while scanning installed apps.** The snapshot save held the database write lock while doing PackageManager IPC to resolve app labels. Labels are now resolved up front; the transaction itself is a pure DB write.
- **Background manifest scanning exhausted heap.** Two parses of large APKs could run concurrently, each spiking to tens of MB during the `ByteArrayOutputStream.grow` cycle, and the raw-XML memory cache held on to hundreds of KB per entry. Parses are now serialized, single-flighted across the viewer and the background scanner, and the memory cache stores only the queries projection.

## Technical Context

- `ApkManifestReader` now preflights `resources.arsc` and `AndroidManifest.xml` entry sizes via a `ZipFile` open. Rejects with `APK_TOO_LARGE` when `arscSize * 3 + manifestSize * 2 + slack` exceeds 25% of max heap. A second free-heap check runs immediately before `.manifestXml` so a transient allocation between the entry gate and the parse still aborts cleanly instead of OOMing. Entry free-heap gate bumped from 15% to 20%. Malformed zips / unknown entry sizes now surface as `MALFORMED_APK` instead of slipping through.
- `ManifestRepo` splits into `getManifest` (viewer, full data via disk cache) and `getQueriesFor` (scanner, `QueriesOutcome` only). Memory cache stores only the outcome — no raw XML — keyed by `(pkg, versionCode, lastUpdateTime)` so app updates auto-invalidate. `LOW_MEMORY` and `Failure` are not cached (retried); `APK_TOO_LARGE` is (stable until app updates). A Mutex-guarded per-key in-flight map single-flights the internal parse so a viewer + scanner collision for the same package shares one read. Concurrency reduced from `Semaphore(2)` to `Semaphore(1)`.
- `ManifestCache` adds `<pkg>.queries.json` siblings so query reads never deserialize raw XML. Lazy backfill from an existing full `.json` file avoids a reparse storm on upgrade for users who already have the old cache populated. Corruption in one file does not evict the sibling.
- `ManifestHintRepo` upserts hints only on `Success`. Non-Success outcomes with a version-mismatched existing hint call the new `ManifestHintDao.deleteByPkgName` so stale flags don't outlive the new app version (previously every `QueriesResult.Error` was persisted as empty queries). `runScan` wraps the body in `try/finally` so a thrown exception resets scan state, and outcome counts (`success/lowMemory/apkTooLarge/failure`) are logged at scan end for post-ship telemetry.
- `AppRepo.saveSnapshot` pre-resolves labels into `Map<Pkg.Id, String>` before opening the transaction. `SnapshotMapper.toEntities` now takes `resolvedLabel: String` directly via `Map.getValue` (loud-failure if a caller forgets to pre-resolve), and no longer depends on `Context`.
- `RecorderModule.triggerFile` and `externalLogDir` are both `by lazy`; first access happens off the main thread.

Review guidance: the trickiest piece is the single-flight. See `parseOrAwait` in `ManifestRepo.kt` — the `Deferred` is launched on `appScope` (detached from caller cancellation) and removes itself from the in-flight map in `finally`. A concurrent `getQueriesFor` + `getManifest` test covers this path.
