### PR TITLE
Fix: App list failure on multi-profile devices

### DIFF
--- a/app/src/main/java/eu/darken/myperm/apps/core/AppRepo.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/AppRepo.kt
@@ -175,6 +175,14 @@ class AppRepo @Inject constructor(
 
         val pkgList = pkgs.toList()
 
+        // Storage identity is (snapshotId, pkgName, userHandleId); Pkg.Id matches that
+        // by design. Scanner output must be unique by Pkg.Id, so a duplicate here is a
+        // scanner bug. Fail fast with the offending ids instead of a SQLite UNIQUE trace.
+        val duplicates = pkgList.groupBy { it.id }.filterValues { it.size > 1 }
+        check(duplicates.isEmpty()) {
+            "Duplicate Pkg.Id in scanner output: ${duplicates.keys}"
+        }
+
         // Resolve labels BEFORE the transaction. loadLabel() triggers PackageManager IPC
         // and Resources loading; holding the DB write lock during that blocks every
         // concurrent reader. We chunk the work to keep peak transient allocations bounded

--- a/app/src/main/java/eu/darken/myperm/apps/core/container/SecondaryProfilePkg.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/core/container/SecondaryProfilePkg.kt
@@ -9,7 +9,6 @@ import android.graphics.drawable.Drawable
 import android.os.Process
 import android.os.UserHandle
 import eu.darken.myperm.apps.core.AppRepo
-import eu.darken.myperm.apps.core.GET_UNINSTALLED_PACKAGES_COMPAT
 import eu.darken.myperm.apps.core.Pkg
 import eu.darken.myperm.apps.core.features.AccessibilityService
 import eu.darken.myperm.apps.core.features.InstallerInfo
@@ -149,34 +148,40 @@ suspend fun getSecondaryProfilePkgs(ipcFunnel: IPCFunnel): Collection<BasePkg> =
             emptyList()
         }
 
-        return launcherInfos.mapNotNull { lai ->
-            val appInfo = lai.applicationInfo
+        // LauncherApps.getActivityList returns one entry per launcher activity, so apps
+        // with multiple launcher activities yield multiple entries for the same package.
+        // Group by package and build one SecondaryProfilePkg per group, falling through to
+        // the next activity in the same group only if the current one's lookup fails.
+        return launcherInfos
+            .groupBy { it.applicationInfo.packageName }
+            .values
+            .mapNotNull { activitiesForPkg ->
+                activitiesForPkg.firstNotNullOfOrNull { lai ->
+                    val appInfo = lai.applicationInfo
 
-            var pkgInfo = ipcFunnel.packageManager.getPackageArchiveInfo(
-                appInfo.packageName,
-                GET_UNINSTALLED_PACKAGES_COMPAT
-            )
+                    val pkgInfo = ipcFunnel.packageManager.getPackageInfo(
+                        appInfo.packageName,
+                        PackageManager.GET_PERMISSIONS,
+                    ) ?: ipcFunnel.packageManager.getPackageArchiveInfo(
+                        appInfo.sourceDir,
+                        PackageManager.GET_PERMISSIONS,
+                    )
 
-            if (pkgInfo == null) {
-                log(AppRepo.TAG, VERBOSE) { "Failed to get info from packagemanager for $appInfo" }
-                pkgInfo =
-                    ipcFunnel.packageManager.getPackageArchiveInfo(appInfo.sourceDir, PackageManager.GET_PERMISSIONS)
+                    if (pkgInfo == null) {
+                        log(AppRepo.TAG, ERROR) { "Failed to read APK: ${appInfo.sourceDir}" }
+                        return@firstNotNullOfOrNull null
+                    }
+
+                    SecondaryProfilePkg(
+                        packageInfo = pkgInfo,
+                        installerInfo = pkgInfo.getInstallerInfo(ipcFunnel),
+                        launcherAppInfo = appInfo,
+                        userHandle = userHandle,
+                        extraPermissions = pkgInfo.determineSpecialPermissions(ipcFunnel, uidOverride = appInfo.uid),
+                        specialPermissionStatuses = pkgInfo.getSpecialPermissionStatuses(ipcFunnel, uidOverride = appInfo.uid),
+                    ).also { log(AppRepo.TAG) { "PKG[profile=${userHandle}}: $it" } }
+                }
             }
-
-            if (pkgInfo == null) {
-                log(AppRepo.TAG, ERROR) { "Failed to read APK: ${appInfo.sourceDir}" }
-                return@mapNotNull null
-            }
-
-            SecondaryProfilePkg(
-                packageInfo = pkgInfo,
-                installerInfo = pkgInfo.getInstallerInfo(ipcFunnel),
-                launcherAppInfo = appInfo,
-                userHandle = userHandle,
-                extraPermissions = pkgInfo.determineSpecialPermissions(ipcFunnel, uidOverride = appInfo.uid),
-                specialPermissionStatuses = pkgInfo.getSpecialPermissionStatuses(ipcFunnel, uidOverride = appInfo.uid),
-            ).also { log(AppRepo.TAG) { "PKG[profile=${userHandle}}: $it" } }
-        }
     }
 
     extraProfiles

--- a/app/src/test/java/eu/darken/myperm/apps/core/AppRepoSaveSnapshotTest.kt
+++ b/app/src/test/java/eu/darken/myperm/apps/core/AppRepoSaveSnapshotTest.kt
@@ -17,8 +17,11 @@ import eu.darken.myperm.common.room.entity.SnapshotPkgDeclaredPermEntity
 import eu.darken.myperm.common.room.entity.SnapshotPkgEntity
 import eu.darken.myperm.common.room.entity.SnapshotPkgPermEntity
 import eu.darken.myperm.common.room.entity.TriggerReason
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.mockk.Runs
+import io.mockk.coVerify
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.just
@@ -303,6 +306,29 @@ class AppRepoSaveSnapshotTest : BaseTest() {
 
             capturedLabel.captured shouldBe "Resolved Label"
         }
+
+    @Test
+    fun `scanAndSave rejects duplicate Pkg Ids from the scanner`() = runTest2(autoCancel = true) {
+        val repo = createAppRepo(this)
+        settleInit()
+
+        // Two BasePkg mocks share the same Pkg.Id instance, matching the scanner regression
+        // where LauncherApps.getActivityList emitted two SecondaryProfilePkg objects for the
+        // same (packageName, userHandle).
+        val duplicateId = Pkg.Id(Pkg.Name("duplicate.app"))
+        val pkg1 = mockk<BasePkg>(relaxed = true).also { every { it.id } returns duplicateId }
+        val pkg2 = mockk<BasePkg>(relaxed = true).also { every { it.id } returns duplicateId }
+
+        coEvery { appSourcer.scanPackages() } returns listOf(pkg1, pkg2)
+
+        val thrown = shouldThrow<IllegalStateException> {
+            repo.scanAndSave(TriggerReason.MANUAL_REFRESH)
+        }
+        thrown.message!! shouldContain "duplicate.app"
+
+        coVerify(exactly = 0) { snapshotPkgDao.insertPkgs(any()) }
+        coVerify(exactly = 0) { snapshotDao.insertSnapshot(any()) }
+    }
 
     @Test
     fun `scanAndSave works with fewer packages than chunk size`() = runTest2(autoCancel = true) {


### PR DESCRIPTION
## What changed

On devices with multiple user profiles (e.g. a work or secondary profile), apps that declare more than one launcher activity — such as some dialer/caller apps and OEM-preinstalled tools — caused the apps list to fail to load and keep showing the error screen from the previous fix (9f5b5c8). The scan now completes successfully on those devices.

Also cuts noisy "Failed to get info from packagemanager" verbose log lines that were showing up for every secondary-profile app.

## Technical Context

- **Root cause**: `LauncherApps.getActivityList(null, userHandle)` returns one entry per launcher activity, not per package. Apps declaring multiple launcher activities produced multiple `SecondaryProfilePkg` instances sharing the same `Pkg.Id = (packageName, userHandle)`, which collided on `SnapshotPkgEntity`'s composite primary key and aborted the whole `saveSnapshot` transaction. The `_scanError` surfacing from 9f5b5c8 worked — the UI correctly showed the error — but retrying re-ran the deterministic failure, so users stayed stuck on the error screen.
- **Source fix**: group `LauncherActivityInfo` by package name in `getSecondaryProfilePkgs` and build one package per group, falling through to sibling activities only if the current one's metadata lookup fails.
- **Incidental cleanup**: the previous first metadata lookup was `getPackageArchiveInfo(appInfo.packageName, …)` — `getPackageArchiveInfo` takes a file path, not a package name, so this always returned null and fell through to the `sourceDir` archive read. Replaced with `getPackageInfo(packageName, GET_PERMISSIONS)`, keeping the `sourceDir` archive read as the cross-profile fallback (the package may not be installed in the current profile).
- **Boundary tripwire**: `AppRepo.saveSnapshot` now asserts no duplicate `Pkg.Id` in scanner output before writing. If this invariant is ever violated again, the failure becomes an `IllegalStateException` with the offending ids — routed through the existing `_scanError` surfacing to the UI and the debug log — instead of a cryptic SQLite UNIQUE constraint trace buried inside Room-generated code.
- **Testing**: added regression test at the `saveSnapshot` boundary covering the tripwire. A scanner-level test for `getSecondaryProfilePkgs` was skipped in favor of the boundary test — mocking the full IPC chain plus the Android framework classes it depends on would add heavy scaffolding for coverage the boundary test already provides.

Closes #349
