### PR TITLE
General: Bump fastlane addressable and json to patched versions

### DIFF
--- a/fastlane/Gemfile.lock
+++ b/fastlane/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     CFPropertyList (3.0.8)
     abbrev (0.1.2)
-    addressable (2.8.8)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     artifactory (3.0.17)
     atomos (0.1.3)
@@ -169,7 +169,7 @@ GEM
     httpclient (2.9.0)
       mutex_m
     jmespath (1.6.2)
-    json (2.18.1)
+    json (2.19.4)
     jwt (2.10.2)
       base64
     logger (1.7.0)
@@ -185,7 +185,7 @@ GEM
     os (1.1.4)
     ostruct (0.6.3)
     plist (3.7.2)
-    public_suffix (7.0.2)
+    public_suffix (7.0.5)
     rake (13.3.1)
     representable (3.2.0)
       declarative (< 0.1.0)


### PR DESCRIPTION
## What changed

No user-facing behavior change. Updates two Ruby gems used by the fastlane screenshot/release pipeline to versions without published vulnerabilities.

## Technical Context

- Resolves Dependabot alerts on `fastlane/Gemfile.lock`:
  - `addressable` 2.8.8 → 2.9.0 (GHSA-h27x-rffw-24p4, ReDoS in template parsing)
  - `json` 2.18.1 → 2.19.4 (GHSA-3m6g-2423-7cp3, format string injection)
  - `public_suffix` 7.0.2 → 7.0.5 (transitive update from addressable)
- `fastlane/Gemfile` has no version pins, so this is a pure lockfile regeneration via targeted `bundle update addressable json`
- Other Dependabot alerts (12 total) auto-resolved when the root `Gemfile.lock` was removed in an earlier cleanup; only the `fastlane/Gemfile.lock` ones remained