### PR TITLE
Apps: Restrict battery filter to whitelisted apps

### DIFF
--- a/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsFilterOptions.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsFilterOptions.kt
@@ -94,7 +94,7 @@ data class AppsFilterOptions(
         BATTERY_OPTIMIZATION(
             group = Group.PROPERTIES,
             labelRes = R.string.apps_filter_battery_optimization_label,
-            matches = { it.batteryOptimization != BatteryOptimization.MANAGED_BY_SYSTEM }
+            matches = { it.batteryOptimization == BatteryOptimization.IGNORED }
         ),
         @SerialName("ACCESSIBILITY")
         ACCESSIBILITY(

--- a/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewViewModel.kt
@@ -173,7 +173,7 @@ class OverviewViewModel @Inject constructor(
             },
             SummaryCategory.SHARED_IDS to countPkg { it.siblingCount > 0 },
             SummaryCategory.BATTERY_OPT to countPkg {
-                it.batteryOptimization != BatteryOptimization.MANAGED_BY_SYSTEM
+                it.batteryOptimization == BatteryOptimization.IGNORED
             },
             SummaryCategory.OLD_API to countPkg {
                 it.apiTargetLevel != null && it.apiTargetLevel < AppsFilterOptions.OLD_API_THRESHOLD

--- a/app/src/test/java/eu/darken/myperm/apps/ui/list/AppsFilterOptionsTest.kt
+++ b/app/src/test/java/eu/darken/myperm/apps/ui/list/AppsFilterOptionsTest.kt
@@ -264,6 +264,19 @@ class AppsFilterOptionsTest : BaseTest() {
     }
 
     @Test
+    fun `BATTERY_OPTIMIZATION filter only matches whitelisted (IGNORED) apps`() {
+        val options = AppsFilterOptions(filters = setOf(AppsFilterOptions.Filter.BATTERY_OPTIMIZATION))
+        // IGNORED = on doze whitelist (Unrestricted) — matches
+        options.matches(app(batteryOptimization = BatteryOptimization.IGNORED)) shouldBe true
+        // OPTIMIZED = declares perm but not whitelisted (default Doze) — does not match
+        options.matches(app(batteryOptimization = BatteryOptimization.OPTIMIZED)) shouldBe false
+        // MANAGED_BY_SYSTEM = does not declare perm — does not match
+        options.matches(app(batteryOptimization = BatteryOptimization.MANAGED_BY_SYSTEM)) shouldBe false
+        // UNKNOWN — does not match
+        options.matches(app(batteryOptimization = BatteryOptimization.UNKNOWN)) shouldBe false
+    }
+
+    @Test
     fun `OLD_API_TARGET filter boundary - null, 28, 29`() {
         val options = AppsFilterOptions(filters = setOf(AppsFilterOptions.Filter.OLD_API_TARGET))
         // null apiTargetLevel — does not match


### PR DESCRIPTION
## What changed

The "Battery unrestricted apps" category on the Overview screen, and the matching battery filter on the Apps list, now only show apps that are actually whitelisted from battery optimization (i.e. set to *Unrestricted* in Android's per-app battery settings). Apps in the default *Optimized* state (or *Restricted*, on devices that expose it) no longer appear there.

Closes #359.

## Technical Context

- The filter was wired with `batteryOptimization != BatteryOptimization.MANAGED_BY_SYSTEM`, which matches both `IGNORED` (whitelisted) **and** `OPTIMIZED` (declares the perm but is not whitelisted). The label said "unrestricted" but the predicate said "any app that *can* request whitelisting".
- Same predicate was duplicated in `AppsFilterOptions.BATTERY_OPTIMIZATION` and `OverviewViewModel#SummaryCategory.BATTERY_OPT`. Both flipped to `== BatteryOptimization.IGNORED`.
- Explains the reporter's observation that "even after a refresh or app restart" the app stayed in the list: the underlying scan *was* updating the enum from `IGNORED` to `OPTIMIZED`, but the filter still matched. No One UI / Samsung quirk involved.
- Added a per-enum-value unit test on `BATTERY_OPTIMIZATION.matches`. Behavioural change is intentional — anyone who relied on the chip surfacing all apps that *declare* the permission has lost that view; the chip now matches the Overview label semantics.