### PR TITLE
Fix: Stop Filter/Sort sheet jitter on Android 12+

### DIFF
--- a/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsFilterSortBottomSheet.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsFilterSortBottomSheet.kt
@@ -62,7 +62,9 @@ fun AppsFilterSortBottomSheet(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .verticalScroll(rememberScrollState())
+                // overscrollEffect = null: API 31+ stretch overscroll dispatches nested-scroll deltas
+                // that race with ModalBottomSheet's drag-to-dismiss, causing visible jitter at the top.
+                .verticalScroll(state = rememberScrollState(), overscrollEffect = null)
                 .padding(horizontal = 16.dp)
                 .padding(bottom = 16.dp),
         ) {

--- a/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermsFilterSortBottomSheet.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermsFilterSortBottomSheet.kt
@@ -59,7 +59,9 @@ fun PermsFilterSortBottomSheet(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .verticalScroll(rememberScrollState())
+                // overscrollEffect = null: API 31+ stretch overscroll dispatches nested-scroll deltas
+                // that race with ModalBottomSheet's drag-to-dismiss, causing visible jitter at the top.
+                .verticalScroll(state = rememberScrollState(), overscrollEffect = null)
                 .padding(horizontal = 16.dp)
                 .padding(bottom = 16.dp),
         ) {


### PR DESCRIPTION
## What changed

The Filter and Sort sheet (opened from the filter icon on the Apps and Permissions tabs) no longer jitters or bounces when scrolled at its top boundary on Android 12 and newer.

## Technical Context

- Root cause: the inner `Column + verticalScroll` inside both `ModalBottomSheet`s used the default overscroll. On API 31+ that is the stretch effect, which dispatches scroll deltas through `NestedScrollConnection`. `ModalBottomSheet` also listens on that connection for its drag-to-dismiss handoff — the two race and produce the visible jitter.
- Fix: pass `overscrollEffect = null` on the inner `verticalScroll` so it no longer dispatches overscroll deltas. Sheet drag-to-dismiss still works via the same nested-scroll handoff.
- Trade-off: pre-API-31 edge glow inside these sheets is also removed — fine given how small the sheet content is.
- Other `ModalBottomSheet`s in the app (`WatcherFilterBottomSheet`, the support debug-log sheet) were checked; they don't use `verticalScroll` and are unaffected.
