### PR TITLE
Fix: Show correct billing period on subscription price hint

### DIFF
--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeScreen.kt
@@ -278,7 +278,7 @@ private fun PricingContent(
 
         if (state.subPrice != null) {
             Text(
-                text = stringResource(R.string.upgrade_screen_subscription_action_hint, state.subPrice),
+                text = stringResource(R.string.upgrade_screen_subscription_action_hint_yearly, state.subPrice),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(top = 4.dp),

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -6,7 +6,7 @@
     <string name="upgrade_screen_preamble">Permission Pilot is ad-free and respects your privacy. Upgrading supports continued development.</string>
     <string name="upgrade_screen_subscription_trial_action">Start free trial</string>
     <string name="upgrade_screen_subscription_action">Subscribe</string>
-    <string name="upgrade_screen_subscription_action_hint">%s/month, cancel anytime</string>
+    <string name="upgrade_screen_subscription_action_hint_yearly">%s/year, cancel anytime</string>
     <string name="upgrade_screen_iap_action">Buy Pro</string>
     <string name="upgrade_screen_iap_action_hint">One-time purchase of %s</string>
     <string name="upgrade_screen_restore_purchase_action">Restore purchase</string>


### PR DESCRIPTION
## What changed

The subscription option on the upgrade screen showed its price as "…/month" even though the subscription is billed once per **year**. Users saw a figure ~12× more expensive than what they're actually charged (e.g. "\$2.49/month" for a \$2.49/year plan). The hint now reads "…/year, cancel anytime".

No change to the one-time purchase.

## Technical Context

- **gplay flavor only** (foss has no billing). The plan is yearly-only, so the hint is fixed to the yearly wording rather than adding billing-period-detection machinery.
- The string key was **renamed** (`_yearly`) so untranslated locales fall back to the correct **English** string until translations are pulled, instead of surfacing the stale "/month" translations of the old key.
- **Translations deferred:** English source updated and already synced to Crowdin; locale files reconcile on the next translate → pull.
- Verified: `:app:compileGplayDebugKotlin` and `:app:lintVitalGplayBeta` pass (`ExtraTranslation` is disabled, so the temporarily-orphaned old key doesn't fail lint).