### PR TITLE
Fastlane: Bump faraday to 1.10.6 (GHSA-98m9-hrrm-r99r)

### DIFF
--- a/fastlane/Gemfile.lock
+++ b/fastlane/Gemfile.lock
@@ -43,7 +43,7 @@ GEM
     dotenv (2.8.1)
     emoji_regex (3.2.3)
     excon (0.112.0)
-    faraday (1.10.5)
+    faraday (1.10.6)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)


### PR DESCRIPTION
## What changed

No user-facing behavior change. Bumps the `faraday` gem (a fastlane build-tooling
dependency) from `1.10.5` to `1.10.6` to resolve a high-severity security advisory.

## Technical Context

- **Advisory:** GHSA-98m9-hrrm-r99r — uncontrolled recursion in Faraday's
  `NestedParamsEncoder` allows a stack-exhaustion DoS via deeply nested query
  parameters. Affects `<= 1.10.5`, patched in `1.10.6`. Closes Dependabot alert #19.
- **Why 1.10.6 (not 2.x):** `faraday` is a transitive dependency pinned to `~> 1.0`
  by both `fastlane` and `faraday_middleware`, so the 1.x line is the only in-range
  option; `1.10.6` is the patched release within it.
- **Why a surgical lockfile edit:** the local toolchain (Ruby 2.6 / bundler 2.2.8)
  differs from the version the lock was resolved with (bundler 2.6.2), so running
  `bundle update` would churn `BUNDLED WITH` and risk resolver drift. `faraday 1.10.6`
  declares an identical runtime dependency set to `1.10.5` (verified against the
  RubyGems API), and the lockfile has no `CHECKSUMS` section, so only the resolved
  version line changes — no sub-gems move.
- CI's Fastlane metadata job runs `bundle`, which validates the lockfile is consistent.
