### PR TITLE
General: Make Pro purchases and restore more reliable

### DIFF
--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/BillingCache.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/BillingCache.kt
@@ -3,6 +3,8 @@ package eu.darken.myperm.common.upgrade.core
 import android.content.Context
 import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.SharedPreferencesMigration
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -27,4 +29,21 @@ class BillingCache @Inject constructor(
         "gplay.cache.lastProAt",
         0L
     )
+
+    // Product id of the last confirmed Pro purchase; determines the grace window length.
+    val lastProStateSku = context.dataStore.createValue(
+        "gplay.cache.lastProSku",
+        ""
+    )
+
+    // Both values in one transaction: a process death or interleaved writer must not pair a fresh
+    // timestamp with a stale SKU, they select the grace window together.
+    suspend fun confirmPro(at: Long, sku: String) {
+        context.dataStore.edit { prefs ->
+            @Suppress("UNCHECKED_CAST")
+            prefs[lastProStateAt.key as Preferences.Key<Long>] = at
+            @Suppress("UNCHECKED_CAST")
+            prefs[lastProStateSku.key as Preferences.Key<String>] = sku
+        }
+    }
 }

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/UpgradeRepoGplay.kt
@@ -1,8 +1,11 @@
 package eu.darken.myperm.common.upgrade.core
 
 import android.app.Activity
+import android.os.SystemClock
 import eu.darken.myperm.common.coroutine.AppScope
 import eu.darken.myperm.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.myperm.common.debug.logging.Logging.Priority.WARN
+import eu.darken.myperm.common.debug.logging.asLog
 import eu.darken.myperm.common.debug.logging.log
 import eu.darken.myperm.common.debug.logging.logTag
 import eu.darken.myperm.common.upgrade.UpgradeRepo
@@ -12,11 +15,15 @@ import eu.darken.myperm.common.upgrade.core.data.BillingDataRepo
 import eu.darken.myperm.common.upgrade.core.data.PurchasedSku
 import eu.darken.myperm.common.upgrade.core.data.Sku
 import eu.darken.myperm.common.upgrade.core.data.SkuDetails
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.stateIn
 import java.io.IOException
@@ -37,39 +44,46 @@ class UpgradeRepoGplay @Inject constructor(
             billingCache.lastProStateAt.valueBlocking = value
         }
 
-    override val upgradeInfo: StateFlow<UpgradeRepo.Info> = billingDataRepo.billingData
-        .map { data ->
-            val now = System.currentTimeMillis()
-            val proSku = data.getProSku()
-            log(TAG) { "now=$now, lastProStateAt=$lastProStateAt, data=${data}" }
-            when {
-                proSku != null -> {
-                    lastProStateAt = now
-                    Info(billingData = data)
-                }
+    private val lastProStateSku: String
+        get() = billingCache.lastProStateSku.valueBlocking
 
-                (now - lastProStateAt) < GRACE_PERIOD_NORMAL_MS -> {
-                    log(TAG, VERBOSE) { "We are not pro, but were recently, did GPlay try annoy us again?" }
-                    Info(gracePeriod = true, billingData = null)
-                }
+    // Monotonic (elapsedRealtime) time of the last observed billing error, null when billing is
+    // healthy. While an error is recent, an empty purchase result can't be trusted as "not owned"
+    // either, so the longer error grace window applies to empty data too — this keeps the reactive
+    // pipeline and explicit restore consistent regardless of which emission is processed last.
+    // Retired when a refresh completes authoritatively.
+    @Volatile private var lastBillingErrorAtElapsed: Long? = null
 
-                else -> {
-                    Info(billingData = data)
+    // Outcomes of explicit restore calls; merged into upgradeInfo so the canonical state always
+    // reflects what an explicit restore concluded (the reactive pipeline may have evaluated
+    // different data, e.g. the error-window grace only applies after a billing error).
+    // replay=1: an outcome must survive until the eagerly started stateIn collector attaches.
+    private val manualInfo = MutableSharedFlow<Info>(replay = 1)
+
+    override val upgradeInfo: StateFlow<UpgradeRepo.Info> = merge(
+        billingDataRepo.billingData
+            .map { data -> data.toUpgradeInfo() }
+            .retryWhen { cause, _ ->
+                if (cause !is BillingException && cause !is IOException) return@retryWhen false
+                val now = System.currentTimeMillis()
+                lastBillingErrorAtElapsed = SystemClock.elapsedRealtime()
+                log(TAG) { "now=$now, lastProStateAt=$lastProStateAt, error=$cause" }
+                if (proStateAge(now) < graceWindowErrorMs()) {
+                    log(TAG, VERBOSE) { "Grace period active after billing error, retrying..." }
+                    emit(Info(gracePeriod = true, billingData = null))
                 }
-            }
-        }
-        .retryWhen { cause, _ ->
-            if (cause !is BillingException && cause !is IOException) return@retryWhen false
-            val now = System.currentTimeMillis()
-            log(TAG) { "now=$now, lastProStateAt=$lastProStateAt, error=$cause" }
-            if ((now - lastProStateAt) < GRACE_PERIOD_ERROR_MS) {
-                log(TAG, VERBOSE) { "Grace period active after billing error, retrying..." }
-                emit(Info(gracePeriod = true, billingData = null))
-            }
-            delay(RETRY_DELAY_MS)
-            true
-        }
-        .stateIn(scope, SharingStarted.Eagerly, cachedInfo())
+                delay(RETRY_DELAY_MS)
+                true
+            },
+        manualInfo,
+    ).stateIn(scope, SharingStarted.Eagerly, cachedInfo())
+
+    // True once this install has ever confirmed a known Pro purchase; drives the proactive restore
+    // banner. Local signal only — a fresh install or a switched Google account starts false.
+    val wasEverPro: Flow<Boolean> = billingCache.lastProStateAt.flow.map { it > 0 }
+
+    // Asynchronous purchase-flow failures (already user-friendly-mapped).
+    val purchaseFailures: Flow<Throwable> = billingDataRepo.purchaseFailures
 
     suspend fun querySkus(): Collection<SkuDetails> {
         return billingDataRepo.querySkus(*MyPermSku.PRO_SKUS.toTypedArray())
@@ -84,8 +98,101 @@ class UpgradeRepoGplay @Inject constructor(
     }
 
     override suspend fun refresh() {
-        billingDataRepo.refresh()
+        log(TAG) { "refresh()" }
+        try {
+            // Same evaluate-and-publish path as an explicit restore, so the authoritative result
+            // always reaches upgradeInfo; only the error handling differs (swallow-and-log).
+            restorePurchaseNow()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Background refresh failed: ${e.asLog()}" }
+        }
     }
+
+    // Explicit "Restore purchase": query Play now and evaluate Pro from the returned data in the
+    // same coroutine (real happens-before), so we never read a stale upgradeInfo value. Billing
+    // errors propagate so the caller can distinguish "not owned" from "Play unavailable".
+    suspend fun restorePurchaseNow(): Info {
+        log(TAG) { "restorePurchaseNow()" }
+        val outcome = try {
+            val data = billingDataRepo.refresh()
+            // Play answered authoritatively — retire the error-window override.
+            lastBillingErrorAtElapsed = null
+            data.toUpgradeInfo()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Mirror the reactive flow's retryWhen: a billing error while we were Pro recently
+            // keeps us Pro via the grace period, otherwise the error surfaces to the caller.
+            val now = System.currentTimeMillis()
+            lastBillingErrorAtElapsed = SystemClock.elapsedRealtime()
+            if (proStateAge(now) < graceWindowErrorMs()) {
+                log(TAG, VERBOSE) { "Restore hit a billing error, but we were Pro recently -> grace" }
+                Info(gracePeriod = true, billingData = null)
+            } else {
+                throw e
+            }
+        }
+        manualInfo.emit(outcome)
+        return outcome
+    }
+
+    // Shared Pro/grace mapping used by both the reactive upgradeInfo flow and restorePurchaseNow().
+    // Only relinquishes Pro if we haven't had it for a while (grace period).
+    private suspend fun BillingData.toUpgradeInfo(): Info {
+        val now = System.currentTimeMillis()
+        val proSkus = getProSkus()
+        log(TAG) { "toUpgradeInfo(): now=$now, lastProStateAt=$lastProStateAt, data=$this" }
+        return when {
+            proSkus.isNotEmpty() -> {
+                // Only a *known* Pro SKU refreshes the grace state. Prefer the permanent IAP so
+                // its longer grace window applies when both product types are owned.
+                billingCache.confirmPro(at = now, sku = preferredProSku(proSkus)?.sku?.id.orEmpty())
+                Info(billingData = this)
+            }
+
+            proStateAge(now) < graceWindowNormalMs() -> {
+                log(TAG, VERBOSE) { "We are not pro, but were recently, did GPlay try annoy us again?" }
+                Info(gracePeriod = true, billingData = null)
+            }
+
+            else -> {
+                Info(billingData = this)
+            }
+        }
+    }
+
+    // Age of the last confirmed Pro state. A timestamp in the future (clock moved backwards) is
+    // reset to now, so wall-clock changes can't create an indefinite grace period.
+    private fun proStateAge(now: Long): Long {
+        val lastAt = lastProStateAt
+        if (lastAt > now) {
+            log(TAG, WARN) { "lastProStateAt=$lastAt is in the future (now=$now), resetting." }
+            lastProStateAt = now
+            return 0L
+        }
+        return now - lastAt
+    }
+
+    // Grace window depends on what was last owned: a permanent one-time purchase should almost
+    // never be dropped on a Play hiccup, a subscription (or unknown/legacy SKU) legitimately lapses.
+    // Empty data is evaluated with the error window while a billing error is recent — an empty
+    // result during billing trouble isn't trustworthy evidence of "not owned".
+    private fun graceWindowNormalMs(): Long = when {
+        isLastProSkuIap() -> GRACE_PERIOD_IAP_MS
+        hasRecentBillingError() -> GRACE_PERIOD_ERROR_MS
+        else -> GRACE_PERIOD_NORMAL_MS
+    }
+
+    private fun hasRecentBillingError(): Boolean = lastBillingErrorAtElapsed
+        ?.let { (SystemClock.elapsedRealtime() - it) < GRACE_PERIOD_ERROR_MS } == true
+
+    private fun graceWindowErrorMs(): Long =
+        if (isLastProSkuIap()) GRACE_PERIOD_IAP_MS else GRACE_PERIOD_ERROR_MS
+
+    private fun isLastProSkuIap(): Boolean =
+        MyPermSku.PRO_SKUS.singleOrNull { it.id == lastProStateSku }?.type == Sku.Type.IAP
 
     data class Info(
         private val gracePeriod: Boolean = false,
@@ -107,18 +214,27 @@ class UpgradeRepoGplay @Inject constructor(
 
     private fun cachedInfo(): Info {
         val now = System.currentTimeMillis()
-        val inGracePeriod = lastProStateAt > 0 && (now - lastProStateAt) < GRACE_PERIOD_ERROR_MS
+        val inGracePeriod = lastProStateAt > 0 && proStateAge(now) < graceWindowErrorMs()
         log(TAG) { "cachedInfo(): now=$now, lastProStateAt=$lastProStateAt, inGracePeriod=$inGracePeriod" }
         return Info(gracePeriod = inGracePeriod, billingData = null)
     }
 
     companion object {
-        private const val GRACE_PERIOD_NORMAL_MS = 6 * 60 * 60 * 1000L   // 6h - GPlay transient unavailability
-        private const val GRACE_PERIOD_ERROR_MS = 24 * 60 * 60 * 1000L    // 24h - billing errors / cold start
+        internal const val GRACE_PERIOD_NORMAL_MS = 6 * 60 * 60 * 1000L   // 6h - GPlay transient unavailability
+        internal const val GRACE_PERIOD_ERROR_MS = 24 * 60 * 60 * 1000L   // 24h - billing errors / cold start
+        internal const val GRACE_PERIOD_IAP_MS = 30 * 24 * 60 * 60 * 1000L // 30d - permanent one-time purchase
         private const val RETRY_DELAY_MS = 60_000L                         // 1min before re-subscribing
 
         private fun BillingData.getProSku(): PurchasedSku? = purchasedSkus
             .firstOrNull { it.sku in MyPermSku.PRO_SKUS }
+
+        private fun BillingData.getProSkus(): Collection<PurchasedSku> = purchasedSkus
+            .filter { it.sku in MyPermSku.PRO_SKUS }
+
+        // The SKU whose grace window applies when several are owned: the permanent one-time
+        // purchase wins over a subscription. null when no known Pro SKU is owned.
+        internal fun preferredProSku(upgrades: Collection<PurchasedSku>): PurchasedSku? =
+            upgrades.firstOrNull { it.sku.type == Sku.Type.IAP } ?: upgrades.firstOrNull()
 
         val TAG: String = logTag("Upgrade", "Gplay", "Control")
     }

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/UpgradeRepoGplay.kt
@@ -3,13 +3,16 @@ package eu.darken.myperm.common.upgrade.core
 import android.app.Activity
 import android.os.SystemClock
 import eu.darken.myperm.common.coroutine.AppScope
+import eu.darken.myperm.common.debug.logging.Logging.Priority.INFO
 import eu.darken.myperm.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.myperm.common.debug.logging.Logging.Priority.WARN
 import eu.darken.myperm.common.debug.logging.asLog
 import eu.darken.myperm.common.debug.logging.log
 import eu.darken.myperm.common.debug.logging.logTag
+import eu.darken.myperm.common.flow.setupCommonEventHandlers
 import eu.darken.myperm.common.upgrade.UpgradeRepo
 import eu.darken.myperm.common.upgrade.core.client.BillingException
+import eu.darken.myperm.common.upgrade.core.client.ItemAlreadyOwnedBillingException
 import eu.darken.myperm.common.upgrade.core.data.BillingData
 import eu.darken.myperm.common.upgrade.core.data.BillingDataRepo
 import eu.darken.myperm.common.upgrade.core.data.PurchasedSku
@@ -22,10 +25,15 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.withTimeoutOrNull
 import java.io.IOException
 import java.time.Instant
 import javax.inject.Inject
@@ -80,10 +88,49 @@ class UpgradeRepoGplay @Inject constructor(
 
     // True once this install has ever confirmed a known Pro purchase; drives the proactive restore
     // banner. Local signal only — a fresh install or a switched Google account starts false.
-    val wasEverPro: Flow<Boolean> = billingCache.lastProStateAt.flow.map { it > 0 }
+    val wasEverPro: Flow<Boolean> = billingCache.lastProStateAt.flow
+        .map { it > 0 }
+        .distinctUntilChanged()
 
-    // Asynchronous purchase-flow failures (already user-friendly-mapped).
-    val purchaseFailures: Flow<Throwable> = billingDataRepo.purchaseFailures
+    init {
+        // Fresh-provenance grace stamping: the reactive upgradeInfo map is read-only; this
+        // persistent collector (subscribed once, never re-subscribes) stamps new emissions, and
+        // refresh()/restorePurchaseNow() stamp their returned query results. Stale purchase data
+        // replayed through the shared flows can no longer keep re-stamping a grace window after
+        // a refund.
+        billingDataRepo.billingData
+            .distinctUntilChanged()
+            .onEach { data ->
+                try {
+                    recordProState(data)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    // A failed DataStore write must not kill this process-lifetime collector.
+                    log(TAG, WARN) { "Failed to record pro state: ${e.asLog()}" }
+                }
+            }
+            .setupCommonEventHandlers(TAG) { "proStateRecorder" }
+            .launchIn(scope)
+
+        // Async variant of the launch-result ITEM_ALREADY_OWNED case: Play told us mid-flow that
+        // the user already owns it. Reconcile silently — Play shows its own UI for purchase-sheet
+        // failures, so no app-side dialog here.
+        billingDataRepo.purchaseFailures
+            .filterIsInstance<ItemAlreadyOwnedBillingException>()
+            .onEach {
+                log(TAG, INFO) { "Async already-owned event -> restoring purchase" }
+                try {
+                    withTimeoutOrNull(RESTORE_ON_OWNED_TIMEOUT_MS) { restorePurchaseNow() }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log(TAG, WARN) { "Async already-owned restore failed: ${e.asLog()}" }
+                }
+            }
+            .setupCommonEventHandlers(TAG) { "asyncAlreadyOwned" }
+            .launchIn(scope)
+    }
 
     suspend fun querySkus(): Collection<SkuDetails> {
         return billingDataRepo.querySkus(*MyPermSku.PRO_SKUS.toTypedArray())
@@ -102,7 +149,9 @@ class UpgradeRepoGplay @Inject constructor(
         try {
             // Same evaluate-and-publish path as an explicit restore, so the authoritative result
             // always reaches upgradeInfo; only the error handling differs (swallow-and-log).
-            restorePurchaseNow()
+            // Bounded: with unbounded connection retry, an unavailable Play would otherwise keep
+            // background callers suspended indefinitely.
+            withTimeoutOrNull(REFRESH_TIMEOUT_MS) { restorePurchaseNow() }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -117,8 +166,10 @@ class UpgradeRepoGplay @Inject constructor(
         log(TAG) { "restorePurchaseNow()" }
         val outcome = try {
             val data = billingDataRepo.refresh()
-            // Play answered authoritatively — retire the error-window override.
+            // Play answered authoritatively — retire the error-window override and stamp the
+            // grace state from the freshly returned query results.
             lastBillingErrorAtElapsed = null
+            recordProState(data)
             data.toUpgradeInfo()
         } catch (e: CancellationException) {
             throw e
@@ -139,18 +190,14 @@ class UpgradeRepoGplay @Inject constructor(
     }
 
     // Shared Pro/grace mapping used by both the reactive upgradeInfo flow and restorePurchaseNow().
-    // Only relinquishes Pro if we haven't had it for a while (grace period).
-    private suspend fun BillingData.toUpgradeInfo(): Info {
+    // Only relinquishes Pro if we haven't had it for a while (grace period). READ-ONLY: this also
+    // runs on replayed/stale shared-flow data, so it must never stamp the grace cache — see
+    // recordProState().
+    private fun BillingData.toUpgradeInfo(): Info {
         val now = System.currentTimeMillis()
-        val proSkus = getProSkus()
         log(TAG) { "toUpgradeInfo(): now=$now, lastProStateAt=$lastProStateAt, data=$this" }
         return when {
-            proSkus.isNotEmpty() -> {
-                // Only a *known* Pro SKU refreshes the grace state. Prefer the permanent IAP so
-                // its longer grace window applies when both product types are owned.
-                billingCache.confirmPro(at = now, sku = preferredProSku(proSkus)?.sku?.id.orEmpty())
-                Info(billingData = this)
-            }
+            getProSkus().isNotEmpty() -> Info(billingData = this)
 
             proStateAge(now) < graceWindowNormalMs() -> {
                 log(TAG, VERBOSE) { "We are not pro, but were recently, did GPlay try annoy us again?" }
@@ -161,6 +208,17 @@ class UpgradeRepoGplay @Inject constructor(
                 Info(billingData = this)
             }
         }
+    }
+
+    // Persists "we saw a known Pro purchase" for the grace machinery. Callers must only pass FRESH
+    // data (returned query results, or new emissions seen by the init collector) — never replayed
+    // flow data, so a refunded purchase can't keep re-stamping its grace window. Only a *known*
+    // Pro SKU counts; the permanent IAP is preferred so it drives the window length. Timestamp and
+    // SKU are written in one transaction (see BillingCache.confirmPro).
+    private suspend fun recordProState(data: BillingData) {
+        val sku = preferredProSku(data.getProSkus())?.sku ?: return
+        log(TAG) { "recordProState(): $sku" }
+        billingCache.confirmPro(at = System.currentTimeMillis(), sku = sku.id)
     }
 
     // Age of the last confirmed Pro state. A timestamp in the future (clock moved backwards) is
@@ -224,6 +282,8 @@ class UpgradeRepoGplay @Inject constructor(
         internal const val GRACE_PERIOD_ERROR_MS = 24 * 60 * 60 * 1000L   // 24h - billing errors / cold start
         internal const val GRACE_PERIOD_IAP_MS = 30 * 24 * 60 * 60 * 1000L // 30d - permanent one-time purchase
         private const val RETRY_DELAY_MS = 60_000L                         // 1min before re-subscribing
+        private const val RESTORE_ON_OWNED_TIMEOUT_MS = 15_000L
+        private const val REFRESH_TIMEOUT_MS = 30_000L
 
         private fun BillingData.getProSku(): PurchasedSku? = purchasedSkus
             .firstOrNull { it.sku in MyPermSku.PRO_SKUS }

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/client/BillingClientConnection.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/client/BillingClientConnection.kt
@@ -1,6 +1,7 @@
 package eu.darken.myperm.common.upgrade.core.client
 
 import android.app.Activity
+import android.os.SystemClock
 import com.android.billingclient.api.AcknowledgePurchaseParams
 import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.BillingFlowParams
@@ -17,20 +18,41 @@ import eu.darken.myperm.common.debug.logging.logTag
 import eu.darken.myperm.common.flow.setupCommonEventHandlers
 import eu.darken.myperm.common.upgrade.core.data.Sku
 import eu.darken.myperm.common.upgrade.core.data.SkuDetails
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 
 data class BillingClientConnection(
     private val client: BillingClient,
     private val purchasesGlobal: Flow<Collection<Purchase>>,
+    private val purchaseFailuresGlobal: Flow<BillingResult>,
 ) {
     private val queryCacheIaps = MutableStateFlow<Collection<Purchase>>(emptySet())
     private val queryCacheSubs = MutableStateFlow<Collection<Purchase>>(emptySet())
+
+    // responseCode + monotonic (elapsedRealtime) time of the last synchronous launch failure.
+    private val lastSyncLaunchFailure = MutableStateFlow<Pair<Int, Long>?>(null)
+
+    // Non-OK results from onPurchasesUpdated — asynchronous purchase-flow failures. The billing
+    // client may post an immediate launch failure to the listener AND return it from
+    // launchBillingFlow; suppress the listener echo so each failure is handled exactly once
+    // (the synchronous path already threw it). One-shot: the marker is consumed by its echo, so
+    // a later same-code failure from a new billing flow is treated as a new event.
+    val purchaseFailures: Flow<BillingResult> = purchaseFailuresGlobal.filter { result ->
+        val syncFailure = lastSyncLaunchFailure.value
+        val isEcho = isSyncLaunchFailureEcho(result, syncFailure, SystemClock.elapsedRealtime())
+        if (isEcho) {
+            lastSyncLaunchFailure.compareAndSet(syncFailure, null)
+            log(TAG) { "Suppressing listener echo of a synchronous launch failure: code=${result.responseCode}" }
+        }
+        !isEcho
+    }
 
     val purchases: Flow<Collection<Purchase>> = combine(
         purchasesGlobal, queryCacheIaps, queryCacheSubs
@@ -54,31 +76,37 @@ data class BillingClientConnection(
     }
         .setupCommonEventHandlers(TAG) { "purchases" }
 
-    suspend fun refreshPurchases(): Collection<Purchase> = supervisorScope {
-        val iapDeferred = async {
-            runCatching { queryPurchasesByType(BillingClient.ProductType.INAPP) }
-        }
-        val subDeferred = async {
-            runCatching { queryPurchasesByType(BillingClient.ProductType.SUBS) }
-        }
+    // Returns the freshly queried PURCHASED purchases so callers get a guaranteed happens-before
+    // relation instead of racing the shared purchases/billingData replay caches after a refresh.
+    suspend fun refreshPurchases(): Collection<Purchase> = coroutineScope {
+        log(TAG) { "refreshPurchases()" }
+        val iapJob = async { queryPurchasedProducts(BillingClient.ProductType.INAPP) { queryCacheIaps.value = it } }
+        val subJob = async { queryPurchasedProducts(BillingClient.ProductType.SUBS) { queryCacheSubs.value = it } }
+        val iaps = iapJob.await()
+        val subs = subJob.await()
+        log(TAG) { "Refreshed IAPs=${iaps.getOrNull()}, SUBs=${subs.getOrNull()}" }
+        combinePurchaseResults(iaps, subs)
+    }
 
-        val iapResult = iapDeferred.await()
-        val subResult = subDeferred.await()
-
-        iapResult.onFailure { log(TAG, WARN) { "IAP purchase query failed: ${it.asLog()}" } }
-        subResult.onFailure { log(TAG, WARN) { "Sub purchase query failed: ${it.asLog()}" } }
-
-        val iaps = iapResult.getOrDefault(emptyList())
-        val subs = subResult.getOrDefault(emptyList())
-
-        queryCacheIaps.value = iaps
-        queryCacheSubs.value = subs
-
-        iaps + subs
+    // Never throws except on cancellation, so a single failing product-type query doesn't cancel
+    // the sibling query. The query cache is only updated on success — a failed query must not wipe
+    // previously known purchases (the grace period covers "couldn't verify").
+    private suspend fun queryPurchasedProducts(
+        productType: String,
+        cache: (Collection<Purchase>) -> Unit,
+    ): Result<Collection<Purchase>> = try {
+        val purchases = queryPurchasesByType(productType)
+        cache(purchases)
+        Result.success(purchases.filter { it.purchaseState == Purchase.PurchaseState.PURCHASED })
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        log(TAG, WARN) { "$productType purchase query failed: ${e.asLog()}" }
+        Result.failure(e)
     }
 
     private suspend fun queryPurchasesByType(productType: String): Collection<Purchase> {
-        val (result, purchases) = suspendCoroutine<Pair<BillingResult, Collection<Purchase>?>> { continuation ->
+        val (result, purchases) = suspendCancellableCoroutine<Pair<BillingResult, Collection<Purchase>?>> { continuation ->
             val params = QueryPurchasesParams.newBuilder().apply {
                 setProductType(productType)
             }.build()
@@ -104,7 +132,7 @@ data class BillingClientConnection(
             setPurchaseToken(purchase.purchaseToken)
         }.build()
 
-        val result = suspendCoroutine<BillingResult> { continuation ->
+        val result = suspendCancellableCoroutine<BillingResult> { continuation ->
             client.acknowledgePurchase(ack) { continuation.resume(it) }
         }
 
@@ -129,7 +157,7 @@ data class BillingClientConnection(
                 setProductList(productList)
             }.build()
 
-            val (result, details) = suspendCoroutine<Pair<BillingResult, Collection<ProductDetails>?>> { continuation ->
+            val (result, details) = suspendCancellableCoroutine<Pair<BillingResult, Collection<ProductDetails>?>> { continuation ->
                 client.queryProductDetailsAsync(params) { billingResult, productDetailsList ->
                     continuation.resume(billingResult to productDetailsList.productDetailsList)
                 }
@@ -154,6 +182,8 @@ data class BillingClientConnection(
         offer: Sku.Subscription.Offer? = null,
     ): BillingResult {
         log(TAG) { "launchBillingFlow(activity=$activity, skuDetails=$skuDetails, offer=$offer)" }
+        // A new launch invalidates any stale echo marker from a previous attempt.
+        lastSyncLaunchFailure.value = null
 
         val productDetailsParams = BillingFlowParams.ProductDetailsParams.newBuilder().apply {
             setProductDetails(skuDetails.details)
@@ -170,15 +200,55 @@ data class BillingClientConnection(
             }
         }.build()
 
-        return client.launchBillingFlow(
+        // The RETURNED result reports whether the flow could be launched at all (ITEM_ALREADY_OWNED,
+        // BILLING_UNAVAILABLE, DEVELOPER_ERROR, ...) — failures arrive here, not as exceptions.
+        val result = client.launchBillingFlow(
             activity,
             BillingFlowParams.newBuilder()
                 .setProductDetailsParamsList(listOf(productDetailsParams))
                 .build()
         )
+        log(TAG) {
+            "launchBillingFlow(sku=${skuDetails.sku}): code=${result.responseCode}, message=${result.debugMessage}"
+        }
+        if (!result.isSuccess) {
+            lastSyncLaunchFailure.value = result.responseCode to SystemClock.elapsedRealtime()
+            throw BillingResultException(result)
+        }
+
+        return result
     }
 
     companion object {
         val TAG: String = logTag("Upgrade", "Gplay", "Billing", "ClientConnection")
+        internal const val SYNC_LAUNCH_FAILURE_ECHO_WINDOW_MS = 5_000L
+
+        // A listener failure matching a just-thrown synchronous launch failure is an echo of the
+        // same event, not a new one. Times are monotonic (elapsedRealtime); a negative age is
+        // never an echo. Pure and unit-tested.
+        internal fun isSyncLaunchFailureEcho(
+            result: BillingResult,
+            syncFailure: Pair<Int, Long>?,
+            now: Long,
+        ): Boolean = syncFailure != null &&
+            syncFailure.first == result.responseCode &&
+            (now - syncFailure.second) in 0 until SYNC_LAUNCH_FAILURE_ECHO_WINDOW_MS
+
+        // Combines the two product-type query results: a purchase found by either type is
+        // authoritative; an error is only propagated when nothing was found, so callers can tell
+        // "not owned" apart from "couldn't verify one product type". Pure and unit-tested.
+        internal fun combinePurchaseResults(
+            iaps: Result<Collection<Purchase>>,
+            subs: Result<Collection<Purchase>>,
+        ): Collection<Purchase> {
+            val found = iaps.getOrNull().orEmpty() + subs.getOrNull().orEmpty()
+            return when {
+                found.isNotEmpty() -> found.sortedByDescending { it.purchaseTime }
+                else -> {
+                    (iaps.exceptionOrNull() ?: subs.exceptionOrNull())?.let { throw it }
+                    emptyList()
+                }
+            }
+        }
     }
 }

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/client/BillingClientConnectionProvider.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/client/BillingClientConnectionProvider.kt
@@ -16,10 +16,12 @@ import eu.darken.myperm.common.debug.logging.log
 import eu.darken.myperm.common.debug.logging.logTag
 import eu.darken.myperm.common.flow.setupCommonEventHandlers
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.retryWhen
@@ -34,6 +36,13 @@ class BillingClientConnectionProvider @Inject constructor(
 
     private val connectionProvider: Flow<BillingClientConnection> = callbackFlow {
         val purchasePublisher = MutableStateFlow<Collection<Purchase>>(emptySet())
+        // Purchase-flow outcomes can arrive here asynchronously after the Play sheet opened (e.g.
+        // ITEM_ALREADY_OWNED, declined payment) — publish them instead of dropping them, so the UI
+        // layer can react. tryEmit because the listener is a plain callback.
+        val purchaseFailurePublisher = MutableSharedFlow<BillingResult>(
+            extraBufferCapacity = 16,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
 
         val client = newBuilder(context).apply {
             enablePendingPurchases(
@@ -51,6 +60,7 @@ class BillingClientConnectionProvider @Inject constructor(
                     log(TAG, WARN) {
                         "error: onPurchasesUpdated(code=${result.responseCode}, message=${result.debugMessage}, purchases=$purchases)"
                     }
+                    purchaseFailurePublisher.tryEmit(result)
                 }
             }
         }.build()
@@ -65,7 +75,7 @@ class BillingClientConnectionProvider @Inject constructor(
 
                 when (result.responseCode) {
                     BillingResponseCode.OK -> {
-                        val connection = BillingClientConnection(client, purchasePublisher)
+                        val connection = BillingClientConnection(client, purchasePublisher, purchaseFailurePublisher)
 
                         trySendBlocking(connection)
 

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/client/ItemAlreadyOwnedBillingException.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/client/ItemAlreadyOwnedBillingException.kt
@@ -1,0 +1,20 @@
+package eu.darken.myperm.common.upgrade.core.client
+
+import android.content.Context
+import com.android.billingclient.api.BillingResult
+import eu.darken.myperm.R
+import eu.darken.myperm.common.error.HasLocalizedError
+import eu.darken.myperm.common.error.LocalizedError
+
+// Play says the user already owns what they tried to buy. Callers should attempt a restore first;
+// this error surfaces only when that reconciliation fails (e.g. account mismatch).
+class ItemAlreadyOwnedBillingException(
+    val result: BillingResult,
+) : BillingException("Item is already owned"), HasLocalizedError {
+
+    override fun getLocalizedError(context: Context): LocalizedError = LocalizedError(
+        throwable = this,
+        label = context.getString(R.string.upgrades_gplay_already_owned_title),
+        description = context.getString(R.string.upgrades_gplay_already_owned_error),
+    )
+}

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/client/UserCanceledBillingException.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/client/UserCanceledBillingException.kt
@@ -1,0 +1,6 @@
+package eu.darken.myperm.common.upgrade.core.client
+
+import com.android.billingclient.api.BillingResult
+
+// Expected user action (backed out of the purchase dialog) — callers must stay silent.
+class UserCanceledBillingException(val result: BillingResult) : BillingException("User canceled the billing flow")

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/data/BillingDataRepo.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/data/BillingDataRepo.kt
@@ -1,6 +1,7 @@
 package eu.darken.myperm.common.upgrade.core.data
 
 import android.app.Activity
+import com.android.billingclient.api.BillingClient.BillingResponseCode
 import com.android.billingclient.api.Purchase
 import eu.darken.myperm.common.coroutine.AppScope
 import eu.darken.myperm.common.debug.Bugs
@@ -12,10 +13,13 @@ import eu.darken.myperm.common.debug.logging.log
 import eu.darken.myperm.common.debug.logging.logTag
 import eu.darken.myperm.common.flow.replayingShare
 import eu.darken.myperm.common.flow.setupCommonEventHandlers
+import eu.darken.myperm.common.upgrade.core.client.BillingClientConnection
 import eu.darken.myperm.common.upgrade.core.client.BillingClientConnectionProvider
 import eu.darken.myperm.common.upgrade.core.client.BillingException
 import eu.darken.myperm.common.upgrade.core.client.BillingResultException
 import eu.darken.myperm.common.upgrade.core.client.GplayServiceUnavailableException
+import eu.darken.myperm.common.upgrade.core.client.ItemAlreadyOwnedBillingException
+import eu.darken.myperm.common.upgrade.core.client.UserCanceledBillingException
 import eu.darken.myperm.common.upgrade.core.client.isGplayUnavailablePermanent
 import eu.darken.myperm.common.upgrade.core.client.isGplayUnavailableTemporary
 import kotlinx.coroutines.CancellationException
@@ -30,6 +34,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.retryWhen
+import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -48,6 +53,19 @@ class BillingDataRepo @Inject constructor(
         .map { BillingData(purchases = it) }
         .setupCommonEventHandlers(TAG) { "billingData" }
         .replayingShare(scope)
+
+    // Asynchronous purchase-flow failures (onPurchasesUpdated with a non-OK result), mapped like
+    // the synchronous launch failures. Hot upstream — subscribers only see failures while active.
+    val purchaseFailures: Flow<Throwable> = connectionProvider
+        .flatMapLatest { it.purchaseFailures }
+        .map { result ->
+            log(TAG, WARN) { "Purchase flow failed: code=${result.responseCode}, message=${result.debugMessage}" }
+            if (!BUG_REPORT_IGNORED_CODES.contains(result.responseCode)) {
+                Bugs.report(RuntimeException("Purchase flow failed: code=${result.responseCode}"))
+            }
+            BillingResultException(result).tryMapUserFriendly()
+        }
+        .setupCommonEventHandlers(TAG) { "purchaseFailures" }
 
     init {
         connectionProvider
@@ -101,9 +119,18 @@ class BillingDataRepo @Inject constructor(
             .launchIn(scope)
     }
 
+    // The connection flow's errors are swallowed by the .catch above, so waiting on it can hang
+    // (or throw NoSuchElementException after completion). Bound it so user actions can't stall.
+    private suspend fun acquireConnection(): BillingClientConnection =
+        withTimeoutOrNull(CONNECTION_TIMEOUT_MS) { connectionProvider.first() }
+            ?: throw GplayServiceUnavailableException(
+                BillingException("Timed out waiting for a billing client connection")
+            )
+
     suspend fun querySkus(vararg skus: Sku): Collection<SkuDetails> = try {
-        val clientConnection = connectionProvider.first()
-        clientConnection.querySkus(*skus)
+        acquireConnection().querySkus(*skus)
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         throw e.tryMapUserFriendly()
     }
@@ -114,12 +141,12 @@ class BillingDataRepo @Inject constructor(
         offer: Sku.Subscription.Offer? = null,
     ) {
         try {
-            val clientConnection = connectionProvider.first()
-            clientConnection.launchBillingFlow(activity, skuDetails, offer)
+            acquireConnection().launchBillingFlow(activity, skuDetails, offer)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             log(TAG, WARN) { "Failed to launch billing flow:\n${e.asLog()}" }
-            val ignoredCodes = listOf(3, 6)
-            if (e !is BillingResultException || !e.result.responseCode.let { ignoredCodes.contains(it) }) {
+            if (e !is BillingResultException || !BUG_REPORT_IGNORED_CODES.contains(e.result.responseCode)) {
                 Bugs.report(RuntimeException("Billing flow failed for ${skuDetails.sku}", e))
             }
 
@@ -127,23 +154,43 @@ class BillingDataRepo @Inject constructor(
         }
     }
 
-    suspend fun refresh() {
-        try {
-            val clientConnection = connectionProvider.first()
-            clientConnection.refreshPurchases()
-        } catch (e: Exception) {
-            throw e.tryMapUserFriendly()
-        }
+    // Queries Play now and returns the fresh purchase data directly, so callers get a real
+    // happens-before instead of racing the shared billingData replay cache after a refresh.
+    suspend fun refresh(): BillingData = try {
+        BillingData(purchases = acquireConnection().refreshPurchases())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        throw e.tryMapUserFriendly()
     }
 
     companion object {
         val TAG: String = logTag("Upgrade", "Gplay", "Billing", "DataRepo")
+        private const val CONNECTION_TIMEOUT_MS = 10_000L
+
+        // Expected environmental/user situations get user-facing handling only, no bug report.
+        private val BUG_REPORT_IGNORED_CODES = setOf(
+            BillingResponseCode.USER_CANCELED,
+            BillingResponseCode.BILLING_UNAVAILABLE,
+            BillingResponseCode.ERROR,
+            BillingResponseCode.ITEM_ALREADY_OWNED,
+        )
 
         internal fun Throwable.tryMapUserFriendly(): Throwable = when {
+            this is BillingResultException && result.responseCode == BillingResponseCode.USER_CANCELED -> {
+                UserCanceledBillingException(result)
+            }
+            this is BillingResultException && result.responseCode == BillingResponseCode.ITEM_ALREADY_OWNED -> {
+                ItemAlreadyOwnedBillingException(result)
+            }
             this is BillingResultException && this.result.isGplayUnavailableTemporary -> {
                 GplayServiceUnavailableException(this)
             }
             this is BillingResultException && this.result.isGplayUnavailablePermanent -> {
+                GplayServiceUnavailableException(this)
+            }
+            this is NoSuchElementException -> {
+                // connectionProvider completed without emitting (connection retries exhausted)
                 GplayServiceUnavailableException(this)
             }
             else -> this

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/data/BillingDataRepo.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/data/BillingDataRepo.kt
@@ -27,7 +27,6 @@ import kotlinx.coroutines.CoroutineScope
 
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
@@ -45,7 +44,19 @@ class BillingDataRepo @Inject constructor(
 ) {
 
     private val connectionProvider = clientConnectionProvider.connection
-        .catch { log(TAG, ERROR) { "Unable to provide client connection:\n${it.asLog()}" } }
+        .retryWhen { cause, attempt ->
+            // Never give up terminally: the ack collector pins this share for the process
+            // lifetime, so a completed upstream could never restart — one transient failure at
+            // first use (e.g. BILLING_UNAVAILABLE while the Play Store updates itself) would
+            // leave billing dead until process restart. Retry with capped backoff instead.
+            if (cause is CancellationException) {
+                false
+            } else {
+                log(TAG, WARN) { "Billing connection failed (attempt=$attempt), will retry: ${cause.asLog()}" }
+                delay((CONNECTION_RETRY_BASE_MS * (attempt + 1)).coerceAtMost(CONNECTION_RETRY_MAX_MS))
+                true
+            }
+        }
         .replayingShare(scope)
 
     val billingData: Flow<BillingData> = connectionProvider
@@ -167,6 +178,8 @@ class BillingDataRepo @Inject constructor(
     companion object {
         val TAG: String = logTag("Upgrade", "Gplay", "Billing", "DataRepo")
         private const val CONNECTION_TIMEOUT_MS = 10_000L
+        private const val CONNECTION_RETRY_BASE_MS = 30_000L
+        private const val CONNECTION_RETRY_MAX_MS = 300_000L
 
         // Expected environmental/user situations get user-facing handling only, no bug report.
         private val BUG_REPORT_IGNORED_CODES = setOf(

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeScreen.kt
@@ -109,7 +109,7 @@ private data class Benefit(val icon: ImageVector, val textRes: Int)
 
 @Composable
 fun UpgradeScreen(
-    state: UpgradeViewModel.Pricing?,
+    state: UpgradeViewModel.State,
     onNavigateUp: () -> Unit,
     onSubscription: () -> Unit,
     onSubscriptionTrial: () -> Unit,
@@ -158,6 +158,15 @@ fun UpgradeScreen(
             )
 
             Spacer(modifier = Modifier.height(24.dp))
+
+            if (state.wasPreviouslyPro) {
+                RestoreBanner(
+                    onRestore = onRestore,
+                    restoreInProgress = state.restoreInProgress,
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+            }
 
             Card(
                 colors = CardDefaults.cardColors(
@@ -211,11 +220,12 @@ fun UpgradeScreen(
 
             Spacer(modifier = Modifier.height(24.dp))
 
-            if (state == null) {
+            if (state.pricing == null) {
                 CircularProgressIndicator(modifier = Modifier.padding(16.dp))
             } else {
                 PricingContent(
-                    state = state,
+                    pricing = state.pricing,
+                    restoreInProgress = state.restoreInProgress,
                     onSubscription = onSubscription,
                     onSubscriptionTrial = onSubscriptionTrial,
                     onIap = onIap,
@@ -240,18 +250,60 @@ fun UpgradeScreen(
 }
 
 @Composable
+private fun RestoreBanner(
+    onRestore: () -> Unit,
+    restoreInProgress: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+        ),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = stringResource(R.string.upgrade_screen_restore_banner_title),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.upgrade_screen_restore_banner_body),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Button(
+                onClick = onRestore,
+                enabled = !restoreInProgress,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                if (restoreInProgress) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        strokeWidth = 2.dp,
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                }
+                Text(text = stringResource(R.string.upgrade_screen_restore_purchase_action))
+            }
+        }
+    }
+}
+
+@Composable
 private fun PricingContent(
-    state: UpgradeViewModel.Pricing,
+    pricing: UpgradeViewModel.Pricing,
+    restoreInProgress: Boolean,
     onSubscription: () -> Unit,
     onSubscriptionTrial: () -> Unit,
     onIap: () -> Unit,
     onRestore: () -> Unit,
 ) {
     // Subscription button (primary)
-    if (state.subAvailable) {
-        val subscriptionAction = if (state.hasTrialOffer) onSubscriptionTrial else onSubscription
+    if (pricing.subAvailable) {
+        val subscriptionAction = if (pricing.hasTrialOffer) onSubscriptionTrial else onSubscription
 
-        val subscriptionLabel = if (state.hasTrialOffer) {
+        val subscriptionLabel = if (pricing.hasTrialOffer) {
             stringResource(R.string.upgrade_screen_subscription_trial_action)
         } else {
             stringResource(R.string.upgrade_screen_subscription_action)
@@ -259,6 +311,7 @@ private fun PricingContent(
 
         Button(
             onClick = subscriptionAction,
+            enabled = !restoreInProgress,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(52.dp),
@@ -276,9 +329,9 @@ private fun PricingContent(
             )
         }
 
-        if (state.subPrice != null) {
+        if (pricing.subPrice != null) {
             Text(
-                text = stringResource(R.string.upgrade_screen_subscription_action_hint_yearly, state.subPrice),
+                text = stringResource(R.string.upgrade_screen_subscription_action_hint_yearly, pricing.subPrice),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(top = 4.dp),
@@ -289,9 +342,10 @@ private fun PricingContent(
     }
 
     // IAP button (secondary)
-    if (state.iapAvailable) {
+    if (pricing.iapAvailable) {
         FilledTonalButton(
             onClick = onIap,
+            enabled = !restoreInProgress,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(52.dp),
@@ -303,9 +357,9 @@ private fun PricingContent(
             )
         }
 
-        if (state.iapPrice != null) {
+        if (pricing.iapPrice != null) {
             Text(
-                text = stringResource(R.string.upgrade_screen_iap_action_hint, state.iapPrice),
+                text = stringResource(R.string.upgrade_screen_iap_action_hint, pricing.iapPrice),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(top = 4.dp),
@@ -314,9 +368,10 @@ private fun PricingContent(
     }
 
     // If no details loaded at all, show a simple fallback upgrade button
-    if (!state.subAvailable && !state.iapAvailable) {
+    if (!pricing.subAvailable && !pricing.iapAvailable) {
         Button(
             onClick = onIap,
+            enabled = !restoreInProgress,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(52.dp),
@@ -350,11 +405,19 @@ private fun PricingContent(
 
     OutlinedButton(
         onClick = onRestore,
+        enabled = !restoreInProgress,
         modifier = Modifier
             .fillMaxWidth()
             .height(52.dp),
         shape = RoundedCornerShape(12.dp),
     ) {
+        if (restoreInProgress) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(18.dp),
+                strokeWidth = 2.dp,
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+        }
         Text(text = stringResource(R.string.upgrade_screen_restore_purchase_action))
     }
 }

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModel.kt
@@ -129,26 +129,6 @@ class UpgradeViewModel @Inject constructor(
                 }
             }
             .launchIn(vmScope)
-
-        // Purchase-flow failures that arrive asynchronously via onPurchasesUpdated after the Play
-        // sheet opened — handled like the synchronous launch failures.
-        upgradeRepo.purchaseFailures
-            .onEach { failure ->
-                when (failure) {
-                    is UserCanceledBillingException -> log(TAG) { "User canceled the billing flow" }
-
-                    is ItemAlreadyOwnedBillingException -> {
-                        log(TAG, INFO) { "Purchase update says already owned, restoring purchase instead" }
-                        restoreAfterAlreadyOwned(failure)
-                    }
-
-                    else -> {
-                        log(TAG, WARN) { "Purchase flow failed: ${failure.asLog()}" }
-                        errorEvents.emitBlocking(failure)
-                    }
-                }
-            }
-            .launchIn(vmScope)
     }
 
     fun onGoIap() {

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModel.kt
@@ -3,6 +3,7 @@ package eu.darken.myperm.common.upgrade.ui
 import android.app.Activity
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.myperm.common.coroutine.DispatcherProvider
+import eu.darken.myperm.common.debug.logging.Logging.Priority.INFO
 import eu.darken.myperm.common.debug.logging.Logging.Priority.WARN
 import eu.darken.myperm.common.debug.logging.asLog
 import eu.darken.myperm.common.debug.logging.log
@@ -11,12 +12,20 @@ import eu.darken.myperm.common.flow.SingleEventFlow
 import eu.darken.myperm.common.uix.ViewModel4
 import eu.darken.myperm.common.upgrade.core.MyPermSku
 import eu.darken.myperm.common.upgrade.core.UpgradeRepoGplay
+import eu.darken.myperm.common.upgrade.core.client.ItemAlreadyOwnedBillingException
+import eu.darken.myperm.common.upgrade.core.client.UserCanceledBillingException
+import eu.darken.myperm.common.upgrade.core.data.Sku
 import eu.darken.myperm.common.upgrade.core.data.SkuDetails
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.withContext
@@ -50,21 +59,33 @@ class UpgradeViewModel @Inject constructor(
         val iapAvailable: Boolean get() = iap != null || iapPrice != null
     }
 
+    data class State(
+        val pricing: Pricing? = null,
+        val wasPreviouslyPro: Boolean = false,
+        val restoreInProgress: Boolean = false,
+    )
+
     val events = SingleEventFlow<UpgradeEvent>()
     val billingEvents = SingleEventFlow<BillingEvent>()
 
-    val state: StateFlow<Pricing?> = flow {
+    private val restoring = MutableStateFlow(false)
+
+    private val pricing: Flow<Pricing?> = flow {
+        emit(null)
+
         val skuDetails = try {
             withTimeoutOrNull(5_000L) {
                 upgradeRepo.querySkus()
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             log(TAG, WARN) { "Failed to query SKUs: ${e.asLog()}" }
             null
         }
 
-        val iapDetails = skuDetails?.firstOrNull { it.sku.type == eu.darken.myperm.common.upgrade.core.data.Sku.Type.IAP }
-        val subDetails = skuDetails?.firstOrNull { it.sku.type == eu.darken.myperm.common.upgrade.core.data.Sku.Type.SUBSCRIPTION }
+        val iapDetails = skuDetails?.firstOrNull { it.sku.type == Sku.Type.IAP }
+        val subDetails = skuDetails?.firstOrNull { it.sku.type == Sku.Type.SUBSCRIPTION }
 
         val subOffers = subDetails?.details?.subscriptionOfferDetails
         val baseOffer = subOffers?.firstOrNull { MyPermSku.Sub.BASE_OFFER.matches(it) }
@@ -79,14 +100,52 @@ class UpgradeViewModel @Inject constructor(
                 hasTrialOffer = hasTrialOffer,
             )
         )
-    }.stateIn(vmScope, SharingStarted.WhileSubscribed(5_000), null)
+    }
+
+    val state: StateFlow<State> = combine(
+        pricing,
+        upgradeRepo.upgradeInfo,
+        upgradeRepo.wasEverPro,
+        restoring,
+    ) { pricing, current, wasEverPro, isRestoring ->
+        State(
+            pricing = pricing,
+            // Hidden while a purchase or the grace period still keeps the user Pro.
+            wasPreviouslyPro = wasEverPro && !current.isPro,
+            restoreInProgress = isRestoring,
+        )
+    }.stateIn(vmScope, SharingStarted.WhileSubscribed(5_000), State())
 
     init {
+        // Dedupe on isPro: consecutive Pro emissions with different backing data (reactive cache
+        // union vs a fresh restore result) must not enqueue multiple navUp events.
         upgradeRepo.upgradeInfo
-            .onEach { info ->
-                if (info.isPro) {
+            .map { it.isPro }
+            .distinctUntilChanged()
+            .onEach { isPro ->
+                if (isPro) {
                     log(TAG) { "User is now pro, navigating back" }
                     navUp()
+                }
+            }
+            .launchIn(vmScope)
+
+        // Purchase-flow failures that arrive asynchronously via onPurchasesUpdated after the Play
+        // sheet opened — handled like the synchronous launch failures.
+        upgradeRepo.purchaseFailures
+            .onEach { failure ->
+                when (failure) {
+                    is UserCanceledBillingException -> log(TAG) { "User canceled the billing flow" }
+
+                    is ItemAlreadyOwnedBillingException -> {
+                        log(TAG, INFO) { "Purchase update says already owned, restoring purchase instead" }
+                        restoreAfterAlreadyOwned(failure)
+                    }
+
+                    else -> {
+                        log(TAG, WARN) { "Purchase flow failed: ${failure.asLog()}" }
+                        errorEvents.emitBlocking(failure)
+                    }
                 }
             }
             .launchIn(vmScope)
@@ -104,59 +163,104 @@ class UpgradeViewModel @Inject constructor(
         billingEvents.tryEmit(BillingEvent.LaunchSubscriptionTrial)
     }
 
-    fun launchBillingIap(activity: Activity) = launch {
+    fun launchBillingIap(activity: Activity) =
+        launchBillingFlow(activity, state.value.pricing?.iap, null)
+
+    fun launchBillingSubscription(activity: Activity) =
+        launchBillingFlow(activity, state.value.pricing?.sub, MyPermSku.Sub.BASE_OFFER)
+
+    fun launchBillingSubscriptionTrial(activity: Activity) =
+        launchBillingFlow(activity, state.value.pricing?.sub, MyPermSku.Sub.TRIAL_OFFER)
+
+    private fun launchBillingFlow(
+        activity: Activity,
+        skuDetails: SkuDetails?,
+        offer: Sku.Subscription.Offer?,
+    ) = launch {
+        skuDetails ?: return@launch
         try {
-            val iap = state.value?.iap ?: return@launch
             withContext(dispatcherProvider.Main) {
-                upgradeRepo.launchBillingFlow(activity, iap)
+                upgradeRepo.launchBillingFlow(activity, skuDetails, offer)
             }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: UserCanceledBillingException) {
+            log(TAG) { "User canceled the billing flow" }
+        } catch (e: ItemAlreadyOwnedBillingException) {
+            // Stale local state: Play says they already own it, so tapping "buy" really means
+            // "unlock what I own" — restore instead of showing an error.
+            log(TAG, INFO) { "Buy attempt says already owned, restoring purchase instead" }
+            restoreAfterAlreadyOwned(e)
         } catch (e: Exception) {
-            log(TAG) { "launchBillingIap failed: $e" }
+            log(TAG, WARN) { "launchBillingFlow failed: ${e.asLog()}" }
             errorEvents.emitBlocking(e)
         }
     }
 
-    fun launchBillingSubscription(activity: Activity) = launch {
-        try {
-            val sub = state.value?.sub ?: return@launch
-            withContext(dispatcherProvider.Main) {
-                upgradeRepo.launchBillingFlow(activity, sub, MyPermSku.Sub.BASE_OFFER)
-            }
-        } catch (e: Exception) {
-            log(TAG) { "launchBillingSubscription failed: $e" }
-            errorEvents.emitBlocking(e)
+    private suspend fun restoreAfterAlreadyOwned(original: ItemAlreadyOwnedBillingException) {
+        if (!restoring.compareAndSet(expect = false, update = true)) {
+            log(TAG) { "Restore already in progress, letting it resolve the entitlement" }
+            return
         }
-    }
-
-    fun launchBillingSubscriptionTrial(activity: Activity) = launch {
         try {
-            val sub = state.value?.sub ?: return@launch
-            withContext(dispatcherProvider.Main) {
-                upgradeRepo.launchBillingFlow(activity, sub, MyPermSku.Sub.TRIAL_OFFER)
+            val restored = try {
+                withTimeoutOrNull(RESTORE_TIMEOUT_MS) { upgradeRepo.restorePurchaseNow() }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log(TAG, WARN) { "Restore after already-owned failed: ${e.asLog()}" }
+                null
             }
-        } catch (e: Exception) {
-            log(TAG) { "launchBillingSubscriptionTrial failed: $e" }
-            errorEvents.emitBlocking(e)
+            if (restored?.isPro == true) {
+                log(TAG, INFO) { "Restored purchase after already-owned buy attempt" }
+            } else {
+                // Couldn't reconcile the entitlement (pending purchase, account mismatch, Play
+                // quirk) — fall back to the already-owned dialog with restore tips.
+                errorEvents.emitBlocking(original)
+            }
+        } finally {
+            restoring.value = false
         }
     }
 
     fun restorePurchase() = launch {
+        // Single-flight: repeated taps while a restore is running (worst case bounded by
+        // RESTORE_TIMEOUT_MS) must not stack concurrent restores and duplicate result dialogs.
+        if (!restoring.compareAndSet(expect = false, update = true)) {
+            log(TAG) { "restorePurchase() ignored, already in progress" }
+            return@launch
+        }
+        log(TAG) { "restorePurchase()" }
         try {
-            upgradeRepo.refresh()
-            val info = upgradeRepo.upgradeInfo.first()
-            if (info.isPro) {
-                log(TAG) { "Pro purchase found" }
-            } else {
-                log(TAG) { "No pro purchase found" }
-                events.tryEmit(UpgradeEvent.RestoreFailed)
+            val restored = withTimeoutOrNull(RESTORE_TIMEOUT_MS) { upgradeRepo.restorePurchaseNow() }
+            when {
+                restored == null -> {
+                    log(TAG, WARN) { "Restore purchase timed out" }
+                    events.tryEmit(UpgradeEvent.RestoreFailed)
+                }
+
+                restored.isPro -> log(TAG, INFO) { "Restored purchase :)" }
+
+                else -> {
+                    log(TAG, WARN) { "No pro purchase found" }
+                    events.tryEmit(UpgradeEvent.RestoreFailed)
+                }
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            log(TAG) { "Restore failed: $e" }
+            // Play/billing error (e.g. service unavailable): surface the proper error dialog
+            // instead of the generic "no purchases found" message.
+            log(TAG, WARN) { "Restore purchase errored: ${e.asLog()}" }
             errorEvents.emitBlocking(e)
+        } finally {
+            // Reset only after result handling, so the single-flight guard covers the whole action.
+            restoring.value = false
         }
     }
 
     companion object {
+        internal const val RESTORE_TIMEOUT_MS = 15_000L
         private val TAG = logTag("Upgrade", "Gplay", "VM")
     }
 }

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -2,6 +2,8 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play services are unavailable.</string>
     <string name="upgrades_no_purchases_found_check_account">No purchases found. Are you using the right account?</string>
+    <string name="upgrades_gplay_already_owned_title">Already purchased</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play reports that you already own this upgrade, but it could not be restored. Check that you are signed in with the Google account used for the original purchase, then try “Restore purchase”.</string>
 
     <string name="upgrade_screen_preamble">Permission Pilot is ad-free and respects your privacy. Upgrading supports continued development.</string>
     <string name="upgrade_screen_subscription_trial_action">Start free trial</string>
@@ -11,6 +13,8 @@
     <string name="upgrade_screen_iap_action_hint">One-time purchase of %s</string>
     <string name="upgrade_screen_restore_purchase_action">Restore purchase</string>
     <string name="upgrade_screen_restore_purchase_message">No purchases found. Check that you are signed in with the correct Google account.</string>
+    <string name="upgrade_screen_restore_banner_title">Already bought Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">It looks like you upgraded to Pro on this device before. Restore your purchase to unlock it again.</string>
     <string name="upgrade_screen_options_description">Subscriptions renew automatically. You can cancel anytime.</string>
     <string name="upgrade_title_suffix">Pro</string>
 </resources>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,8 @@
     <application
         android:name="eu.darken.myperm.App"
         android:allowBackup="true"
+        android:fullBackupContent="@xml/backup_rules"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:largeHeap="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+    The billing entitlement cache (grace period state) is device-local by design and must not
+    survive backup/restore onto other installations. Everything else stays included.
+-->
+<full-backup-content>
+    <exclude
+        domain="file"
+        path="datastore/settings_gplay.preferences_pb" />
+    <exclude
+        domain="sharedpref"
+        path="settings_gplay.xml" />
+</full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+    API 31+ variant of backup_rules.xml: the billing entitlement cache (grace period state) is
+    device-local by design and must not survive backup/restore or device-to-device transfer.
+-->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude
+            domain="file"
+            path="datastore/settings_gplay.preferences_pb" />
+        <exclude
+            domain="sharedpref"
+            path="settings_gplay.xml" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude
+            domain="file"
+            path="datastore/settings_gplay.preferences_pb" />
+        <exclude
+            domain="sharedpref"
+            path="settings_gplay.xml" />
+    </device-transfer>
+</data-extraction-rules>

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/UpgradeRepoGplayTest.kt
@@ -1,0 +1,197 @@
+package eu.darken.myperm.common.upgrade.core
+
+import com.android.billingclient.api.Purchase
+import eu.darken.myperm.common.upgrade.core.data.BillingData
+import eu.darken.myperm.common.upgrade.core.data.BillingDataRepo
+import eu.darken.myperm.common.upgrade.core.data.PurchasedSku
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.longs.shouldBeGreaterThan
+import io.kotest.matchers.longs.shouldBeLessThanOrEqual
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import org.junit.jupiter.api.Test
+import testhelper.BaseTest
+import testhelper.coroutine.runTest2
+import testhelpers.datastore.mockDataStoreValue
+import java.time.Duration
+import java.time.Instant
+
+class UpgradeRepoGplayTest : BaseTest() {
+
+    private val scope = CoroutineScope(Dispatchers.Unconfined)
+    private val billingDataRepo = mockk<BillingDataRepo>()
+    private val billingCache = mockk<BillingCache>()
+
+    // Builds a repo whose cached last-Pro state is `lastProAt`/`lastSku`. billingData is stubbed
+    // because the eager upgradeInfo flow subscribes it at construction.
+    private fun repo(
+        lastProAt: Long = 0L,
+        lastSku: String = "",
+        billingData: Flow<BillingData> = flowOf(BillingData(emptySet())),
+    ): UpgradeRepoGplay {
+        every { billingDataRepo.billingData } returns billingData
+        every { billingDataRepo.purchaseFailures } returns emptyFlow()
+        val atValue = mockDataStoreValue(lastProAt)
+        val skuValue = mockDataStoreValue(lastSku)
+        every { billingCache.lastProStateAt } returns atValue
+        every { billingCache.lastProStateSku } returns skuValue
+        coEvery { billingCache.confirmPro(any(), any()) } coAnswers {
+            atValue.value(arg(0))
+            skuValue.value(arg(1))
+        }
+        return UpgradeRepoGplay(scope, billingDataRepo, billingCache)
+    }
+
+    private fun proPurchase(sku: String = MyPermSku.Iap.PRO_UPGRADE.id) = mockk<Purchase>().apply {
+        every { products } returns listOf(sku)
+        every { purchaseState } returns Purchase.PurchaseState.PURCHASED
+        every { purchaseTime } returns Instant.parse("2024-01-01T00:00:00Z").toEpochMilli()
+    }
+
+    @Test fun `restore returns pro when a purchase is found`() = runTest2 {
+        coEvery { billingDataRepo.refresh() } returns BillingData(setOf(proPurchase()))
+
+        repo().restorePurchaseNow().isPro shouldBe true
+    }
+
+    @Test fun `restore records the confirmed sku and timestamp`() = runTest2 {
+        coEvery { billingDataRepo.refresh() } returns BillingData(setOf(proPurchase()))
+        val repo = repo()
+
+        repo.restorePurchaseNow()
+
+        billingCache.lastProStateAt.value() shouldBeGreaterThan 0L
+        billingCache.lastProStateSku.value() shouldBe MyPermSku.Iap.PRO_UPGRADE.id
+    }
+
+    @Test fun `restore keeps pro within grace when the query comes back empty`() = runTest2 {
+        coEvery { billingDataRepo.refresh() } returns BillingData(emptySet())
+
+        repo(lastProAt = System.currentTimeMillis() - 1_000).restorePurchaseNow().isPro shouldBe true
+    }
+
+    @Test fun `restore is not pro when the query is empty and grace has expired`() = runTest2 {
+        coEvery { billingDataRepo.refresh() } returns BillingData(emptySet())
+
+        val expired = System.currentTimeMillis() - UpgradeRepoGplay.GRACE_PERIOD_NORMAL_MS - 1_000
+        repo(lastProAt = expired).restorePurchaseNow().isPro shouldBe false
+    }
+
+    @Test fun `restore keeps pro within grace when the query errors`() = runTest2 {
+        coEvery { billingDataRepo.refresh() } throws RuntimeException("Play unavailable")
+
+        repo(lastProAt = System.currentTimeMillis() - 1_000).restorePurchaseNow().isPro shouldBe true
+    }
+
+    @Test fun `restore rethrows the error when it happens outside grace`() = runTest2 {
+        coEvery { billingDataRepo.refresh() } throws RuntimeException("Play unavailable")
+
+        shouldThrow<RuntimeException> {
+            repo(lastProAt = 0L).restorePurchaseNow()
+        }
+    }
+
+    @Test fun `restore publishes its outcome into the canonical upgradeInfo`() = runTest2 {
+        coEvery { billingDataRepo.refresh() } throws RuntimeException("Play unavailable")
+        // 8h ago: outside the reactive 6h "normal" window, inside the 24h "error" window.
+        val eightHoursAgo = System.currentTimeMillis() - Duration.ofHours(8).toMillis()
+        val source = MutableSharedFlow<BillingData>()
+        val repo = repo(lastProAt = eightHoursAgo, billingData = source)
+
+        // The reactive pipeline evaluates empty data with the 6h window -> non-Pro.
+        source.emit(BillingData(emptySet()))
+        repo.upgradeInfo.value.isPro shouldBe false
+
+        // The explicit restore hits a billing error within the 24h error window -> grace-Pro.
+        // That outcome must reach the canonical upgradeInfo, not just the returned value.
+        repo.restorePurchaseNow().isPro shouldBe true
+        repo.upgradeInfo.value.isPro shouldBe true
+    }
+
+    @Test fun `reactive empty data after a billing error keeps the error grace window`() = runTest2 {
+        coEvery { billingDataRepo.refresh() } throws RuntimeException("Play unavailable")
+        val eightHoursAgo = System.currentTimeMillis() - Duration.ofHours(8).toMillis()
+        val source = MutableSharedFlow<BillingData>()
+        val repo = repo(lastProAt = eightHoursAgo, billingData = source)
+
+        // Records the billing error and concludes grace-Pro via the 24h window.
+        repo.restorePurchaseNow().isPro shouldBe true
+
+        // A racing reactive empty emission processed afterwards must not downgrade to the 6h
+        // window — an empty result during billing trouble isn't evidence of "not owned".
+        source.emit(BillingData(emptySet()))
+        repo.upgradeInfo.value.isPro shouldBe true
+    }
+
+    @Test fun `a successful refresh retires the error grace override`() = runTest2 {
+        val eightHoursAgo = System.currentTimeMillis() - Duration.ofHours(8).toMillis()
+        val repo = repo(lastProAt = eightHoursAgo)
+
+        // A billing error activates the 24h error window...
+        coEvery { billingDataRepo.refresh() } throws RuntimeException("Play unavailable")
+        repo.restorePurchaseNow().isPro shouldBe true
+
+        // ...but once Play answers authoritatively, empty settles back to the 6h window.
+        coEvery { billingDataRepo.refresh() } returns BillingData(emptySet())
+        repo.restorePurchaseNow().isPro shouldBe false
+    }
+
+    @Test fun `permanent IAP keeps grace well beyond the subscription windows`() = runTest2 {
+        coEvery { billingDataRepo.refresh() } returns BillingData(emptySet())
+        // 20 days ago: far past the 6h/24h windows, but within the 30-day IAP window.
+        val twentyDaysAgo = System.currentTimeMillis() - Duration.ofDays(20).toMillis()
+
+        repo(lastProAt = twentyDaysAgo, lastSku = MyPermSku.Iap.PRO_UPGRADE.id)
+            .restorePurchaseNow().isPro shouldBe true
+    }
+
+    @Test fun `subscription grace expires after the short window`() = runTest2 {
+        coEvery { billingDataRepo.refresh() } returns BillingData(emptySet())
+        val twentyDaysAgo = System.currentTimeMillis() - Duration.ofDays(20).toMillis()
+
+        repo(lastProAt = twentyDaysAgo, lastSku = MyPermSku.Sub.PRO_UPGRADE.id)
+            .restorePurchaseNow().isPro shouldBe false
+    }
+
+    @Test fun `legacy cache without a sku gets the short windows`() = runTest2 {
+        coEvery { billingDataRepo.refresh() } returns BillingData(emptySet())
+        val twentyDaysAgo = System.currentTimeMillis() - Duration.ofDays(20).toMillis()
+
+        repo(lastProAt = twentyDaysAgo, lastSku = "").restorePurchaseNow().isPro shouldBe false
+    }
+
+    @Test fun `a future timestamp is reset instead of granting indefinite grace`() = runTest2 {
+        coEvery { billingDataRepo.refresh() } returns BillingData(emptySet())
+        val future = System.currentTimeMillis() + Duration.ofDays(365).toMillis()
+        val repo = repo(lastProAt = future)
+
+        // Treated as "just now": still in grace for this evaluation, but the stored timestamp is
+        // clamped so the grace window ends on schedule instead of a year from now.
+        repo.restorePurchaseNow().isPro shouldBe true
+        billingCache.lastProStateAt.value() shouldBeLessThanOrEqual System.currentTimeMillis()
+    }
+
+    @Test fun `grace window constants`() {
+        (UpgradeRepoGplay.GRACE_PERIOD_IAP_MS > UpgradeRepoGplay.GRACE_PERIOD_ERROR_MS) shouldBe true
+        (UpgradeRepoGplay.GRACE_PERIOD_ERROR_MS > UpgradeRepoGplay.GRACE_PERIOD_NORMAL_MS) shouldBe true
+        UpgradeRepoGplay.GRACE_PERIOD_IAP_MS shouldBe Duration.ofDays(30).toMillis()
+    }
+
+    @Test fun `preferredProSku prefers the permanent IAP when both are owned`() {
+        val iap = PurchasedSku(MyPermSku.Iap.PRO_UPGRADE, mockk<Purchase>())
+        val sub = PurchasedSku(MyPermSku.Sub.PRO_UPGRADE, mockk<Purchase>())
+
+        UpgradeRepoGplay.preferredProSku(listOf(sub, iap))?.sku shouldBe MyPermSku.Iap.PRO_UPGRADE
+        UpgradeRepoGplay.preferredProSku(listOf(iap))?.sku shouldBe MyPermSku.Iap.PRO_UPGRADE
+        UpgradeRepoGplay.preferredProSku(listOf(sub))?.sku shouldBe MyPermSku.Sub.PRO_UPGRADE
+        UpgradeRepoGplay.preferredProSku(emptyList()) shouldBe null
+    }
+}

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/UpgradeRepoGplayTest.kt
@@ -1,6 +1,9 @@
 package eu.darken.myperm.common.upgrade.core
 
+import com.android.billingclient.api.BillingClient.BillingResponseCode
+import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.Purchase
+import eu.darken.myperm.common.upgrade.core.client.ItemAlreadyOwnedBillingException
 import eu.darken.myperm.common.upgrade.core.data.BillingData
 import eu.darken.myperm.common.upgrade.core.data.BillingDataRepo
 import eu.darken.myperm.common.upgrade.core.data.PurchasedSku
@@ -9,6 +12,7 @@ import io.kotest.matchers.longs.shouldBeGreaterThan
 import io.kotest.matchers.longs.shouldBeLessThanOrEqual
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
@@ -36,9 +40,10 @@ class UpgradeRepoGplayTest : BaseTest() {
         lastProAt: Long = 0L,
         lastSku: String = "",
         billingData: Flow<BillingData> = flowOf(BillingData(emptySet())),
+        purchaseFailures: Flow<Throwable> = emptyFlow(),
     ): UpgradeRepoGplay {
         every { billingDataRepo.billingData } returns billingData
-        every { billingDataRepo.purchaseFailures } returns emptyFlow()
+        every { billingDataRepo.purchaseFailures } returns purchaseFailures
         val atValue = mockDataStoreValue(lastProAt)
         val skuValue = mockDataStoreValue(lastSku)
         every { billingCache.lastProStateAt } returns atValue
@@ -183,6 +188,58 @@ class UpgradeRepoGplayTest : BaseTest() {
         (UpgradeRepoGplay.GRACE_PERIOD_IAP_MS > UpgradeRepoGplay.GRACE_PERIOD_ERROR_MS) shouldBe true
         (UpgradeRepoGplay.GRACE_PERIOD_ERROR_MS > UpgradeRepoGplay.GRACE_PERIOD_NORMAL_MS) shouldBe true
         UpgradeRepoGplay.GRACE_PERIOD_IAP_MS shouldBe Duration.ofDays(30).toMillis()
+    }
+
+    @Test fun `reactive pro emissions stamp once via the init collector, the map never stamps`() = runTest2 {
+        // billingData carries a pro purchase. Both the read-only upgradeInfo map and the persistent
+        // init collector consume it — if the map still stamped, the count would exceed one.
+        val repo = repo(
+            lastProAt = 0L,
+            billingData = flowOf(BillingData(setOf(proPurchase()))),
+        )
+
+        repo.upgradeInfo.value.isPro shouldBe true
+        coVerify(exactly = 1) { billingCache.confirmPro(any(), any()) }
+    }
+
+    @Test fun `restore with an empty result does not stamp the grace cache`() = runTest2 {
+        coEvery { billingDataRepo.refresh() } returns BillingData(emptySet())
+
+        repo(lastProAt = System.currentTimeMillis() - 1_000).restorePurchaseNow()
+
+        coVerify(exactly = 0) { billingCache.confirmPro(any(), any()) }
+    }
+
+    @Test fun `background refresh stamps the grace cache from the fresh result`() = runTest2 {
+        coEvery { billingDataRepo.refresh() } returns BillingData(setOf(proPurchase()))
+
+        repo(lastProAt = 0L).refresh()
+
+        coVerify(exactly = 1) { billingCache.confirmPro(any(), MyPermSku.Iap.PRO_UPGRADE.id) }
+    }
+
+    @Test fun `async already-owned purchase event triggers a silent restore`() = runTest2 {
+        coEvery { billingDataRepo.refresh() } returns BillingData(setOf(proPurchase()))
+
+        repo(
+            lastProAt = 0L,
+            purchaseFailures = flowOf(
+                ItemAlreadyOwnedBillingException(
+                    BillingResult.newBuilder().setResponseCode(BillingResponseCode.ITEM_ALREADY_OWNED).build()
+                )
+            ),
+        )
+
+        coVerify(exactly = 1) { billingDataRepo.refresh() }
+    }
+
+    @Test fun `other async purchase failures do not trigger a restore`() = runTest2 {
+        repo(
+            lastProAt = 0L,
+            purchaseFailures = flowOf(RuntimeException("payment declined")),
+        )
+
+        coVerify(exactly = 0) { billingDataRepo.refresh() }
     }
 
     @Test fun `preferredProSku prefers the permanent IAP when both are owned`() {

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/client/BillingClientConnectionTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/client/BillingClientConnectionTest.kt
@@ -1,0 +1,88 @@
+package eu.darken.myperm.common.upgrade.core.client
+
+import com.android.billingclient.api.BillingClient
+import com.android.billingclient.api.BillingResult
+import com.android.billingclient.api.Purchase
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import testhelper.BaseTest
+
+class BillingClientConnectionTest : BaseTest() {
+
+    private fun purchase(time: Long) = mockk<Purchase>().apply {
+        every { purchaseTime } returns time
+    }
+
+    @Test
+    fun `combines both product types, newest first`() {
+        val older = purchase(1_000)
+        val newer = purchase(2_000)
+
+        BillingClientConnection.combinePurchaseResults(
+            iaps = Result.success(listOf(older)),
+            subs = Result.success(listOf(newer)),
+        ) shouldBe listOf(newer, older)
+    }
+
+    @Test
+    fun `a single product-type failure does not mask a purchase found by the other`() {
+        val owned = purchase(1_000)
+
+        BillingClientConnection.combinePurchaseResults(
+            iaps = Result.success(listOf(owned)),
+            subs = Result.failure(RuntimeException("SUBS query failed")),
+        ) shouldBe listOf(owned)
+
+        BillingClientConnection.combinePurchaseResults(
+            iaps = Result.failure(RuntimeException("IAP query failed")),
+            subs = Result.success(listOf(owned)),
+        ) shouldBe listOf(owned)
+    }
+
+    @Test
+    fun `both product types empty returns empty`() {
+        BillingClientConnection.combinePurchaseResults(
+            iaps = Result.success(emptyList()),
+            subs = Result.success(emptyList()),
+        ) shouldBe emptyList()
+    }
+
+    @Test
+    fun `nothing found but a query failed rethrows the error`() {
+        shouldThrow<RuntimeException> {
+            BillingClientConnection.combinePurchaseResults(
+                iaps = Result.success(emptyList()),
+                subs = Result.failure(RuntimeException("SUBS query failed")),
+            )
+        }
+    }
+
+    private fun result(code: Int) = BillingResult.newBuilder().setResponseCode(code).build()
+
+    @Test
+    fun `listener echo of a synchronous launch failure is detected`() {
+        val code = BillingClient.BillingResponseCode.DEVELOPER_ERROR
+        val now = 100_000L
+        val justFailed = code to now - 1_000
+
+        BillingClientConnection.isSyncLaunchFailureEcho(result(code), justFailed, now) shouldBe true
+
+        // A different code is a new failure, not an echo.
+        BillingClientConnection.isSyncLaunchFailureEcho(
+            result(BillingClient.BillingResponseCode.ERROR), justFailed, now,
+        ) shouldBe false
+
+        // Outside the echo window it counts as a new failure again.
+        val longAgo = code to now - BillingClientConnection.SYNC_LAUNCH_FAILURE_ECHO_WINDOW_MS - 1
+        BillingClientConnection.isSyncLaunchFailureEcho(result(code), longAgo, now) shouldBe false
+
+        // No synchronous failure recorded at all.
+        BillingClientConnection.isSyncLaunchFailureEcho(result(code), null, now) shouldBe false
+
+        // A negative age is never an echo (clock anomalies must not suppress real failures).
+        BillingClientConnection.isSyncLaunchFailureEcho(result(code), code to now + 1_000, now) shouldBe false
+    }
+}

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/data/BillingDataRepoTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/data/BillingDataRepoTest.kt
@@ -1,0 +1,98 @@
+package eu.darken.myperm.common.upgrade.core.data
+
+import com.android.billingclient.api.BillingClient.BillingResponseCode
+import com.android.billingclient.api.BillingResult
+import eu.darken.myperm.common.upgrade.core.client.BillingClientConnection
+import eu.darken.myperm.common.upgrade.core.client.BillingClientConnectionProvider
+import eu.darken.myperm.common.upgrade.core.client.BillingResultException
+import eu.darken.myperm.common.upgrade.core.client.GplayServiceUnavailableException
+import eu.darken.myperm.common.upgrade.core.client.ItemAlreadyOwnedBillingException
+import eu.darken.myperm.common.upgrade.core.client.UserCanceledBillingException
+import eu.darken.myperm.common.upgrade.core.data.BillingDataRepo.Companion.tryMapUserFriendly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import org.junit.jupiter.api.Test
+import testhelper.BaseTest
+import testhelper.coroutine.runTest2
+
+class BillingDataRepoTest : BaseTest() {
+
+    private fun resultException(code: Int) = BillingResultException(
+        BillingResult.newBuilder().setResponseCode(code).build()
+    )
+
+    private fun repoWithListenerFailure(code: Int): BillingDataRepo {
+        val connection = mockk<BillingClientConnection> {
+            every { purchases } returns emptyFlow()
+            every { purchaseFailures } returns flowOf(BillingResult.newBuilder().setResponseCode(code).build())
+        }
+        val provider = mockk<BillingClientConnectionProvider> {
+            every { this@mockk.connection } returns flowOf(connection)
+        }
+        return BillingDataRepo(provider, CoroutineScope(Dispatchers.Unconfined))
+    }
+
+    @Test
+    fun `async listener failures are mapped like launch failures`() = runTest2 {
+        repoWithListenerFailure(BillingResponseCode.ITEM_ALREADY_OWNED)
+            .purchaseFailures.first()
+            .shouldBeInstanceOf<ItemAlreadyOwnedBillingException>()
+
+        repoWithListenerFailure(BillingResponseCode.USER_CANCELED)
+            .purchaseFailures.first()
+            .shouldBeInstanceOf<UserCanceledBillingException>()
+
+        repoWithListenerFailure(BillingResponseCode.DEVELOPER_ERROR)
+            .purchaseFailures.first()
+            .shouldBeInstanceOf<BillingResultException>()
+    }
+
+    @Test
+    fun `user cancel maps to the silent cancel exception`() {
+        resultException(BillingResponseCode.USER_CANCELED)
+            .tryMapUserFriendly()
+            .shouldBeInstanceOf<UserCanceledBillingException>()
+    }
+
+    @Test
+    fun `already owned maps to its own exception`() {
+        resultException(BillingResponseCode.ITEM_ALREADY_OWNED)
+            .tryMapUserFriendly()
+            .shouldBeInstanceOf<ItemAlreadyOwnedBillingException>()
+    }
+
+    @Test
+    fun `temporary and permanent unavailability map to the service error`() {
+        resultException(BillingResponseCode.SERVICE_UNAVAILABLE)
+            .tryMapUserFriendly()
+            .shouldBeInstanceOf<GplayServiceUnavailableException>()
+
+        resultException(BillingResponseCode.BILLING_UNAVAILABLE)
+            .tryMapUserFriendly()
+            .shouldBeInstanceOf<GplayServiceUnavailableException>()
+    }
+
+    @Test
+    fun `a completed connection flow maps to the service error`() {
+        // connectionProvider.first() throws this when the flow completed without emitting
+        NoSuchElementException("Flow is empty")
+            .tryMapUserFriendly()
+            .shouldBeInstanceOf<GplayServiceUnavailableException>()
+    }
+
+    @Test
+    fun `unrelated errors pass through unchanged`() {
+        val boom = IllegalStateException("boom")
+        boom.tryMapUserFriendly() shouldBe boom
+
+        val developerError = resultException(BillingResponseCode.DEVELOPER_ERROR)
+        developerError.tryMapUserFriendly() shouldBe developerError
+    }
+}

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModelTest.kt
@@ -20,7 +20,6 @@ import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -55,15 +54,12 @@ class UpgradeViewModelTest : BaseTest() {
         billingData = null,
     )
 
-    private val failureEvents = MutableSharedFlow<Throwable>()
-
     private fun mockRepo(
         isPro: Boolean = false,
         wasEverPro: Boolean = false,
     ): UpgradeRepoGplay = mockk<UpgradeRepoGplay>(relaxed = true).apply {
         every { upgradeInfo } returns MutableStateFlow(info(isPro))
         every { this@apply.wasEverPro } returns MutableStateFlow(wasEverPro)
-        every { purchaseFailures } returns failureEvents
         coEvery { querySkus() } returns emptyList()
     }
 
@@ -311,55 +307,6 @@ class UpgradeViewModelTest : BaseTest() {
 
         navEvents.size shouldBe 1
         collector.cancel()
-    }
-
-    @Test
-    fun `async already-owned failure triggers the silent auto-restore`() = runTest2(context = testDispatcher) {
-        val repo = mockRepo()
-        coEvery { repo.restorePurchaseNow() } returns info(isPro = true)
-        val vm = buildVm(repo)
-
-        val errors = mutableListOf<Throwable>()
-        val collector = launch { vm.errorEvents.collect { errors.add(it) } }
-        advanceUntilIdle() // let the init collector subscribe before emitting
-
-        failureEvents.emit(ItemAlreadyOwnedBillingException(result(BillingResponseCode.ITEM_ALREADY_OWNED)))
-        advanceUntilIdle()
-
-        errors shouldBe emptyList()
-        coVerify(exactly = 1) { repo.restorePurchaseNow() }
-        collector.cancel()
-    }
-
-    @Test
-    fun `async user cancel stays silent`() = runTest2(context = testDispatcher) {
-        val repo = mockRepo()
-        val vm = buildVm(repo)
-
-        val errors = mutableListOf<Throwable>()
-        val collector = launch { vm.errorEvents.collect { errors.add(it) } }
-        advanceUntilIdle()
-
-        failureEvents.emit(UserCanceledBillingException(result(BillingResponseCode.USER_CANCELED)))
-        advanceUntilIdle()
-
-        errors shouldBe emptyList()
-        coVerify(exactly = 0) { repo.restorePurchaseNow() }
-        collector.cancel()
-    }
-
-    @Test
-    fun `other async failures are forwarded to the error dialog`() = runTest2(context = testDispatcher) {
-        val repo = mockRepo()
-        val boom = IllegalStateException("payment declined")
-        val vm = buildVm(repo)
-
-        advanceUntilIdle() // let the init collector subscribe before emitting
-
-        failureEvents.emit(boom)
-        advanceUntilIdle()
-
-        vm.errorEvents.first() shouldBe boom
     }
 
     @Test

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModelTest.kt
@@ -1,0 +1,382 @@
+package eu.darken.myperm.common.upgrade.ui
+
+import android.app.Activity
+import com.android.billingclient.api.BillingClient.BillingResponseCode
+import com.android.billingclient.api.BillingResult
+import com.android.billingclient.api.ProductDetails
+import eu.darken.myperm.common.upgrade.UpgradeRepo
+import eu.darken.myperm.common.upgrade.core.MyPermSku
+import eu.darken.myperm.common.upgrade.core.UpgradeRepoGplay
+import eu.darken.myperm.common.upgrade.core.client.ItemAlreadyOwnedBillingException
+import eu.darken.myperm.common.upgrade.core.client.UserCanceledBillingException
+import eu.darken.myperm.common.upgrade.core.data.BillingData
+import eu.darken.myperm.common.upgrade.core.data.SkuDetails
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelper.BaseTest
+import testhelper.coroutine.TestDispatcherProvider
+import testhelper.coroutine.runTest2
+
+class UpgradeViewModelTest : BaseTest() {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val activity = mockk<Activity>()
+
+    @BeforeEach
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterEach
+    fun teardown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun info(isPro: Boolean) = UpgradeRepoGplay.Info(
+        gracePeriod = isPro,
+        billingData = null,
+    )
+
+    private val failureEvents = MutableSharedFlow<Throwable>()
+
+    private fun mockRepo(
+        isPro: Boolean = false,
+        wasEverPro: Boolean = false,
+    ): UpgradeRepoGplay = mockk<UpgradeRepoGplay>(relaxed = true).apply {
+        every { upgradeInfo } returns MutableStateFlow(info(isPro))
+        every { this@apply.wasEverPro } returns MutableStateFlow(wasEverPro)
+        every { purchaseFailures } returns failureEvents
+        coEvery { querySkus() } returns emptyList()
+    }
+
+    private fun buildVm(repo: UpgradeRepoGplay): UpgradeViewModel = UpgradeViewModel(
+        dispatcherProvider = TestDispatcherProvider(testDispatcher),
+        upgradeRepo = repo,
+    )
+
+    private fun iapSkuDetails(): SkuDetails = SkuDetails(
+        sku = MyPermSku.Iap.PRO_UPGRADE,
+        details = mockk<ProductDetails> {
+            every { oneTimePurchaseOfferDetails } returns null
+            every { subscriptionOfferDetails } returns null
+        },
+    )
+
+    private fun result(code: Int): BillingResult = BillingResult.newBuilder().setResponseCode(code).build()
+
+    @Test
+    fun `restore with no purchase emits RestoreFailed`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } returns info(isPro = false)
+        val vm = buildVm(repo)
+
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        vm.events.first() shouldBe UpgradeViewModel.UpgradeEvent.RestoreFailed
+    }
+
+    @Test
+    fun `restore that finds pro emits no failure`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } returns info(isPro = true)
+        val vm = buildVm(repo)
+
+        val events = mutableListOf<UpgradeViewModel.UpgradeEvent>()
+        val collector = launch { vm.events.collect { events.add(it) } }
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        events shouldBe emptyList()
+        collector.cancel()
+    }
+
+    @Test
+    fun `restore that times out emits RestoreFailed`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } coAnswers {
+            delay(30_000) // longer than the 15s restore timeout
+            info(isPro = true)
+        }
+        val vm = buildVm(repo)
+
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        vm.events.first() shouldBe UpgradeViewModel.UpgradeEvent.RestoreFailed
+    }
+
+    @Test
+    fun `restore that errors forwards the error instead of RestoreFailed`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        val boom = IllegalStateException("Play unavailable")
+        coEvery { repo.restorePurchaseNow() } throws boom
+        val vm = buildVm(repo)
+
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        vm.errorEvents.first() shouldBe boom
+    }
+
+    @Test
+    fun `restore is single-flight, taps during a running restore are ignored`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } coAnswers {
+            delay(5_000)
+            info(isPro = true)
+        }
+        val vm = buildVm(repo)
+
+        vm.restorePurchase()
+        vm.restorePurchase()
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { repo.restorePurchaseNow() }
+    }
+
+    @Test
+    fun `a finished restore allows a new attempt`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } returns info(isPro = false)
+        val vm = buildVm(repo)
+
+        vm.restorePurchase()
+        advanceUntilIdle()
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        coVerify(exactly = 2) { repo.restorePurchaseNow() }
+    }
+
+    @Test
+    fun `restore progress flows into the ui state and resets`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } coAnswers {
+            delay(5_000)
+            info(isPro = false)
+        }
+        val vm = buildVm(repo)
+
+        val inProgress = async { vm.state.first { it.restoreInProgress } }
+        vm.restorePurchase()
+        inProgress.await().restoreInProgress shouldBe true
+
+        advanceUntilIdle()
+        vm.state.first { !it.restoreInProgress }.restoreInProgress shouldBe false
+    }
+
+    @Test
+    fun `previously-pro on this device flows into the banner flag`() = runTest2(context = testDispatcher) {
+        val vm = buildVm(mockRepo(isPro = false, wasEverPro = true))
+
+        val state = async { vm.state.first { it.pricing != null } }
+        advanceUntilIdle()
+
+        state.await().wasPreviouslyPro shouldBe true
+    }
+
+    @Test
+    fun `banner flag stays off while grace still keeps the user pro`() = runTest2(context = testDispatcher) {
+        val vm = buildVm(mockRepo(isPro = true, wasEverPro = true))
+
+        val state = async { vm.state.first { it.pricing != null } }
+        advanceUntilIdle()
+
+        state.await().wasPreviouslyPro shouldBe false
+    }
+
+    @Test
+    fun `user cancel during the billing flow stays silent`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.querySkus() } returns listOf(iapSkuDetails())
+        coEvery { repo.launchBillingFlow(any(), any(), null) } throws
+            UserCanceledBillingException(result(BillingResponseCode.USER_CANCELED))
+        val vm = buildVm(repo)
+
+        val errors = mutableListOf<Throwable>()
+        val collector = launch { vm.errorEvents.collect { errors.add(it) } }
+
+        val ready = async { vm.state.first { it.pricing?.iap != null } }
+        advanceUntilIdle()
+        ready.await()
+
+        vm.launchBillingIap(activity)
+        advanceUntilIdle()
+
+        errors shouldBe emptyList()
+        collector.cancel()
+    }
+
+    @Test
+    fun `already-owned buy attempt silently restores the purchase instead of erroring`() =
+        runTest2(context = testDispatcher) {
+            val repo = mockRepo()
+            coEvery { repo.querySkus() } returns listOf(iapSkuDetails())
+            coEvery { repo.launchBillingFlow(any(), any(), null) } throws
+                ItemAlreadyOwnedBillingException(result(BillingResponseCode.ITEM_ALREADY_OWNED))
+            coEvery { repo.restorePurchaseNow() } returns info(isPro = true)
+            val vm = buildVm(repo)
+
+            val errors = mutableListOf<Throwable>()
+            val collector = launch { vm.errorEvents.collect { errors.add(it) } }
+
+            val ready = async { vm.state.first { it.pricing?.iap != null } }
+            advanceUntilIdle()
+            ready.await()
+
+            vm.launchBillingIap(activity)
+            advanceUntilIdle()
+
+            errors shouldBe emptyList()
+            coVerify(exactly = 1) { repo.restorePurchaseNow() }
+            collector.cancel()
+        }
+
+    @Test
+    fun `already-owned buy attempt falls back to the error dialog when restore finds nothing`() =
+        runTest2(context = testDispatcher) {
+            val repo = mockRepo()
+            coEvery { repo.querySkus() } returns listOf(iapSkuDetails())
+            coEvery { repo.launchBillingFlow(any(), any(), null) } throws
+                ItemAlreadyOwnedBillingException(result(BillingResponseCode.ITEM_ALREADY_OWNED))
+            coEvery { repo.restorePurchaseNow() } returns info(isPro = false)
+            val vm = buildVm(repo)
+
+            val ready = async { vm.state.first { it.pricing?.iap != null } }
+            advanceUntilIdle()
+            ready.await()
+
+            vm.launchBillingIap(activity)
+            advanceUntilIdle()
+
+            vm.errorEvents.first().shouldBeInstanceOf<ItemAlreadyOwnedBillingException>()
+        }
+
+    @Test
+    fun `already-owned buy attempt falls back to the error dialog when restore itself errors`() =
+        runTest2(context = testDispatcher) {
+            val repo = mockRepo()
+            coEvery { repo.querySkus() } returns listOf(iapSkuDetails())
+            coEvery { repo.launchBillingFlow(any(), any(), null) } throws
+                ItemAlreadyOwnedBillingException(result(BillingResponseCode.ITEM_ALREADY_OWNED))
+            coEvery { repo.restorePurchaseNow() } throws RuntimeException("Play unavailable")
+            val vm = buildVm(repo)
+
+            val ready = async { vm.state.first { it.pricing?.iap != null } }
+            advanceUntilIdle()
+            ready.await()
+
+            vm.launchBillingIap(activity)
+            advanceUntilIdle()
+
+            vm.errorEvents.first().shouldBeInstanceOf<ItemAlreadyOwnedBillingException>()
+        }
+
+    @Test
+    fun `consecutive unequal pro emissions trigger a single navUp`() = runTest2(context = testDispatcher) {
+        val infoFlow = MutableStateFlow<UpgradeRepo.Info>(info(isPro = false))
+        val repo = mockRepo()
+        every { repo.upgradeInfo } returns infoFlow
+        val vm = buildVm(repo)
+
+        val navEvents = mutableListOf<Any>()
+        val collector = launch { vm.navEvents.collect { navEvents.add(it) } }
+        advanceUntilIdle()
+
+        // Two Pro Infos with different backing data — unequal objects, both isPro.
+        infoFlow.value = UpgradeRepoGplay.Info(gracePeriod = true, billingData = null)
+        advanceUntilIdle()
+        infoFlow.value = UpgradeRepoGplay.Info(gracePeriod = true, billingData = BillingData(emptySet()))
+        advanceUntilIdle()
+
+        navEvents.size shouldBe 1
+        collector.cancel()
+    }
+
+    @Test
+    fun `async already-owned failure triggers the silent auto-restore`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } returns info(isPro = true)
+        val vm = buildVm(repo)
+
+        val errors = mutableListOf<Throwable>()
+        val collector = launch { vm.errorEvents.collect { errors.add(it) } }
+        advanceUntilIdle() // let the init collector subscribe before emitting
+
+        failureEvents.emit(ItemAlreadyOwnedBillingException(result(BillingResponseCode.ITEM_ALREADY_OWNED)))
+        advanceUntilIdle()
+
+        errors shouldBe emptyList()
+        coVerify(exactly = 1) { repo.restorePurchaseNow() }
+        collector.cancel()
+    }
+
+    @Test
+    fun `async user cancel stays silent`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        val vm = buildVm(repo)
+
+        val errors = mutableListOf<Throwable>()
+        val collector = launch { vm.errorEvents.collect { errors.add(it) } }
+        advanceUntilIdle()
+
+        failureEvents.emit(UserCanceledBillingException(result(BillingResponseCode.USER_CANCELED)))
+        advanceUntilIdle()
+
+        errors shouldBe emptyList()
+        coVerify(exactly = 0) { repo.restorePurchaseNow() }
+        collector.cancel()
+    }
+
+    @Test
+    fun `other async failures are forwarded to the error dialog`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        val boom = IllegalStateException("payment declined")
+        val vm = buildVm(repo)
+
+        advanceUntilIdle() // let the init collector subscribe before emitting
+
+        failureEvents.emit(boom)
+        advanceUntilIdle()
+
+        vm.errorEvents.first() shouldBe boom
+    }
+
+    @Test
+    fun `other launch failures are forwarded to the error dialog`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        val boom = IllegalStateException("launch broke")
+        coEvery { repo.querySkus() } returns listOf(iapSkuDetails())
+        coEvery { repo.launchBillingFlow(any(), any(), null) } throws boom
+        val vm = buildVm(repo)
+
+        val ready = async { vm.state.first { it.pricing?.iap != null } }
+        advanceUntilIdle()
+        ready.await()
+
+        vm.launchBillingIap(activity)
+        advanceUntilIdle()
+
+        vm.errorEvents.first() shouldBe boom
+    }
+}


### PR DESCRIPTION
## What changed

Google Play billing is now much more reliable:

- **"Restore purchase" no longer reports failure for people who already own Pro.** It also shows progress while running, can't be triggered twice in parallel, and distinguishes "no purchase found" from "Google Play is unavailable".
- **Buy buttons no longer fail silently.** If Google Play can't start a purchase, the matching error is shown — and if Play reports the upgrade is already owned, it is restored automatically instead of showing an error.
- **One-time Pro buyers stay Pro through longer Play outages** — up to 30 days of billing hiccups, up from 6–24 hours. Subscriptions keep the short windows since they can genuinely lapse.
- **Returning buyers see an "Already bought Pro?" banner** with a restore button at the top of the upgrade screen, instead of heading straight into the paywall.
- **Billing recovers on its own** if Google Play was briefly unavailable when the app started (previously it could stay broken until an app restart), and a refund now reliably ends the Pro grace period on schedule.

## Technical Context

Ports the SD Maid 2/SE billing hardening series (d4rken-org/sdmaid-se#2554, d4rken-org/sdmaid-se#2555, d4rken-org/sdmaid-se#2556, d4rken-org/sdmaid-se#2558, d4rken-org/sdmaid-se#2559, d4rken-org/sdmaid-se#2561), adapted to this app's billing architecture (`BillingClientConnectionProvider` → `BillingClientConnection` → `BillingDataRepo` → `UpgradeRepoGplay`).

- **Restore root cause:** the restore path read the eagerly shared `upgradeInfo` StateFlow right after triggering a refresh — a near-deterministic stale read. Restore now evaluates the query results *returned* by the refresh in the same coroutine and publishes the outcome into the shared state. `refreshPurchases()` also no longer swallows query errors (`runCatching` + `getOrDefault` made "Play down" indistinguishable from "not owned"); a purchase found by either product type is authoritative, an error only surfaces when nothing was found.
- **Silent buy taps:** `launchBillingFlow()`'s returned `BillingResult` was discarded — per the Billing 8.3 contract, immediate launch failures arrive there and are *also* echoed to `onPurchasesUpdated`; the echo is suppressed one-shot (`isSyncLaunchFailureEcho`) so each failure is handled exactly once. Async `ITEM_ALREADY_OWNED` is reconciled by a persistent repo-level collector; other async purchase-sheet failures stay app-silent (Play shows its own UI).
- **Cancellation correctness:** billing wrappers moved from `suspendCoroutine` to `suspendCancellableCoroutine` — the restore timeout could otherwise never cancel a hung Play callback.
- **Grace provenance:** the reactive mapping is read-only; grace state is stamped only from fresh data (returned query results + one persistent collector), so stale/replayed purchase data can't keep extending a refunded user's grace window. Timestamp + SKU are written in one DataStore transaction, future timestamps are clamped, and the entitlement cache is excluded from backup/device-transfer.
- **Connection resilience:** the connection share retries indefinitely with capped backoff instead of dying on a terminal failure — the ack collector pins the share for the process lifetime, so a completed upstream could never restart (one transient `BILLING_UNAVAILABLE` at first use previously bricked billing until process restart).
- **Review guidance:** the subtle parts are the grace-stamping provenance (`recordProState` doc comment) and the sync/async double-delivery of launch failures (`BillingClientConnection.isSyncLaunchFailureEcho`).
- Adds this repo's first billing unit tests (46 tests under `app/src/testGplay/`). FOSS flavor is untouched.
