### PR TITLE
General: Recover billing faster after a Play outage recovers mid-session

### DIFF
--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/client/BillingClientConnection.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/client/BillingClientConnection.kt
@@ -36,6 +36,11 @@ data class BillingClientConnection(
     private val queryCacheIaps = MutableStateFlow<Collection<Purchase>>(emptySet())
     private val queryCacheSubs = MutableStateFlow<Collection<Purchase>>(emptySet())
 
+    // Whether the underlying client is still connected. False for a connection that has since been
+    // disconnected/ended — callers must not use such a stale connection (it may linger in a replay
+    // cache while a reconnect is pending).
+    val isReady: Boolean get() = client.isReady
+
     // responseCode + monotonic (elapsedRealtime) time of the last synchronous launch failure.
     private val lastSyncLaunchFailure = MutableStateFlow<Pair<Int, Long>?>(null)
 

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/data/BillingDataRepo.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/data/BillingDataRepo.kt
@@ -24,7 +24,7 @@ import eu.darken.myperm.common.upgrade.core.client.isGplayUnavailablePermanent
 import eu.darken.myperm.common.upgrade.core.client.isGplayUnavailableTemporary
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
-
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
@@ -43,6 +43,10 @@ class BillingDataRepo @Inject constructor(
     @AppScope private val scope: CoroutineScope,
 ) {
 
+    // Wakes an in-progress connection backoff. Conflated so a request sent while the retry loop is
+    // NOT sleeping is still consumed by the next backoff — exactly once, so it can't cause a spin.
+    private val reconnectSignal = Channel<Unit>(Channel.CONFLATED)
+
     private val connectionProvider = clientConnectionProvider.connection
         .retryWhen { cause, attempt ->
             // Never give up terminally: the ack collector pins this share for the process
@@ -53,7 +57,7 @@ class BillingDataRepo @Inject constructor(
                 false
             } else {
                 log(TAG, WARN) { "Billing connection failed (attempt=$attempt), will retry: ${cause.asLog()}" }
-                delay((CONNECTION_RETRY_BASE_MS * (attempt + 1)).coerceAtMost(CONNECTION_RETRY_MAX_MS))
+                awaitReconnectBackoff(attempt)
                 true
             }
         }
@@ -130,13 +134,35 @@ class BillingDataRepo @Inject constructor(
             .launchIn(scope)
     }
 
-    // The connection flow's errors are swallowed by the .catch above, so waiting on it can hang
-    // (or throw NoSuchElementException after completion). Bound it so user actions can't stall.
-    private suspend fun acquireConnection(): BillingClientConnection =
-        withTimeoutOrNull(CONNECTION_TIMEOUT_MS) { connectionProvider.first() }
+    // connectionProvider's retryWhen absorbs terminal errors (it never completes), so waiting on it
+    // can only stall, never throw. Bound it so user actions can't hang, and kick the retry loop so a
+    // connection that is mid-backoff after a failure reconnects within this call instead of waiting
+    // out the capped backoff (up to 5 min).
+    //
+    // `first { it.isReady }` — not plain first(): after a disconnect the dead connection lingers in
+    // the replay cache during the reconnect backoff. Skip it and wait for a live one (which the
+    // reconnect signal above makes arrive promptly) instead of handing back an ended client.
+    private suspend fun acquireConnection(): BillingClientConnection {
+        requestReconnect()
+        return withTimeoutOrNull(CONNECTION_TIMEOUT_MS) { connectionProvider.first { it.isReady } }
             ?: throw GplayServiceUnavailableException(
                 BillingException("Timed out waiting for a billing client connection")
             )
+    }
+
+    // Buffers a reconnect request (conflated). It has an effect only when the retry loop next enters
+    // its backoff — waking it so recovery doesn't wait out the capped backoff. Harmless while
+    // connected: the token is consumed by the next backoff that actually occurs.
+    internal fun requestReconnect() {
+        reconnectSignal.trySend(Unit)
+    }
+
+    // Interruptible connection backoff: sleeps the capped linear delay, or returns early when a
+    // reconnect is requested (an explicit user action). Extracted so the wake behavior is testable.
+    internal suspend fun awaitReconnectBackoff(attempt: Long) {
+        val backoff = (CONNECTION_RETRY_BASE_MS * (attempt + 1)).coerceAtMost(CONNECTION_RETRY_MAX_MS)
+        withTimeoutOrNull(backoff) { reconnectSignal.receive() }
+    }
 
     suspend fun querySkus(vararg skus: Sku): Collection<SkuDetails> = try {
         acquireConnection().querySkus(*skus)

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/data/BillingDataRepoTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/data/BillingDataRepoTest.kt
@@ -11,13 +11,21 @@ import eu.darken.myperm.common.upgrade.core.client.UserCanceledBillingException
 import eu.darken.myperm.common.upgrade.core.data.BillingDataRepo.Companion.tryMapUserFriendly
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
 import org.junit.jupiter.api.Test
 import testhelper.BaseTest
 import testhelper.coroutine.runTest2
@@ -27,6 +35,107 @@ class BillingDataRepoTest : BaseTest() {
     private fun resultException(code: Int) = BillingResultException(
         BillingResult.newBuilder().setResponseCode(code).build()
     )
+
+    private fun repo(): BillingDataRepo {
+        val connection = mockk<BillingClientConnection> {
+            every { purchases } returns emptyFlow()
+            every { purchaseFailures } returns emptyFlow()
+        }
+        val provider = mockk<BillingClientConnectionProvider> {
+            every { this@mockk.connection } returns flowOf(connection)
+        }
+        return BillingDataRepo(provider, CoroutineScope(Dispatchers.Unconfined))
+    }
+
+    @Test
+    fun `a reconnect request wakes the connection backoff with no delay`() =
+        runTest2(context = StandardTestDispatcher()) {
+            val repo = repo()
+            var finished = false
+            // attempt=100 pins the backoff at the 5-min cap; only a signal can end it without time passing.
+            launch { repo.awaitReconnectBackoff(attempt = 100); finished = true }
+            runCurrent()
+            finished shouldBe false
+
+            repo.requestReconnect()
+            runCurrent() // no virtual time advanced — the signal alone must complete the wait
+            finished shouldBe true
+        }
+
+    @Test
+    fun `the connection backoff waits out its delay when no reconnect is requested`() =
+        runTest2(context = StandardTestDispatcher()) {
+            val repo = repo()
+            var finished = false
+            launch { repo.awaitReconnectBackoff(attempt = 0); finished = true } // 30s backoff
+
+            advanceTimeBy(29_999)
+            runCurrent()
+            finished shouldBe false
+
+            advanceTimeBy(2)
+            runCurrent()
+            finished shouldBe true
+        }
+
+    @Test
+    fun `acquireConnection skips a disconnected cached connection and waits for a ready one`() =
+        runTest2(context = StandardTestDispatcher()) {
+            // A disconnected connection lingers in the replay cache during the reconnect backoff;
+            // acquireConnection must not hand it back — it must wait for the next live one.
+            val source = MutableSharedFlow<BillingClientConnection>(replay = 1)
+            val provider = mockk<BillingClientConnectionProvider> {
+                every { connection } returns source
+            }
+            // backgroundScope so the repo's process-lifetime collectors (which subscribe the
+            // never-completing source) are cancelled when the test body ends.
+            val repo = BillingDataRepo(provider, backgroundScope)
+
+            val stale = mockk<BillingClientConnection>(relaxed = true) {
+                every { isReady } returns false
+                every { purchases } returns emptyFlow()
+                every { purchaseFailures } returns emptyFlow()
+            }
+            source.emit(stale)
+            runCurrent()
+
+            val sku = mockk<Sku>()
+            val call = async { repo.querySkus(sku) }
+            runCurrent()
+            call.isCompleted shouldBe false // dead cached connection skipped — still waiting
+
+            val live = mockk<BillingClientConnection>(relaxed = true) {
+                every { isReady } returns true
+                every { purchases } returns emptyFlow()
+                every { purchaseFailures } returns emptyFlow()
+                coEvery { querySkus(sku) } returns emptyList()
+            }
+            source.emit(live)
+            runCurrent()
+            call.await()
+
+            coVerify(exactly = 1) { live.querySkus(sku) }
+            coVerify(exactly = 0) { stale.querySkus(sku) }
+        }
+
+    @Test
+    fun `a reconnect request sent before the backoff is consumed exactly once, no spin`() =
+        runTest2(context = StandardTestDispatcher()) {
+            val repo = repo()
+            // Request arrives while the loop is NOT waiting (conflated channel holds it).
+            repo.requestReconnect()
+
+            var firstFinished = false
+            launch { repo.awaitReconnectBackoff(attempt = 100); firstFinished = true }
+            runCurrent()
+            firstFinished shouldBe true // the buffered request wakes the first backoff immediately
+
+            // The next backoff must NOT be woken by the already-consumed request.
+            var secondFinished = false
+            launch { repo.awaitReconnectBackoff(attempt = 100); secondFinished = true }
+            runCurrent()
+            secondFinished shouldBe false
+        }
 
     private fun repoWithListenerFailure(code: Int): BillingDataRepo {
         val connection = mockk<BillingClientConnection> {


### PR DESCRIPTION
## What changed

If Google Play billing briefly became unavailable during a session (for example while the Play Store updates itself) and then recovered, tapping "Restore purchase" — or opening the upgrade screen — could keep showing "Google Play services are unavailable" for up to ~5 minutes even though Play was working again. Now those actions reconnect and succeed promptly instead of waiting out the retry backoff.

## Technical Context

Follow-up to the billing hardening series (#371). Two bounded gaps in `BillingDataRepo`'s connection path, both masked by the up-to-5-minute retry backoff:

- **Backoff wasn't interruptible.** The connection `retryWhen` slept a plain `delay()`, so an explicit user action couldn't shorten it — `acquireConnection()` just waited on the shared retry loop (≤10s) and failed if the loop happened to be mid-backoff. It now sleeps on a **conflated reconnect signal** (`Channel(CONFLATED)`): a user action calls `requestReconnect()`, waking a mid-backoff retry so it reconnects within the call's timeout. Conflated so a signal sent while the loop isn't sleeping is consumed by the next backoff exactly once — no spin.
- **Stale connection served from the replay cache.** After a real disconnect the ended `BillingClientConnection` lingered in the `replayingShare(replay=1)` cache during the backoff, so `acquireConnection()` returned a dead client and the operation failed against it. It now selects the first **ready** connection (`connectionProvider.first { it.isReady }`, backed by `BillingClient.isReady`) — a live cached connection is returned immediately, a dead one is skipped and it waits for the fresh reconnect.

Combined: prompt recovery for both the never-connected and was-connected-then-disconnected cases.

- **Review guidance:** the concurrency-sensitive bits are the conflated-channel wake (`awaitReconnectBackoff` / `requestReconnect`) and the `first { it.isReady }` predicate. Both were reviewed for spin/livelock, missed-wake, and replay staleness.
- **Deliberate non-goal:** the inner per-attempt retry in `BillingClientConnectionProvider` (≤15s delays) is not interrupted by the signal; it's bounded and doesn't affect the `BILLING_UNAVAILABLE` outage path (which exits that inner retry immediately). Left as-is.
- Adds unit tests for the interruptible backoff (virtual-time, wake vs. wait-out, no-spin) and the stale-connection skip. FOSS flavor untouched.
