### PR TITLE
General: See your Pro status and switch to a one-time purchase

### DIFF
--- a/app/src/foss/java/eu/darken/myperm/common/upgrade/ui/UpgradeNavigation.kt
+++ b/app/src/foss/java/eu/darken/myperm/common/upgrade/ui/UpgradeNavigation.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 
 class UpgradeNavigation @Inject constructor() : NavigationEntry {
     override fun EntryProviderScope<NavKey>.setup() {
-        entry<Nav.Main.Upgrade> { UpgradeScreenHost() }
+        entry<Nav.Main.Upgrade> { key -> UpgradeScreenHost(manage = key.manage) }
     }
 
     @Module

--- a/app/src/foss/java/eu/darken/myperm/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/foss/java/eu/darken/myperm/common/upgrade/ui/UpgradeScreen.kt
@@ -1,5 +1,6 @@
 package eu.darken.myperm.common.upgrade.ui
 
+import android.text.format.DateFormat
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -15,18 +16,20 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
+import androidx.compose.material.icons.twotone.Code
 import androidx.compose.material.icons.twotone.Favorite
 import androidx.compose.material.icons.twotone.FileDownload
 import androidx.compose.material.icons.twotone.Notifications
 import androidx.compose.material.icons.twotone.Palette
-import androidx.compose.material.icons.twotone.Code
 import androidx.compose.material.icons.twotone.Tune
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -35,10 +38,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -53,11 +59,18 @@ import eu.darken.myperm.R
 import eu.darken.myperm.common.compose.PermPilotMascot
 import eu.darken.myperm.common.error.ErrorEventHandler
 import eu.darken.myperm.common.navigation.NavigationEventHandler
+import java.time.Instant
+import java.util.Date
 
 @Composable
-fun UpgradeScreenHost(vm: UpgradeViewModel = hiltViewModel()) {
+fun UpgradeScreenHost(
+    manage: Boolean,
+    vm: UpgradeViewModel = hiltViewModel(),
+) {
     ErrorEventHandler(vm)
     NavigationEventHandler(vm)
+
+    LaunchedEffect(manage) { vm.init(manage) }
 
     val snackbarHostState = remember { SnackbarHostState() }
     val returnedEarlyMessage = stringResource(R.string.upgrade_foss_sponsor_returned_early)
@@ -65,9 +78,7 @@ fun UpgradeScreenHost(vm: UpgradeViewModel = hiltViewModel()) {
     val lifecycleOwner = LocalLifecycleOwner.current
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_RESUME) {
-                vm.onResume()
-            }
+            if (event == Lifecycle.Event.ON_RESUME) vm.onResume()
         }
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
@@ -76,44 +87,46 @@ fun UpgradeScreenHost(vm: UpgradeViewModel = hiltViewModel()) {
     LaunchedEffect(Unit) {
         vm.sponsorEvents.collect { event ->
             when (event) {
-                UpgradeViewModel.SponsorEvent.ReturnedTooEarly -> {
-                    snackbarHostState.showSnackbar(returnedEarlyMessage)
-                }
+                UpgradeViewModel.SponsorEvent.ReturnedTooEarly -> snackbarHostState.showSnackbar(returnedEarlyMessage)
             }
         }
     }
 
+    val state by vm.state.collectAsState()
+
     UpgradeScreen(
+        state = state,
         snackbarHostState = snackbarHostState,
         onNavigateUp = { vm.navUp() },
         onSponsor = { vm.sponsor() },
+        onSponsorAgain = { vm.openSponsorPage() },
     )
 }
 
 private data class Benefit(val icon: ImageVector, val textRes: Int)
 
+private val upgradeBenefits = listOf(
+    Benefit(Icons.TwoTone.Palette, R.string.upgrade_benefit_themes),
+    Benefit(Icons.TwoTone.Tune, R.string.upgrade_benefit_filtering),
+    Benefit(Icons.TwoTone.FileDownload, R.string.upgrade_benefit_export),
+    Benefit(Icons.TwoTone.Notifications, R.string.upgrade_benefit_monitoring),
+    Benefit(Icons.TwoTone.Code, R.string.upgrade_benefit_manifest_viewer),
+    Benefit(Icons.TwoTone.Favorite, R.string.upgrade_benefit_support),
+)
+
 @Composable
 fun UpgradeScreen(
+    state: UpgradeViewModel.State,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     onNavigateUp: () -> Unit,
     onSponsor: () -> Unit,
+    onSponsorAgain: () -> Unit,
 ) {
-    val benefits = listOf(
-        Benefit(Icons.TwoTone.Palette, R.string.upgrade_benefit_themes),
-        Benefit(Icons.TwoTone.Tune, R.string.upgrade_benefit_filtering),
-        Benefit(Icons.TwoTone.FileDownload, R.string.upgrade_benefit_export),
-        Benefit(Icons.TwoTone.Notifications, R.string.upgrade_benefit_monitoring),
-        Benefit(Icons.TwoTone.Code, R.string.upgrade_benefit_manifest_viewer),
-        Benefit(Icons.TwoTone.Favorite, R.string.upgrade_benefit_support),
-    )
-
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         containerColor = MaterialTheme.colorScheme.surface,
     ) { paddingValues ->
-        Box(
-            modifier = Modifier.padding(paddingValues)
-        ) {
+        Box(modifier = Modifier.padding(paddingValues)) {
             Column(
                 modifier = Modifier
                     .verticalScroll(rememberScrollState())
@@ -121,117 +134,23 @@ fun UpgradeScreen(
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 Spacer(modifier = Modifier.height(16.dp))
-
-                Box(contentAlignment = Alignment.Center) {
-                    Surface(
-                        modifier = Modifier.size(120.dp),
-                        shape = CircleShape,
-                        color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.5f),
-                    ) {}
-                    PermPilotMascot(size = 80.dp)
-                }
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                Text(
-                    text = buildAnnotatedString {
-                        append(stringResource(R.string.upgrade_title_prefix))
-                        append(" ")
-                        withStyle(SpanStyle(color = MaterialTheme.colorScheme.secondary, fontWeight = FontWeight.Bold)) {
-                            append(stringResource(R.string.upgrade_title_suffix))
-                        }
-                    },
-                    style = MaterialTheme.typography.headlineLarge,
-                    color = MaterialTheme.colorScheme.onSurface,
-                )
-
+                UpgradeHeader()
                 Spacer(modifier = Modifier.height(24.dp))
 
-                Card(
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                    ),
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Text(
-                        text = stringResource(R.string.upgrade_foss_preamble),
-                        style = MaterialTheme.typography.bodyMedium,
-                        modifier = Modifier.padding(16.dp),
+                when (state.view) {
+                    null -> CircularProgressIndicator(modifier = Modifier.padding(16.dp))
+                    FossUpgradeView.PITCH -> PitchContent(onSponsor = onSponsor)
+                    FossUpgradeView.STATUS_FREE -> FreeStatusContent(onSponsor = onSponsor)
+                    FossUpgradeView.STATUS_UPGRADED -> UpgradedStatusContent(
+                        upgradedAt = state.upgradedAt,
+                        onSponsorAgain = onSponsorAgain,
                     )
                 }
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                Card(
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Column(modifier = Modifier.padding(vertical = 4.dp)) {
-                        benefits.forEach { benefit ->
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = 12.dp, vertical = 4.dp),
-                                verticalAlignment = Alignment.CenterVertically,
-                            ) {
-                                Surface(
-                                    shape = RoundedCornerShape(8.dp),
-                                    color = MaterialTheme.colorScheme.secondaryContainer,
-                                    modifier = Modifier.size(28.dp),
-                                ) {
-                                    Box(contentAlignment = Alignment.Center) {
-                                        Icon(
-                                            imageVector = benefit.icon,
-                                            contentDescription = null,
-                                            tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                                            modifier = Modifier.size(16.dp),
-                                        )
-                                    }
-                                }
-                                Spacer(modifier = Modifier.width(12.dp))
-                                Text(
-                                    text = stringResource(benefit.textRes),
-                                    style = MaterialTheme.typography.bodyLarge,
-                                )
-                            }
-                        }
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                Button(
-                    onClick = onSponsor,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(52.dp),
-                    shape = RoundedCornerShape(12.dp),
-                ) {
-                    Icon(
-                        imageVector = Icons.TwoTone.Favorite,
-                        contentDescription = null,
-                        modifier = Modifier.size(20.dp),
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(
-                        text = stringResource(R.string.upgrade_foss_sponsor_action),
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                }
-
-                Text(
-                    text = stringResource(R.string.upgrade_foss_sponsor_subtitle),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(top = 8.dp),
-                )
 
                 Spacer(modifier = Modifier.height(24.dp))
             }
 
-            IconButton(
-                onClick = onNavigateUp,
-                modifier = Modifier.padding(4.dp),
-            ) {
+            IconButton(onClick = onNavigateUp, modifier = Modifier.padding(4.dp)) {
                 Icon(
                     imageVector = Icons.AutoMirrored.TwoTone.ArrowBack,
                     contentDescription = null,
@@ -239,5 +158,181 @@ fun UpgradeScreen(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun UpgradeHeader() {
+    Box(contentAlignment = Alignment.Center) {
+        Surface(
+            modifier = Modifier.size(120.dp),
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.5f),
+        ) {}
+        PermPilotMascot(size = 80.dp)
+    }
+    Spacer(modifier = Modifier.height(16.dp))
+    Text(
+        text = buildAnnotatedString {
+            append(stringResource(R.string.upgrade_title_prefix))
+            append(" ")
+            withStyle(SpanStyle(color = MaterialTheme.colorScheme.secondary, fontWeight = FontWeight.Bold)) {
+                append(stringResource(R.string.upgrade_title_suffix))
+            }
+        },
+        style = MaterialTheme.typography.headlineLarge,
+        color = MaterialTheme.colorScheme.onSurface,
+    )
+}
+
+@Composable
+private fun PitchContent(onSponsor: () -> Unit) {
+    PreambleCard(R.string.upgrade_foss_preamble)
+    Spacer(modifier = Modifier.height(16.dp))
+    BenefitsCard()
+    Spacer(modifier = Modifier.height(16.dp))
+    SponsorButton(labelRes = R.string.upgrade_foss_sponsor_action, onClick = onSponsor)
+    Text(
+        text = stringResource(R.string.upgrade_foss_sponsor_subtitle),
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(top = 8.dp),
+    )
+}
+
+@Composable
+private fun FreeStatusContent(onSponsor: () -> Unit) {
+    StatusCard(
+        titleRes = R.string.upgrade_screen_status_free_title,
+        bodyRes = R.string.upgrade_screen_status_free_body,
+    )
+    Spacer(modifier = Modifier.height(16.dp))
+    BenefitsCard()
+    Spacer(modifier = Modifier.height(16.dp))
+    SponsorButton(labelRes = R.string.upgrade_screen_status_free_action, onClick = onSponsor)
+}
+
+@Composable
+private fun UpgradedStatusContent(
+    upgradedAt: Instant?,
+    onSponsorAgain: () -> Unit,
+) {
+    val context = LocalContext.current
+    val sinceText = upgradedAt?.let {
+        DateFormat.getMediumDateFormat(context).format(Date(it.toEpochMilli()))
+    }
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = stringResource(R.string.upgrade_screen_status_upgraded_title),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.upgrade_screen_status_upgraded_body),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            if (sinceText != null) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = stringResource(R.string.upgrade_screen_supporter_since, sinceText),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+    Spacer(modifier = Modifier.height(24.dp))
+    StatusCard(
+        titleRes = R.string.upgrade_screen_recurring_title,
+        bodyRes = R.string.upgrade_screen_recurring_body,
+    )
+    Spacer(modifier = Modifier.height(16.dp))
+    OutlinedButton(
+        onClick = onSponsorAgain,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(52.dp),
+        shape = RoundedCornerShape(12.dp),
+    ) {
+        Icon(Icons.TwoTone.Favorite, contentDescription = null, modifier = Modifier.size(20.dp))
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(stringResource(R.string.upgrade_screen_recurring_action))
+    }
+}
+
+@Composable
+private fun PreambleCard(bodyRes: Int) {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text(
+            text = stringResource(bodyRes),
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}
+
+@Composable
+private fun StatusCard(titleRes: Int, bodyRes: Int) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(text = stringResource(titleRes), style = MaterialTheme.typography.titleMedium)
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(text = stringResource(bodyRes), style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+}
+
+@Composable
+private fun BenefitsCard() {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(vertical = 4.dp)) {
+            upgradeBenefits.forEach { benefit ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 12.dp, vertical = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Surface(
+                        shape = RoundedCornerShape(8.dp),
+                        color = MaterialTheme.colorScheme.secondaryContainer,
+                        modifier = Modifier.size(28.dp),
+                    ) {
+                        Box(contentAlignment = Alignment.Center) {
+                            Icon(
+                                imageVector = benefit.icon,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                                modifier = Modifier.size(16.dp),
+                            )
+                        }
+                    }
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text(text = stringResource(benefit.textRes), style = MaterialTheme.typography.bodyLarge)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SponsorButton(labelRes: Int, onClick: () -> Unit) {
+    Button(
+        onClick = onClick,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(52.dp),
+        shape = RoundedCornerShape(12.dp),
+    ) {
+        Icon(Icons.TwoTone.Favorite, contentDescription = null, modifier = Modifier.size(20.dp))
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(text = stringResource(labelRes), style = MaterialTheme.typography.titleMedium)
     }
 }

--- a/app/src/foss/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModel.kt
@@ -1,6 +1,5 @@
 package eu.darken.myperm.common.upgrade.ui
 
-import java.lang.System
 import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.myperm.common.WebpageTool
@@ -10,7 +9,16 @@ import eu.darken.myperm.common.flow.SingleEventFlow
 import eu.darken.myperm.common.uix.ViewModel4
 import eu.darken.myperm.common.upgrade.core.FossUpgrade
 import eu.darken.myperm.common.upgrade.core.UpgradeControlFoss
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.stateIn
+import java.time.Instant
 import javax.inject.Inject
+
+enum class FossUpgradeView { PITCH, STATUS_FREE, STATUS_UPGRADED }
 
 @HiltViewModel
 class UpgradeViewModel @Inject constructor(
@@ -26,9 +34,45 @@ class UpgradeViewModel @Inject constructor(
 
     val sponsorEvents = SingleEventFlow<SponsorEvent>()
 
+    // null until the route resolves. Keeps the view unresolved (Loading in the UI) until we know
+    // whether this is the sponsor pitch or the status screen.
+    private val manageMode = MutableStateFlow<Boolean?>(null)
+
+    data class State(
+        val view: FossUpgradeView? = null,
+        val upgradedAt: Instant? = null,
+        val reason: FossUpgrade.Reason? = null,
+    )
+
+    val state: StateFlow<State> = combine(
+        manageMode.filterNotNull(),
+        upgradeControlFoss.upgradeInfo,
+    ) { manage, info ->
+        val gplayInfo = info as? UpgradeControlFoss.Info
+        val view = when {
+            // Upgraded status always wins, even if a stale "show pitch" route was requested.
+            info.isPro -> FossUpgradeView.STATUS_UPGRADED
+            manage -> FossUpgradeView.STATUS_FREE
+            else -> FossUpgradeView.PITCH
+        }
+        State(view = view, upgradedAt = info.upgradedAt, reason = gplayInfo?.upgradeReason)
+    }.stateIn(vmScope, SharingStarted.WhileSubscribed(5_000), State())
+
+    fun init(manage: Boolean) {
+        manageMode.compareAndSet(null, manage)
+    }
+
+    // Arming sponsor flow (pitch / free-status): after returning from the page (>= 5s) we unlock Pro
+    // locally on resume.
     fun sponsor() {
         savedStateHandle[KEY_SPONSOR_OPENED_AT] = System.currentTimeMillis()
-        webpageTool.open("https://github.com/sponsors/d4rken")
+        webpageTool.open(SPONSOR_URL)
+    }
+
+    // Non-arming: from the upgraded-status view (recurring-donation nudge). Must NOT re-trigger the
+    // resume unlock heuristic — the user is already a supporter.
+    fun openSponsorPage() {
+        webpageTool.open(SPONSOR_URL)
     }
 
     fun onResume() {
@@ -45,6 +89,7 @@ class UpgradeViewModel @Inject constructor(
 
     companion object {
         private const val KEY_SPONSOR_OPENED_AT = "sponsor_opened_at"
+        private const val SPONSOR_URL = "https://github.com/sponsors/d4rken"
         private val TAG = logTag("Upgrade", "Foss", "VM")
     }
 }

--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -5,4 +5,20 @@
     <string name="upgrade_foss_sponsor_subtitle">Opens GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Please take a moment to check out the sponsor page!</string>
     <string name="upgrade_title_suffix" translatable="false">FOSS</string>
+
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Free version</string>
+    <string name="upgrade_screen_status_free_body">You\'re using the free, open-source build. Support development to unlock the Pro features.</string>
+    <string name="upgrade_screen_status_free_action">Become a Sponsor</string>
+
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">Thank you for your support!</string>
+    <string name="upgrade_screen_status_upgraded_body">You\'ve unlocked all Pro features. Your support keeps Permission Pilot free and open-source.</string>
+    <string name="upgrade_screen_supporter_since">Supporter since %1$s</string>
+    <string name="upgrade_screen_recurring_title">Support again</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot is developed in the open. Consider a recurring sponsorship to help sustain it.</string>
+    <string name="upgrade_screen_recurring_action">Open GitHub Sponsors</string>
 </resources>

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/UpgradeRepoGplay.kt
@@ -2,6 +2,7 @@ package eu.darken.myperm.common.upgrade.core
 
 import android.app.Activity
 import android.os.SystemClock
+import com.android.billingclient.api.Purchase
 import eu.darken.myperm.common.coroutine.AppScope
 import eu.darken.myperm.common.debug.logging.Logging.Priority.INFO
 import eu.darken.myperm.common.debug.logging.Logging.Priority.VERBOSE
@@ -92,6 +93,12 @@ class UpgradeRepoGplay @Inject constructor(
         .map { it > 0 }
         .distinctUntilChanged()
 
+    // Wall-clock time of the last confirmed Pro purchase (0 = never). Drives the lean grace
+    // diagnostics boundary: recovery UI (restore / switch offers) is surfaced once we've been unable
+    // to reconfirm a Pro purchase for GRACE_DIAGNOSTICS_AFTER. No separate episode stamp — this
+    // timestamp naturally ages during a Play outage, so the boundary advances without a live refresh.
+    val lastProConfirmedAt: Flow<Long> = billingCache.lastProStateAt.flow.distinctUntilChanged()
+
     init {
         // Fresh-provenance grace stamping: the reactive upgradeInfo map is read-only; this
         // persistent collector (subscribed once, never re-subscribes) stamps new emissions, and
@@ -135,6 +142,10 @@ class UpgradeRepoGplay @Inject constructor(
     suspend fun querySkus(): Collection<SkuDetails> {
         return billingDataRepo.querySkus(*MyPermSku.PRO_SKUS.toTypedArray())
     }
+
+    // Fresh SUBS-only query for the switch-to-one-time gate. Errors propagate so the caller fails
+    // closed (does not launch the one-time purchase while a subscription may still be renewing).
+    suspend fun queryCurrentSubscriptions(): Collection<Purchase> = billingDataRepo.querySubscriptions()
 
     suspend fun launchBillingFlow(
         activity: Activity,
@@ -253,15 +264,20 @@ class UpgradeRepoGplay @Inject constructor(
         MyPermSku.PRO_SKUS.singleOrNull { it.id == lastProStateSku }?.type == Sku.Type.IAP
 
     data class Info(
-        private val gracePeriod: Boolean = false,
+        val gracePeriod: Boolean = false,
         private val billingData: BillingData?,
     ) : UpgradeRepo.Info {
 
         override val type: UpgradeRepo.Type
             get() = UpgradeRepo.Type.GPLAY
 
+        // Owned Pro purchases (IAP and/or subscription). Empty during a grace-only window (kept Pro
+        // by the resilience grace with no confirmed purchase). Drives the ownership / switch UI.
+        val proPurchases: Collection<PurchasedSku>
+            get() = billingData?.getProSkus() ?: emptyList()
+
         override val isPro: Boolean
-            get() = billingData?.getProSku() != null || gracePeriod
+            get() = proPurchases.isNotEmpty() || gracePeriod
 
         override val upgradedAt: Instant?
             get() = billingData

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/client/BillingClientConnection.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/client/BillingClientConnection.kt
@@ -23,14 +23,24 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
 
+// A listener snapshot carrying a monotonic generation. The generation lets a fresh query detect
+// whether a purchase push arrived *during* the query (newer → must win) versus a stale snapshot from
+// before the query (the query is then authoritative). Money-path safety for the switch gate.
+data class ListenerPurchases(
+    val generation: Long,
+    val purchases: Collection<Purchase>,
+)
+
 data class BillingClientConnection(
     private val client: BillingClient,
-    private val purchasesGlobal: Flow<Collection<Purchase>>,
+    private val purchasesGlobal: StateFlow<ListenerPurchases>,
     private val purchaseFailuresGlobal: Flow<BillingResult>,
 ) {
     private val queryCacheIaps = MutableStateFlow<Collection<Purchase>>(emptySet())
@@ -60,7 +70,7 @@ data class BillingClientConnection(
     }
 
     val purchases: Flow<Collection<Purchase>> = combine(
-        purchasesGlobal, queryCacheIaps, queryCacheSubs
+        purchasesGlobal.map { it.purchases }, queryCacheIaps, queryCacheSubs
     ) { global, iaps, subs ->
         val combined = mutableMapOf<String, Purchase>()
         (global + iaps + subs).forEach { purchase ->
@@ -91,6 +101,29 @@ data class BillingClientConnection(
         val subs = subJob.await()
         log(TAG) { "Refreshed IAPs=${iaps.getOrNull()}, SUBs=${subs.getOrNull()}" }
         combinePurchaseResults(iaps, subs)
+    }
+
+    // Fail-closed SUBS-only query for the "switch subscription -> one-time purchase" gate: returns
+    // the freshest known PURCHASED subscriptions so the caller can check `isAutoRenewing`. Errors
+    // propagate (the caller must fail closed and NOT launch the purchase).
+    //
+    // Why a generation fence and not a plain query: `Purchase.purchaseTime` does not change when a
+    // subscription is cancelled (isAutoRenewing flips false on the SAME purchase token), so a naive
+    // merge can't order a fresh query against a concurrent listener push by time. We instead capture
+    // the listener generation before querying: only a push that arrived *during* the query (newer
+    // generation) overlays the query result by token — a stale pre-query snapshot never overrides the
+    // authoritative query, so a genuinely cancelled sub is recognised while a live renewing sub can
+    // never be masked (which would permit double billing).
+    suspend fun querySubscriptions(): Collection<Purchase> {
+        val result = verifyStableSubscriptions(
+            maxAttempts = SUBS_VERIFY_MAX_ATTEMPTS,
+            generation = { purchasesGlobal.value.generation },
+            query = { queryPurchasesByType(BillingClient.ProductType.SUBS) },
+        )
+        // Keep the reactive purchases flow consistent with this authoritative query.
+        queryCacheSubs.value = result
+        log(TAG) { "querySubscriptions(): $result" }
+        return result
     }
 
     // Never throws except on cancellation, so a single failing product-type query doesn't cancel
@@ -238,6 +271,30 @@ data class BillingClientConnection(
         ): Boolean = syncFailure != null &&
             syncFailure.first == result.responseCode &&
             (now - syncFailure.second) in 0 until SYNC_LAUNCH_FAILURE_ECHO_WINDOW_MS
+
+        internal const val SUBS_VERIFY_MAX_ATTEMPTS = 4
+
+        // Money-path double-billing guard. Re-runs the SUBS query until it completes WITHOUT the
+        // listener generation changing underneath it — i.e. no purchase/cancel callback raced the
+        // read, so the query result is authoritative. We can't trust the latest callback payload as a
+        // complete inventory (a superseding callback can drop an intervening subscription update), so
+        // a raced read is retried rather than merged. Throws when it can't get a stable read; the
+        // caller must then fail closed and NOT launch the one-time purchase. Pure/testable via the
+        // injected generation supplier and query lambda.
+        internal suspend fun verifyStableSubscriptions(
+            maxAttempts: Int,
+            generation: () -> Long,
+            query: suspend () -> Collection<Purchase>,
+        ): Collection<Purchase> {
+            repeat(maxAttempts) {
+                val before = generation()
+                val fresh = query().filter { it.purchaseState == Purchase.PurchaseState.PURCHASED }
+                if (generation() == before) {
+                    return fresh.sortedByDescending { it.purchaseTime }
+                }
+            }
+            throw BillingException("Subscription verification did not stabilize after $maxAttempts attempts")
+        }
 
         // Combines the two product-type query results: a purchase found by either type is
         // authoritative; an error is only propagated when nothing was found, so callers can tell

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/client/BillingClientConnectionProvider.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/client/BillingClientConnectionProvider.kt
@@ -6,7 +6,6 @@ import com.android.billingclient.api.BillingClient.newBuilder
 import com.android.billingclient.api.BillingClientStateListener
 import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.PendingPurchasesParams
-import com.android.billingclient.api.Purchase
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.myperm.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.myperm.common.debug.logging.Logging.Priority.VERBOSE
@@ -25,6 +24,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.retryWhen
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -35,7 +35,7 @@ class BillingClientConnectionProvider @Inject constructor(
 ) {
 
     private val connectionProvider: Flow<BillingClientConnection> = callbackFlow {
-        val purchasePublisher = MutableStateFlow<Collection<Purchase>>(emptySet())
+        val purchasePublisher = MutableStateFlow(ListenerPurchases(generation = 0L, purchases = emptySet()))
         // Purchase-flow outcomes can arrive here asynchronously after the Play sheet opened (e.g.
         // ITEM_ALREADY_OWNED, declined payment) — publish them instead of dropping them, so the UI
         // layer can react. tryEmit because the listener is a plain callback.
@@ -55,7 +55,11 @@ class BillingClientConnectionProvider @Inject constructor(
                     log(TAG) {
                         "onPurchasesUpdated(code=${result.responseCode}, message=${result.debugMessage}, purchases=$purchases)"
                     }
-                    purchasePublisher.value = purchases.orEmpty()
+                    // Bump the generation so a query in flight can tell this push arrived after it
+                    // started. update{} makes the read-modify-write atomic against concurrent callbacks.
+                    purchasePublisher.update {
+                        ListenerPurchases(generation = it.generation + 1, purchases = purchases.orEmpty())
+                    }
                 } else {
                     log(TAG, WARN) {
                         "error: onPurchasesUpdated(code=${result.responseCode}, message=${result.debugMessage}, purchases=$purchases)"

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/data/BillingDataRepo.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/data/BillingDataRepo.kt
@@ -47,6 +47,14 @@ class BillingDataRepo @Inject constructor(
     // NOT sleeping is still consumed by the next backoff — exactly once, so it can't cause a spin.
     private val reconnectSignal = Channel<Unit>(Channel.CONFLATED)
 
+    // Purchase tokens we've already acknowledged at least once. Play keeps reporting a just-acked
+    // purchase as isAcknowledged=false until a fresh query supersedes it, so the ack legitimately
+    // re-fires on every emission. Re-acknowledging is a documented Play no-op, and gating the ack on
+    // this set would risk skipping a genuinely-needed ack (Play auto-refunds after ~3 days), so the
+    // set is used ONLY to pick the log level (first ack = INFO, idempotent repeats = DEBUG). Mutated
+    // from a single sequential collector, so no synchronization is needed.
+    private val loggedAckTokens = mutableSetOf<String>()
+
     private val connectionProvider = clientConnectionProvider.connection
         .retryWhen { cause, attempt ->
             // Never give up terminally: the ack collector pins this share for the process
@@ -90,17 +98,17 @@ class BillingDataRepo @Inject constructor(
             .onEach { (client, purchases) ->
                 purchases
                     .filter { it.purchaseState == Purchase.PurchaseState.PURCHASED }
-                    .filter {
-                        val needsAck = !it.isAcknowledged
-
-                        if (needsAck) log(TAG, INFO) { "Needs ACK: $it" }
-                        else log(TAG) { "Already ACK'ed: $it" }
-
-                        needsAck
-                    }
+                    .filter { !it.isAcknowledged }
                     .forEach {
-                        log(TAG, INFO) { "Acknowledging purchase: $it" }
+                        // Keep acking unconditionally (safe over-ack bias); use the token set only to
+                        // quiet idempotent-repeat logs from INFO to DEBUG.
+                        if (it.purchaseToken !in loggedAckTokens) {
+                            log(TAG, INFO) { "Acknowledging purchase: $it" }
+                        } else {
+                            log(TAG) { "Re-acknowledging (idempotent no-op until re-query): $it" }
+                        }
                         client.acknowledgePurchase(it)
+                        loggedAckTokens.add(it.purchaseToken)
                     }
             }
             .setupCommonEventHandlers(TAG) { "connection-acks" }
@@ -195,6 +203,16 @@ class BillingDataRepo @Inject constructor(
     // happens-before instead of racing the shared billingData replay cache after a refresh.
     suspend fun refresh(): BillingData = try {
         BillingData(purchases = acquireConnection().refreshPurchases())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        throw e.tryMapUserFriendly()
+    }
+
+    // Fresh SUBS-only query for the switch-to-one-time gate. Errors propagate (mapped) so the caller
+    // fails closed and does not launch the purchase.
+    suspend fun querySubscriptions(): Collection<Purchase> = try {
+        acquireConnection().querySubscriptions()
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeNavigation.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeNavigation.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 
 class UpgradeNavigation @Inject constructor() : NavigationEntry {
     override fun EntryProviderScope<NavKey>.setup() {
-        entry<Nav.Main.Upgrade> { UpgradeScreenHost() }
+        entry<Nav.Main.Upgrade> { key -> UpgradeScreenHost(manage = key.manage) }
     }
 
     @Module

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeOwnership.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeOwnership.kt
@@ -1,0 +1,437 @@
+package eu.darken.myperm.common.upgrade.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.twotone.OpenInNew
+import androidx.compose.material.icons.twotone.Stars
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import eu.darken.myperm.R
+
+@Composable
+fun OwnershipContent(
+    state: UpgradeUiState.Loaded,
+    onSubscribe: () -> Unit,
+    onBuyIap: () -> Unit,
+    onSwitchToIap: () -> Unit,
+    onRestore: () -> Unit,
+    onManageSubscription: () -> Unit,
+    onContactSupport: () -> Unit,
+) {
+    if (state.gracePeriod) {
+        GraceCard(
+            showDiagnostics = state.graceHint?.showDiagnostics == true,
+            restoreInProgress = state.restoreInProgress,
+            enabled = state.isSettled && !state.actionBusy,
+            onRestore = onRestore,
+            onContactSupport = onContactSupport,
+        )
+        // Surface the offers even in grace, so a genuinely lapsed subscriber can re-subscribe or
+        // switch to the one-time purchase immediately instead of waiting the window out.
+        Spacer(modifier = Modifier.height(24.dp))
+        OffersCard(
+            pricing = state.pricing,
+            enabled = state.isSettled && !state.actionBusy,
+            onSubscribe = onSubscribe,
+            onBuyIap = onBuyIap,
+        )
+        return
+    }
+
+    CongratsHero(state.ownership)
+    Spacer(modifier = Modifier.height(16.dp))
+
+    val sub = state.ownership.subscription
+    if (sub != null) {
+        OwnedSubscriptionCard(
+            isAutoRenewing = sub.isAutoRenewing,
+            alsoOwnsIap = state.ownership.hasIap,
+            onManageSubscription = onManageSubscription,
+        )
+        // Only offer the switch when the sub is the sole entitlement; if they already own the IAP
+        // there is nothing to switch to.
+        if (!state.ownership.hasIap) {
+            Spacer(modifier = Modifier.height(16.dp))
+            SwitchOfferCard(
+                iapPrice = state.pricing.iapPrice,
+                switchUnlocked = state.switchUnlocked,
+                verificationInProgress = state.verificationInProgress,
+                enabled = state.isSettled && !state.actionBusy,
+                onSwitchToIap = onSwitchToIap,
+            )
+        }
+    } else if (state.ownership.hasIap) {
+        OwnedIapCard()
+    }
+
+    Spacer(modifier = Modifier.height(24.dp))
+    RestoreSection(
+        restoreInProgress = state.restoreInProgress,
+        enabled = state.isSettled && !state.actionBusy,
+        onRestore = onRestore,
+    )
+}
+
+@Composable
+private fun CongratsHero(ownership: Ownership) {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.tertiaryContainer),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = stringResource(R.string.upgrade_screen_owned_hero_title),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            val bodyRes = if (ownership.hasIap) {
+                R.string.upgrade_screen_owned_hero_iap_body
+            } else {
+                R.string.upgrade_screen_owned_hero_sub_body
+            }
+            Text(
+                text = stringResource(bodyRes),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+    }
+}
+
+@Composable
+private fun OwnedSubscriptionCard(
+    isAutoRenewing: Boolean,
+    alsoOwnsIap: Boolean,
+    onManageSubscription: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = stringResource(R.string.upgrade_screen_owned_sub_title),
+                style = MaterialTheme.typography.titleSmall,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            val bodyRes = when {
+                alsoOwnsIap -> R.string.upgrade_screen_owned_both_warning
+                isAutoRenewing -> R.string.upgrade_screen_owned_sub_renewing_body
+                else -> R.string.upgrade_screen_owned_sub_not_renewing_body
+            }
+            Text(text = stringResource(bodyRes), style = MaterialTheme.typography.bodyMedium)
+            Spacer(modifier = Modifier.height(12.dp))
+            OutlinedButton(onClick = onManageSubscription, modifier = Modifier.fillMaxWidth()) {
+                Icon(Icons.AutoMirrored.TwoTone.OpenInNew, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(stringResource(R.string.upgrade_screen_manage_subscription_action))
+            }
+        }
+    }
+}
+
+@Composable
+private fun OwnedIapCard() {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = stringResource(R.string.upgrade_screen_owned_iap_title),
+                style = MaterialTheme.typography.titleSmall,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.upgrade_screen_owned_iap_body),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SwitchOfferCard(
+    iapPrice: String?,
+    switchUnlocked: Boolean,
+    verificationInProgress: Boolean,
+    enabled: Boolean,
+    onSwitchToIap: () -> Unit,
+) {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = stringResource(R.string.upgrade_screen_switch_title),
+                style = MaterialTheme.typography.titleSmall,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(
+                    if (switchUnlocked) R.string.upgrade_screen_switch_purchase_note
+                    else R.string.upgrade_screen_switch_locked_note,
+                ),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Button(
+                onClick = onSwitchToIap,
+                enabled = switchUnlocked && enabled,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                if (verificationInProgress) {
+                    CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+                    Spacer(modifier = Modifier.width(8.dp))
+                }
+                val label = if (iapPrice != null) {
+                    stringResource(R.string.upgrade_screen_iap_action_hint, iapPrice)
+                } else {
+                    stringResource(R.string.upgrade_screen_iap_action)
+                }
+                Text(label)
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.upgrade_screen_limitation_disclosure),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun GraceCard(
+    showDiagnostics: Boolean,
+    restoreInProgress: Boolean,
+    enabled: Boolean,
+    onRestore: () -> Unit,
+    onContactSupport: () -> Unit,
+) {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = stringResource(R.string.upgrade_screen_grace_title),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(
+                    if (showDiagnostics) R.string.upgrade_screen_grace_diagnostics_body
+                    else R.string.upgrade_screen_grace_body,
+                ),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            if (showDiagnostics) {
+                Spacer(modifier = Modifier.height(12.dp))
+                Button(onClick = onRestore, enabled = enabled, modifier = Modifier.fillMaxWidth()) {
+                    if (restoreInProgress) {
+                        CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+                        Spacer(modifier = Modifier.width(8.dp))
+                    }
+                    Text(stringResource(R.string.upgrade_screen_restore_purchase_action))
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                TextButton(onClick = onContactSupport, modifier = Modifier.fillMaxWidth()) {
+                    Text(stringResource(R.string.contact_support_label))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun OffersCard(
+    pricing: Pricing,
+    enabled: Boolean,
+    onSubscribe: () -> Unit,
+    onBuyIap: () -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+        if (pricing.subAvailable) {
+            Button(
+                onClick = onSubscribe,
+                enabled = enabled,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(52.dp),
+                shape = RoundedCornerShape(12.dp),
+            ) {
+                Icon(Icons.TwoTone.Stars, contentDescription = null, modifier = Modifier.size(20.dp))
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = stringResource(
+                        if (pricing.subscriptionAction == SubscriptionAction.TRIAL) {
+                            R.string.upgrade_screen_subscription_trial_action
+                        } else {
+                            R.string.upgrade_screen_subscription_action
+                        },
+                    ),
+                    style = MaterialTheme.typography.titleMedium,
+                )
+            }
+            if (pricing.subPrice != null) {
+                Text(
+                    text = stringResource(R.string.upgrade_screen_subscription_action_hint_yearly, pricing.subPrice),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 4.dp),
+                )
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+        }
+
+        if (pricing.iapAvailable) {
+            FilledTonalButton(
+                onClick = onBuyIap,
+                enabled = enabled,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(52.dp),
+                shape = RoundedCornerShape(12.dp),
+            ) {
+                Text(
+                    text = stringResource(R.string.upgrade_screen_iap_action),
+                    style = MaterialTheme.typography.titleMedium,
+                )
+            }
+            if (pricing.iapPrice != null) {
+                Text(
+                    text = stringResource(R.string.upgrade_screen_iap_action_hint, pricing.iapPrice),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 4.dp),
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = stringResource(R.string.upgrade_screen_options_description),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+@Composable
+fun RestoreSection(
+    restoreInProgress: Boolean,
+    enabled: Boolean,
+    onRestore: () -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.upgrade_screen_restore_status_title),
+            style = MaterialTheme.typography.titleSmall,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = stringResource(R.string.upgrade_screen_restore_status_body),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        OutlinedButton(
+            onClick = onRestore,
+            enabled = enabled,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(52.dp),
+            shape = RoundedCornerShape(12.dp),
+        ) {
+            if (restoreInProgress) {
+                CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+                Spacer(modifier = Modifier.width(8.dp))
+            }
+            Text(stringResource(R.string.upgrade_screen_restore_purchase_action))
+        }
+    }
+}
+
+@Composable
+fun RestoreBanner(
+    onRestore: () -> Unit,
+    restoreInProgress: Boolean,
+    enabled: Boolean,
+) {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.tertiaryContainer),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = stringResource(R.string.upgrade_screen_restore_banner_title),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.upgrade_screen_restore_banner_body),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Button(
+                onClick = onRestore,
+                enabled = enabled,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                if (restoreInProgress) {
+                    CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+                    Spacer(modifier = Modifier.width(8.dp))
+                }
+                Text(stringResource(R.string.upgrade_screen_restore_purchase_action))
+            }
+        }
+    }
+}
+
+@Composable
+fun FailedRestoreDialog(
+    onContactSupport: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.upgrade_screen_restore_status_title)) },
+        text = {
+            Column {
+                Text(stringResource(R.string.upgrade_screen_restore_purchase_message))
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = stringResource(R.string.upgrade_screen_restore_webinstall_hint),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onDismiss(); onContactSupport() }) {
+                Text(stringResource(R.string.contact_support_label))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.general_cancel_action)) }
+        },
+    )
+}

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeScreen.kt
@@ -21,28 +21,27 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
+import androidx.compose.material.icons.twotone.Code
 import androidx.compose.material.icons.twotone.Favorite
 import androidx.compose.material.icons.twotone.FileDownload
 import androidx.compose.material.icons.twotone.Notifications
 import androidx.compose.material.icons.twotone.Palette
-import androidx.compose.material.icons.twotone.Stars
-import androidx.compose.material.icons.twotone.Code
 import androidx.compose.material.icons.twotone.Tune
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -51,80 +50,101 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.compose.runtime.DisposableEffect
 import eu.darken.myperm.R
 import eu.darken.myperm.common.compose.PermPilotMascot
 import eu.darken.myperm.common.error.ErrorEventHandler
 import eu.darken.myperm.common.navigation.NavigationEventHandler
 
 @Composable
-fun UpgradeScreenHost(vm: UpgradeViewModel = hiltViewModel()) {
+fun UpgradeScreenHost(
+    manage: Boolean,
+    vm: UpgradeViewModel = hiltViewModel(),
+) {
     ErrorEventHandler(vm)
     NavigationEventHandler(vm)
 
     val context = LocalContext.current
     val activity = context as? Activity
     if (activity == null) Log.w("UpgradeScreen", "Context is not an Activity: $context")
+
+    LaunchedEffect(manage) { vm.init(manage) }
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) vm.onResume()
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
     val state by vm.state.collectAsState()
 
+    var showRestoreFailedDialog by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) {
         vm.events.collect { event ->
             when (event) {
-                UpgradeViewModel.UpgradeEvent.RestoreFailed -> {
-                    Toast.makeText(
-                        context,
-                        R.string.upgrade_screen_restore_purchase_message,
-                        Toast.LENGTH_LONG
-                    ).show()
-                }
+                UpgradeViewModel.UpgradeEvent.RestoreFailed -> showRestoreFailedDialog = true
+                UpgradeViewModel.UpgradeEvent.RestoreSucceeded ->
+                    Toast.makeText(context, R.string.upgrade_screen_restore_success_message, Toast.LENGTH_LONG).show()
+
+                UpgradeViewModel.UpgradeEvent.SubscriptionStillRenewing ->
+                    Toast.makeText(context, R.string.upgrade_screen_sub_still_renewing_message, Toast.LENGTH_LONG).show()
+
+                UpgradeViewModel.UpgradeEvent.SubscriptionCheckFailed ->
+                    Toast.makeText(context, R.string.upgrade_screen_sub_check_failed_message, Toast.LENGTH_LONG).show()
             }
         }
     }
 
-    LaunchedEffect(Unit) {
-        vm.billingEvents.collect { event ->
-            activity ?: return@collect
-            when (event) {
-                UpgradeViewModel.BillingEvent.LaunchIap -> vm.launchBillingIap(activity)
-                UpgradeViewModel.BillingEvent.LaunchSubscription -> vm.launchBillingSubscription(activity)
-                UpgradeViewModel.BillingEvent.LaunchSubscriptionTrial -> vm.launchBillingSubscriptionTrial(activity)
-            }
-        }
+    if (showRestoreFailedDialog) {
+        FailedRestoreDialog(
+            onContactSupport = { vm.onContactSupport() },
+            onDismiss = { showRestoreFailedDialog = false },
+        )
     }
 
     UpgradeScreen(
         state = state,
         onNavigateUp = { vm.navUp() },
-        onSubscription = { vm.onGoSubscription() },
-        onSubscriptionTrial = { vm.onGoSubscriptionTrial() },
-        onIap = { vm.onGoIap() },
-        onRestore = { vm.restorePurchase() },
+        onSubscribe = { activity?.let { vm.onSubscribe(it) } },
+        onBuyIap = { activity?.let { vm.onBuyIap(it) } },
+        onSwitchToIap = { activity?.let { vm.onSwitchToIap(it) } },
+        onRestore = { vm.onRestore() },
+        onManageSubscription = { vm.onManageSubscription() },
+        onContactSupport = { vm.onContactSupport() },
     )
 }
 
 private data class Benefit(val icon: ImageVector, val textRes: Int)
 
+private val upgradeBenefits = listOf(
+    Benefit(Icons.TwoTone.Palette, R.string.upgrade_benefit_themes),
+    Benefit(Icons.TwoTone.Tune, R.string.upgrade_benefit_filtering),
+    Benefit(Icons.TwoTone.FileDownload, R.string.upgrade_benefit_export),
+    Benefit(Icons.TwoTone.Notifications, R.string.upgrade_benefit_monitoring),
+    Benefit(Icons.TwoTone.Code, R.string.upgrade_benefit_manifest_viewer),
+    Benefit(Icons.TwoTone.Favorite, R.string.upgrade_benefit_support),
+)
+
 @Composable
 fun UpgradeScreen(
-    state: UpgradeViewModel.State,
+    state: UpgradeUiState,
     onNavigateUp: () -> Unit,
-    onSubscription: () -> Unit,
-    onSubscriptionTrial: () -> Unit,
-    onIap: () -> Unit,
+    onSubscribe: () -> Unit,
+    onBuyIap: () -> Unit,
+    onSwitchToIap: () -> Unit,
     onRestore: () -> Unit,
+    onManageSubscription: () -> Unit,
+    onContactSupport: () -> Unit,
 ) {
-    val benefits = listOf(
-        Benefit(Icons.TwoTone.Palette, R.string.upgrade_benefit_themes),
-        Benefit(Icons.TwoTone.Tune, R.string.upgrade_benefit_filtering),
-        Benefit(Icons.TwoTone.FileDownload, R.string.upgrade_benefit_export),
-        Benefit(Icons.TwoTone.Notifications, R.string.upgrade_benefit_monitoring),
-        Benefit(Icons.TwoTone.Code, R.string.upgrade_benefit_manifest_viewer),
-        Benefit(Icons.TwoTone.Favorite, R.string.upgrade_benefit_support),
-    )
-
     Box(modifier = Modifier.windowInsetsPadding(WindowInsets.systemBars)) {
         Column(
             modifier = Modifier
@@ -133,104 +153,34 @@ fun UpgradeScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Spacer(modifier = Modifier.height(16.dp))
-
-            Box(contentAlignment = Alignment.Center) {
-                Surface(
-                    modifier = Modifier.size(120.dp),
-                    shape = CircleShape,
-                    color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f),
-                ) {}
-                PermPilotMascot(size = 80.dp)
-            }
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            Text(
-                text = buildAnnotatedString {
-                    append(stringResource(R.string.upgrade_title_prefix))
-                    append(" ")
-                    withStyle(SpanStyle(color = MaterialTheme.colorScheme.tertiary, fontWeight = FontWeight.Bold)) {
-                        append(stringResource(R.string.upgrade_title_suffix))
-                    }
-                },
-                style = MaterialTheme.typography.headlineLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-
+            UpgradeHeader()
             Spacer(modifier = Modifier.height(24.dp))
 
-            if (state.wasPreviouslyPro) {
-                RestoreBanner(
-                    onRestore = onRestore,
-                    restoreInProgress = state.restoreInProgress,
-                )
+            when (state) {
+                UpgradeUiState.Loading -> {
+                    CircularProgressIndicator(modifier = Modifier.padding(16.dp))
+                }
 
-                Spacer(modifier = Modifier.height(24.dp))
-            }
-
-            Card(
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                ),
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Text(
-                    text = stringResource(R.string.upgrade_screen_preamble),
-                    style = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier.padding(16.dp),
-                )
-            }
-
-            Spacer(modifier = Modifier.height(24.dp))
-
-            Card(
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Column(modifier = Modifier.padding(vertical = 4.dp)) {
-                    benefits.forEach { benefit ->
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 12.dp, vertical = 4.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Surface(
-                                shape = RoundedCornerShape(8.dp),
-                                color = MaterialTheme.colorScheme.primaryContainer,
-                                modifier = Modifier.size(28.dp),
-                            ) {
-                                Box(contentAlignment = Alignment.Center) {
-                                    Icon(
-                                        imageVector = benefit.icon,
-                                        contentDescription = null,
-                                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                                        modifier = Modifier.size(16.dp),
-                                    )
-                                }
-                            }
-                            Spacer(modifier = Modifier.width(12.dp))
-                            Text(
-                                text = stringResource(benefit.textRes),
-                                style = MaterialTheme.typography.bodyLarge,
-                            )
-                        }
+                is UpgradeUiState.Loaded -> {
+                    if (state.showOwnership) {
+                        OwnershipContent(
+                            state = state,
+                            onSubscribe = onSubscribe,
+                            onBuyIap = onBuyIap,
+                            onSwitchToIap = onSwitchToIap,
+                            onRestore = onRestore,
+                            onManageSubscription = onManageSubscription,
+                            onContactSupport = onContactSupport,
+                        )
+                    } else {
+                        SalesContent(
+                            state = state,
+                            onSubscribe = onSubscribe,
+                            onBuyIap = onBuyIap,
+                            onRestore = onRestore,
+                        )
                     }
                 }
-            }
-
-            Spacer(modifier = Modifier.height(24.dp))
-
-            if (state.pricing == null) {
-                CircularProgressIndicator(modifier = Modifier.padding(16.dp))
-            } else {
-                PricingContent(
-                    pricing = state.pricing,
-                    restoreInProgress = state.restoreInProgress,
-                    onSubscription = onSubscription,
-                    onSubscriptionTrial = onSubscriptionTrial,
-                    onIap = onIap,
-                    onRestore = onRestore,
-                )
             }
 
             Spacer(modifier = Modifier.height(24.dp))
@@ -250,174 +200,107 @@ fun UpgradeScreen(
 }
 
 @Composable
-private fun RestoreBanner(
-    onRestore: () -> Unit,
-    restoreInProgress: Boolean,
-    modifier: Modifier = Modifier,
-) {
-    Card(
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
-        ),
-        modifier = modifier.fillMaxWidth(),
-    ) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Text(
-                text = stringResource(R.string.upgrade_screen_restore_banner_title),
-                style = MaterialTheme.typography.titleMedium,
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = stringResource(R.string.upgrade_screen_restore_banner_body),
-                style = MaterialTheme.typography.bodyMedium,
-            )
-            Spacer(modifier = Modifier.height(12.dp))
-            Button(
-                onClick = onRestore,
-                enabled = !restoreInProgress,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                if (restoreInProgress) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(18.dp),
-                        strokeWidth = 2.dp,
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                }
-                Text(text = stringResource(R.string.upgrade_screen_restore_purchase_action))
-            }
-        }
+private fun UpgradeHeader() {
+    Box(contentAlignment = Alignment.Center) {
+        Surface(
+            modifier = Modifier.size(120.dp),
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f),
+        ) {}
+        PermPilotMascot(size = 80.dp)
     }
+    Spacer(modifier = Modifier.height(16.dp))
+    Text(
+        text = buildAnnotatedString {
+            append(stringResource(R.string.upgrade_title_prefix))
+            append(" ")
+            withStyle(SpanStyle(color = MaterialTheme.colorScheme.tertiary, fontWeight = FontWeight.Bold)) {
+                append(stringResource(R.string.upgrade_title_suffix))
+            }
+        },
+        style = MaterialTheme.typography.headlineLarge,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
 }
 
 @Composable
-private fun PricingContent(
-    pricing: UpgradeViewModel.Pricing,
-    restoreInProgress: Boolean,
-    onSubscription: () -> Unit,
-    onSubscriptionTrial: () -> Unit,
-    onIap: () -> Unit,
+private fun SalesContent(
+    state: UpgradeUiState.Loaded,
+    onSubscribe: () -> Unit,
+    onBuyIap: () -> Unit,
     onRestore: () -> Unit,
 ) {
-    // Subscription button (primary)
-    if (pricing.subAvailable) {
-        val subscriptionAction = if (pricing.hasTrialOffer) onSubscriptionTrial else onSubscription
-
-        val subscriptionLabel = if (pricing.hasTrialOffer) {
-            stringResource(R.string.upgrade_screen_subscription_trial_action)
-        } else {
-            stringResource(R.string.upgrade_screen_subscription_action)
-        }
-
-        Button(
-            onClick = subscriptionAction,
-            enabled = !restoreInProgress,
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(52.dp),
-            shape = RoundedCornerShape(12.dp),
-        ) {
-            Icon(
-                imageVector = Icons.TwoTone.Stars,
-                contentDescription = null,
-                modifier = Modifier.size(20.dp),
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(
-                text = subscriptionLabel,
-                style = MaterialTheme.typography.titleMedium,
-            )
-        }
-
-        if (pricing.subPrice != null) {
-            Text(
-                text = stringResource(R.string.upgrade_screen_subscription_action_hint_yearly, pricing.subPrice),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(top = 4.dp),
-            )
-        }
-
-        Spacer(modifier = Modifier.height(12.dp))
+    if (state.wasPreviouslyPro) {
+        RestoreBanner(
+            onRestore = onRestore,
+            restoreInProgress = state.restoreInProgress,
+            enabled = state.isSettled && !state.actionBusy,
+        )
+        Spacer(modifier = Modifier.height(24.dp))
     }
 
-    // IAP button (secondary)
-    if (pricing.iapAvailable) {
-        FilledTonalButton(
-            onClick = onIap,
-            enabled = !restoreInProgress,
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(52.dp),
-            shape = RoundedCornerShape(12.dp),
-        ) {
-            Text(
-                text = stringResource(R.string.upgrade_screen_iap_action),
-                style = MaterialTheme.typography.titleMedium,
-            )
-        }
-
-        if (pricing.iapPrice != null) {
-            Text(
-                text = stringResource(R.string.upgrade_screen_iap_action_hint, pricing.iapPrice),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(top = 4.dp),
-            )
-        }
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text(
+            text = stringResource(R.string.upgrade_screen_preamble),
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(16.dp),
+        )
     }
 
-    // If no details loaded at all, show a simple fallback upgrade button
-    if (!pricing.subAvailable && !pricing.iapAvailable) {
-        Button(
-            onClick = onIap,
-            enabled = !restoreInProgress,
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(52.dp),
-            shape = RoundedCornerShape(12.dp),
-        ) {
-            Icon(
-                imageVector = Icons.TwoTone.Stars,
-                contentDescription = null,
-                modifier = Modifier.size(20.dp),
-                tint = MaterialTheme.colorScheme.onPrimary,
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(
-                text = stringResource(R.string.general_upgrade_action),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onPrimary,
-            )
-        }
-    }
+    Spacer(modifier = Modifier.height(24.dp))
+    BenefitsCard()
+    Spacer(modifier = Modifier.height(24.dp))
 
-    Spacer(modifier = Modifier.height(8.dp))
-
-    Text(
-        text = stringResource(R.string.upgrade_screen_options_description),
-        style = MaterialTheme.typography.bodySmall,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        textAlign = TextAlign.Center,
+    OffersCard(
+        pricing = state.pricing,
+        enabled = state.isSettled && !state.actionBusy,
+        onSubscribe = onSubscribe,
+        onBuyIap = onBuyIap,
     )
 
-    Spacer(modifier = Modifier.height(16.dp))
+    Spacer(modifier = Modifier.height(24.dp))
+    RestoreSection(
+        restoreInProgress = state.restoreInProgress,
+        enabled = state.isSettled && !state.actionBusy,
+        onRestore = onRestore,
+    )
+}
 
-    OutlinedButton(
-        onClick = onRestore,
-        enabled = !restoreInProgress,
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(52.dp),
-        shape = RoundedCornerShape(12.dp),
-    ) {
-        if (restoreInProgress) {
-            CircularProgressIndicator(
-                modifier = Modifier.size(18.dp),
-                strokeWidth = 2.dp,
-            )
-            Spacer(modifier = Modifier.width(8.dp))
+@Composable
+private fun BenefitsCard() {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(vertical = 4.dp)) {
+            upgradeBenefits.forEach { benefit ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 12.dp, vertical = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Surface(
+                        shape = RoundedCornerShape(8.dp),
+                        color = MaterialTheme.colorScheme.primaryContainer,
+                        modifier = Modifier.size(28.dp),
+                    ) {
+                        Box(contentAlignment = Alignment.Center) {
+                            Icon(
+                                imageVector = benefit.icon,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                                modifier = Modifier.size(16.dp),
+                            )
+                        }
+                    }
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text(
+                        text = stringResource(benefit.textRes),
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                }
+            }
         }
-        Text(text = stringResource(R.string.upgrade_screen_restore_purchase_action))
     }
 }

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeUiState.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeUiState.kt
@@ -1,0 +1,120 @@
+package eu.darken.myperm.common.upgrade.ui
+
+import eu.darken.myperm.common.upgrade.core.UpgradeRepoGplay
+import eu.darken.myperm.common.upgrade.core.data.Sku
+import eu.darken.myperm.common.upgrade.core.data.SkuDetails
+
+// Owned-subscription facts the switch UI needs. Derived from replayed upgradeInfo — display only;
+// the actual switch launch re-verifies with a fresh SUBS query and never trusts this.
+data class SubscriptionOwnership(
+    val isAutoRenewing: Boolean,
+)
+
+data class Ownership(
+    val hasIap: Boolean,
+    val subscription: SubscriptionOwnership?,
+) {
+    val hasSubscription: Boolean get() = subscription != null
+}
+
+data class GraceHint(
+    // false = calm "waiting for Google Play to re-confirm"; true = escalate to diagnostics + restore.
+    val showDiagnostics: Boolean,
+)
+
+enum class SubscriptionAction { TRIAL, STANDARD, UNAVAILABLE }
+
+// The single money-path guard: restore, switch-verification, and launch are mutually exclusive.
+enum class ActionState { IDLE, RESTORING, VERIFYING }
+
+data class Pricing(
+    val iap: SkuDetails? = null,
+    val sub: SkuDetails? = null,
+    val subPrice: String? = null,
+    val iapPrice: String? = null,
+    val hasTrialOffer: Boolean = false,
+) {
+    val subAvailable: Boolean get() = sub != null || subPrice != null
+    val iapAvailable: Boolean get() = iap != null || iapPrice != null
+    val subscriptionAction: SubscriptionAction
+        get() = when {
+            !subAvailable -> SubscriptionAction.UNAVAILABLE
+            hasTrialOffer -> SubscriptionAction.TRIAL
+            else -> SubscriptionAction.STANDARD
+        }
+}
+
+sealed interface UpgradeUiState {
+    data object Loading : UpgradeUiState
+
+    data class Loaded(
+        val manageMode: Boolean,
+        val isPro: Boolean,
+        val gracePeriod: Boolean,
+        val ownership: Ownership,
+        val graceHint: GraceHint?,
+        val pricing: Pricing,
+        // Whether billing has completed its first fresh reconciliation. Purchase/switch/restore
+        // actions stay disabled until settled so a cold-start empty snapshot can't offer acquisition
+        // to an existing owner (double-buy protection).
+        val isSettled: Boolean,
+        val action: ActionState,
+        val wasPreviouslyPro: Boolean,
+    ) : UpgradeUiState {
+        val restoreInProgress: Boolean get() = action == ActionState.RESTORING
+        val verificationInProgress: Boolean get() = action == ActionState.VERIFYING
+        val actionBusy: Boolean get() = action != ActionState.IDLE
+
+        // Show the ownership / status surface (congrats hero + switch) rather than the sales pitch.
+        val showOwnership: Boolean get() = isPro
+
+        // The one-time switch offer is unlocked only when a subscription is owned AND not renewing.
+        val switchUnlocked: Boolean
+            get() = ownership.subscription?.let { !it.isAutoRenewing } ?: false
+    }
+}
+
+// Conservative: a subscription counts as renewing if ANY owned record for it is auto-renewing — this
+// can only under-offer the switch, never wrongly enable it (which could permit double billing).
+fun UpgradeRepoGplay.Info.toOwnership(): Ownership {
+    val subs = proPurchases.filter { it.sku.type == Sku.Type.SUBSCRIPTION }
+    return Ownership(
+        hasIap = proPurchases.any { it.sku.type == Sku.Type.IAP },
+        subscription = subs.takeIf { it.isNotEmpty() }?.let { list ->
+            SubscriptionOwnership(isAutoRenewing = list.any { it.purchase.isAutoRenewing })
+        },
+    )
+}
+
+// Pure builder for the loaded state so the grace mapping and the 24h diagnostics boundary are
+// unit-testable without the ViewModel. `lastProConfirmedAt`/`now` are wall-clock millis.
+fun toLoadedState(
+    manageMode: Boolean,
+    info: UpgradeRepoGplay.Info,
+    pricing: Pricing,
+    lastProConfirmedAt: Long,
+    now: Long,
+    isSettled: Boolean,
+    action: ActionState,
+    wasEverPro: Boolean,
+    graceDiagnosticsAfterMs: Long,
+): UpgradeUiState.Loaded {
+    val inGrace = info.gracePeriod && info.proPurchases.isEmpty()
+    val graceHint = if (inGrace) {
+        val agedOut = lastProConfirmedAt > 0 && (now - lastProConfirmedAt) >= graceDiagnosticsAfterMs
+        GraceHint(showDiagnostics = agedOut)
+    } else {
+        null
+    }
+    return UpgradeUiState.Loaded(
+        manageMode = manageMode,
+        isPro = info.isPro,
+        gracePeriod = inGrace,
+        ownership = info.toOwnership(),
+        graceHint = graceHint,
+        pricing = pricing,
+        isSettled = isSettled,
+        action = action,
+        wasPreviouslyPro = wasEverPro && !info.isPro,
+    )
+}

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModel.kt
@@ -1,7 +1,10 @@
 package eu.darken.myperm.common.upgrade.ui
 
 import android.app.Activity
+import android.os.SystemClock
 import dagger.hilt.android.lifecycle.HiltViewModel
+import eu.darken.myperm.common.BuildConfigWrap
+import eu.darken.myperm.common.WebpageTool
 import eu.darken.myperm.common.coroutine.DispatcherProvider
 import eu.darken.myperm.common.debug.logging.Logging.Priority.INFO
 import eu.darken.myperm.common.debug.logging.Logging.Priority.WARN
@@ -9,6 +12,7 @@ import eu.darken.myperm.common.debug.logging.asLog
 import eu.darken.myperm.common.debug.logging.log
 import eu.darken.myperm.common.debug.logging.logTag
 import eu.darken.myperm.common.flow.SingleEventFlow
+import eu.darken.myperm.common.navigation.Nav
 import eu.darken.myperm.common.uix.ViewModel4
 import eu.darken.myperm.common.upgrade.core.MyPermSku
 import eu.darken.myperm.common.upgrade.core.UpgradeRepoGplay
@@ -17,12 +21,13 @@ import eu.darken.myperm.common.upgrade.core.client.UserCanceledBillingException
 import eu.darken.myperm.common.upgrade.core.data.Sku
 import eu.darken.myperm.common.upgrade.core.data.SkuDetails
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -36,47 +41,101 @@ import javax.inject.Inject
 class UpgradeViewModel @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
     private val upgradeRepo: UpgradeRepoGplay,
+    private val webpageTool: WebpageTool,
 ) : ViewModel4(dispatcherProvider) {
 
     sealed interface UpgradeEvent {
         data object RestoreFailed : UpgradeEvent
+        data object RestoreSucceeded : UpgradeEvent
+        data object SubscriptionStillRenewing : UpgradeEvent
+        data object SubscriptionCheckFailed : UpgradeEvent
     }
-
-    sealed interface BillingEvent {
-        data object LaunchIap : BillingEvent
-        data object LaunchSubscription : BillingEvent
-        data object LaunchSubscriptionTrial : BillingEvent
-    }
-
-    data class Pricing(
-        val iap: SkuDetails? = null,
-        val sub: SkuDetails? = null,
-        val subPrice: String? = null,
-        val iapPrice: String? = null,
-        val hasTrialOffer: Boolean = false,
-    ) {
-        val subAvailable: Boolean get() = sub != null || subPrice != null
-        val iapAvailable: Boolean get() = iap != null || iapPrice != null
-    }
-
-    data class State(
-        val pricing: Pricing? = null,
-        val wasPreviouslyPro: Boolean = false,
-        val restoreInProgress: Boolean = false,
-    )
 
     val events = SingleEventFlow<UpgradeEvent>()
-    val billingEvents = SingleEventFlow<BillingEvent>()
 
-    private val restoring = MutableStateFlow(false)
+    // null until the nav route resolves via init(manage). The state flow gates on this so we never
+    // render (or auto-navigate) before we know whether this is the sales or the manage screen.
+    private val manageMode = MutableStateFlow<Boolean?>(null)
 
-    private val pricing: Flow<Pricing?> = flow {
-        emit(null)
+    // Single money-path guard: restore, switch-verification and purchase launch are mutually exclusive.
+    private val action = MutableStateFlow(ActionState.IDLE)
 
+    // Billing has completed its first reconciliation (or the fallback elapsed). Purchase actions stay
+    // disabled until then so a cold-start empty snapshot can't offer acquisition to an existing owner.
+    private val settled = MutableStateFlow(false)
+
+    private val pricing = MutableStateFlow<Pricing?>(null)
+
+    // Re-evaluates the 24h grace-diagnostics boundary while the screen is open (the boundary is
+    // derived from a wall-clock timestamp, so combined flows alone won't re-fire when it elapses).
+    private val graceTick = flow {
+        while (true) {
+            emit(Unit)
+            delay(GRACE_TICK_INTERVAL_MS)
+        }
+    }
+
+    val state: StateFlow<UpgradeUiState> = combine(
+        pricing,
+        upgradeRepo.upgradeInfo,
+        upgradeRepo.wasEverPro,
+        upgradeRepo.lastProConfirmedAt,
+        combine(settled, action, manageMode.filterNotNull(), graceTick) { s, a, m, _ -> Triple(s, a, m) },
+    ) { pricing, info, wasEverPro, lastProAt, (isSettled, action, manage) ->
+        val gplayInfo = info as? UpgradeRepoGplay.Info ?: UpgradeRepoGplay.Info(billingData = null)
+        toLoadedState(
+            manageMode = manage,
+            info = gplayInfo,
+            pricing = pricing ?: Pricing(),
+            lastProConfirmedAt = lastProAt,
+            now = System.currentTimeMillis(),
+            isSettled = isSettled,
+            action = action,
+            wasEverPro = wasEverPro,
+            graceDiagnosticsAfterMs = GRACE_DIAGNOSTICS_AFTER_MS,
+        )
+    }.stateIn(vmScope, SharingStarted.WhileSubscribed(5_000), UpgradeUiState.Loading)
+
+    init {
+        launch { loadPricingNow() }
+        settle()
+    }
+
+    fun init(manage: Boolean) {
+        if (!manageMode.compareAndSet(null, manage)) return
+        log(TAG) { "init(manage=$manage)" }
+        if (!manage) {
+            // Sales mode only: close the screen the instant the user becomes Pro. Manage mode stays
+            // open so a current subscriber can view status and switch plans.
+            upgradeRepo.upgradeInfo
+                .map { it.isPro }
+                .distinctUntilChanged()
+                .onEach { isPro -> if (isPro) navUp() }
+                .launchIn(vmScope)
+        }
+    }
+
+    // Re-query on return from Google Play (e.g. after the user cancels the subscription in Play), so
+    // the locked one-time offer unlocks without needing a manual refresh action. Also retries the SKU
+    // pricing if a previous query failed (a transient Play outage otherwise leaves the screen with no
+    // purchase buttons even after billing recovers).
+    fun onResume() = launch {
+        try {
+            upgradeRepo.refresh()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "onResume refresh failed: ${e.asLog()}" }
+        }
+        val current = pricing.value
+        if (current == null || (!current.subAvailable && !current.iapAvailable)) {
+            loadPricingNow()
+        }
+    }
+
+    private suspend fun loadPricingNow() {
         val skuDetails = try {
-            withTimeoutOrNull(5_000L) {
-                upgradeRepo.querySkus()
-            }
+            withTimeoutOrNull(SKU_QUERY_TIMEOUT_MS) { upgradeRepo.querySkus() }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -86,78 +145,111 @@ class UpgradeViewModel @Inject constructor(
 
         val iapDetails = skuDetails?.firstOrNull { it.sku.type == Sku.Type.IAP }
         val subDetails = skuDetails?.firstOrNull { it.sku.type == Sku.Type.SUBSCRIPTION }
-
         val subOffers = subDetails?.details?.subscriptionOfferDetails
         val baseOffer = subOffers?.firstOrNull { MyPermSku.Sub.BASE_OFFER.matches(it) }
         val hasTrialOffer = subOffers?.any { MyPermSku.Sub.TRIAL_OFFER.matches(it) } == true
 
-        emit(
-            Pricing(
-                iap = iapDetails,
-                sub = subDetails,
-                subPrice = baseOffer?.pricingPhases?.pricingPhaseList?.lastOrNull()?.formattedPrice,
-                iapPrice = iapDetails?.details?.oneTimePurchaseOfferDetails?.formattedPrice,
-                hasTrialOffer = hasTrialOffer,
-            )
+        pricing.value = Pricing(
+            iap = iapDetails,
+            sub = subDetails,
+            subPrice = baseOffer?.pricingPhases?.pricingPhaseList?.lastOrNull()?.formattedPrice,
+            iapPrice = iapDetails?.details?.oneTimePurchaseOfferDetails?.formattedPrice,
+            hasTrialOffer = hasTrialOffer,
         )
     }
 
-    val state: StateFlow<State> = combine(
-        pricing,
-        upgradeRepo.upgradeInfo,
-        upgradeRepo.wasEverPro,
-        restoring,
-    ) { pricing, current, wasEverPro, isRestoring ->
-        State(
-            pricing = pricing,
-            // Hidden while a purchase or the grace period still keeps the user Pro.
-            wasPreviouslyPro = wasEverPro && !current.isPro,
-            restoreInProgress = isRestoring,
-        )
-    }.stateIn(vmScope, SharingStarted.WhileSubscribed(5_000), State())
+    private fun settle() = launch {
+        // Flip settled after the first reconciliation, or after a bounded fallback so actions can't
+        // stay disabled forever during a Play outage.
+        try {
+            withTimeoutOrNull(SETTLE_FALLBACK_MS) { upgradeRepo.refresh() }
+        } finally {
+            settled.value = true
+        }
+    }
 
-    init {
-        // Dedupe on isPro: consecutive Pro emissions with different backing data (reactive cache
-        // union vs a fresh restore result) must not enqueue multiple navUp events.
-        upgradeRepo.upgradeInfo
-            .map { it.isPro }
-            .distinctUntilChanged()
-            .onEach { isPro ->
-                if (isPro) {
-                    log(TAG) { "User is now pro, navigating back" }
-                    navUp()
-                }
+    fun onSubscribe(activity: Activity) {
+        val current = pricing.value ?: return
+        val skuDetails = current.sub ?: return
+        val offer = if (current.hasTrialOffer) MyPermSku.Sub.TRIAL_OFFER else MyPermSku.Sub.BASE_OFFER
+        // Acquire the guard synchronously on the caller (main) thread BEFORE launching, so two rapid
+        // taps can't both slip past the CAS from separate coroutines.
+        if (!action.compareAndSet(ActionState.IDLE, ActionState.VERIFYING)) return
+        launch {
+            try {
+                launchBillingFlow(activity, skuDetails, offer)
+            } finally {
+                action.value = ActionState.IDLE
             }
-            .launchIn(vmScope)
+        }
     }
 
-    fun onGoIap() {
-        billingEvents.tryEmit(BillingEvent.LaunchIap)
+    // Both the sales "Buy" button and the ownership "switch" route through here. EVERY one-time (IAP)
+    // acquisition is gated on a fresh SUBS verification and fails closed, so we never launch the
+    // one-time purchase while a subscription may still be auto-renewing (double billing) — including
+    // during a grace window where a stale entitlement could otherwise expose an unguarded buy button.
+    fun onBuyIap(activity: Activity) = verifyThenLaunchIap(activity)
+
+    fun onSwitchToIap(activity: Activity) = verifyThenLaunchIap(activity)
+
+    private fun verifyThenLaunchIap(activity: Activity) {
+        if (!action.compareAndSet(ActionState.IDLE, ActionState.VERIFYING)) {
+            log(TAG) { "IAP acquisition ignored, an action is already in progress" }
+            return
+        }
+        launch {
+            try {
+                val subscriptions = try {
+                    withTimeoutOrNull(VERIFY_TIMEOUT_MS) { upgradeRepo.queryCurrentSubscriptions() }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log(TAG, WARN) { "Subscription verify failed: ${e.asLog()}" }
+                    errorEvents.emitBlocking(e)
+                    return@launch
+                }
+                when {
+                    subscriptions == null -> {
+                        log(TAG, WARN) { "Subscription verify timed out -> failing closed" }
+                        events.tryEmit(UpgradeEvent.SubscriptionCheckFailed)
+                    }
+
+                    subscriptions.any { it.isAutoRenewing } -> {
+                        log(TAG, INFO) { "Subscription still renewing -> blocking one-time purchase" }
+                        events.tryEmit(UpgradeEvent.SubscriptionStillRenewing)
+                    }
+
+                    else -> {
+                        val iap = pricing.value?.iap
+                        if (iap == null) {
+                            log(TAG, WARN) { "No IAP SkuDetails available" }
+                        } else {
+                            launchBillingFlow(activity, iap, null)
+                        }
+                    }
+                }
+            } finally {
+                action.value = ActionState.IDLE
+            }
+        }
     }
 
-    fun onGoSubscription() {
-        billingEvents.tryEmit(BillingEvent.LaunchSubscription)
+    fun onManageSubscription() {
+        val url = "https://play.google.com/store/account/subscriptions" +
+            "?sku=${MyPermSku.Sub.PRO_UPGRADE.id}&package=${BuildConfigWrap.APPLICATION_ID}"
+        webpageTool.open(url)
     }
 
-    fun onGoSubscriptionTrial() {
-        billingEvents.tryEmit(BillingEvent.LaunchSubscriptionTrial)
+    fun onContactSupport() {
+        navTo(Nav.Settings.ContactForm)
     }
 
-    fun launchBillingIap(activity: Activity) =
-        launchBillingFlow(activity, state.value.pricing?.iap, null)
-
-    fun launchBillingSubscription(activity: Activity) =
-        launchBillingFlow(activity, state.value.pricing?.sub, MyPermSku.Sub.BASE_OFFER)
-
-    fun launchBillingSubscriptionTrial(activity: Activity) =
-        launchBillingFlow(activity, state.value.pricing?.sub, MyPermSku.Sub.TRIAL_OFFER)
-
-    private fun launchBillingFlow(
+    // Assumes the action guard is already held by the caller.
+    private suspend fun launchBillingFlow(
         activity: Activity,
-        skuDetails: SkuDetails?,
+        skuDetails: SkuDetails,
         offer: Sku.Subscription.Offer?,
-    ) = launch {
-        skuDetails ?: return@launch
+    ) {
         try {
             withContext(dispatcherProvider.Main) {
                 upgradeRepo.launchBillingFlow(activity, skuDetails, offer)
@@ -167,59 +259,69 @@ class UpgradeViewModel @Inject constructor(
         } catch (e: UserCanceledBillingException) {
             log(TAG) { "User canceled the billing flow" }
         } catch (e: ItemAlreadyOwnedBillingException) {
-            // Stale local state: Play says they already own it, so tapping "buy" really means
-            // "unlock what I own" — restore instead of showing an error.
             log(TAG, INFO) { "Buy attempt says already owned, restoring purchase instead" }
-            restoreAfterAlreadyOwned(e)
+            restoreAfterAlreadyOwned(e, skuDetails)
         } catch (e: Exception) {
             log(TAG, WARN) { "launchBillingFlow failed: ${e.asLog()}" }
             errorEvents.emitBlocking(e)
         }
     }
 
-    private suspend fun restoreAfterAlreadyOwned(original: ItemAlreadyOwnedBillingException) {
-        if (!restoring.compareAndSet(expect = false, update = true)) {
-            log(TAG) { "Restore already in progress, letting it resolve the entitlement" }
-            return
+    // Recovery for ITEM_ALREADY_OWNED: only treat it as resolved if the restore actually returns the
+    // EXACT SKU the launch was for (not merely any Pro purchase / a grace-only state).
+    private suspend fun restoreAfterAlreadyOwned(
+        original: ItemAlreadyOwnedBillingException,
+        skuDetails: SkuDetails,
+    ) {
+        val restored = try {
+            withTimeoutOrNull(RESTORE_TIMEOUT_MS) { upgradeRepo.restorePurchaseNow() }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Restore after already-owned failed: ${e.asLog()}" }
+            null
         }
-        try {
-            val restored = try {
-                withTimeoutOrNull(RESTORE_TIMEOUT_MS) { upgradeRepo.restorePurchaseNow() }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                log(TAG, WARN) { "Restore after already-owned failed: ${e.asLog()}" }
-                null
-            }
-            if (restored?.isPro == true) {
-                log(TAG, INFO) { "Restored purchase after already-owned buy attempt" }
-            } else {
-                // Couldn't reconcile the entitlement (pending purchase, account mismatch, Play
-                // quirk) — fall back to the already-owned dialog with restore tips.
-                errorEvents.emitBlocking(original)
-            }
-        } finally {
-            restoring.value = false
+        val ownsExact = (restored as? UpgradeRepoGplay.Info)
+            ?.proPurchases
+            ?.any { it.sku.id == skuDetails.sku.id } == true
+        if (ownsExact) {
+            log(TAG, INFO) { "Restored ${skuDetails.sku} after already-owned buy attempt" }
+        } else {
+            errorEvents.emitBlocking(original)
         }
     }
 
-    fun restorePurchase() = launch {
-        // Single-flight: repeated taps while a restore is running (worst case bounded by
-        // RESTORE_TIMEOUT_MS) must not stack concurrent restores and duplicate result dialogs.
-        if (!restoring.compareAndSet(expect = false, update = true)) {
-            log(TAG) { "restorePurchase() ignored, already in progress" }
-            return@launch
+    fun onRestore() {
+        // Acquire synchronously before launching (see onSubscribe).
+        if (!action.compareAndSet(ActionState.IDLE, ActionState.RESTORING)) {
+            log(TAG) { "onRestore ignored, an action is already in progress" }
+            return
         }
-        log(TAG) { "restorePurchase()" }
+        launch { runRestore() }
+    }
+
+    private suspend fun runRestore() {
+        log(TAG) { "onRestore()" }
         try {
+            // Keep the progress state visible for a minimum duration, so a warm-cache restore still
+            // reads as "a live Play check happened" instead of flashing for a single frame. Padding
+            // the remainder after the query yields the same max(queryTime, minVisible) floor.
+            val startedAt = SystemClock.elapsedRealtime()
             val restored = withTimeoutOrNull(RESTORE_TIMEOUT_MS) { upgradeRepo.restorePurchaseNow() }
+            val elapsed = SystemClock.elapsedRealtime() - startedAt
+            if (elapsed < RESTORE_MIN_VISIBLE_MS) delay(RESTORE_MIN_VISIBLE_MS - elapsed)
+            val ownsSomething = (restored as? UpgradeRepoGplay.Info)?.proPurchases?.isNotEmpty() == true
             when {
                 restored == null -> {
                     log(TAG, WARN) { "Restore purchase timed out" }
                     events.tryEmit(UpgradeEvent.RestoreFailed)
                 }
 
-                restored.isPro -> log(TAG, INFO) { "Restored purchase :)" }
+                // Grace-only Pro (no returned purchase) is NOT a successful restore.
+                ownsSomething -> {
+                    log(TAG, INFO) { "Restored purchase :)" }
+                    events.tryEmit(UpgradeEvent.RestoreSucceeded)
+                }
 
                 else -> {
                     log(TAG, WARN) { "No pro purchase found" }
@@ -229,18 +331,21 @@ class UpgradeViewModel @Inject constructor(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            // Play/billing error (e.g. service unavailable): surface the proper error dialog
-            // instead of the generic "no purchases found" message.
             log(TAG, WARN) { "Restore purchase errored: ${e.asLog()}" }
             errorEvents.emitBlocking(e)
         } finally {
-            // Reset only after result handling, so the single-flight guard covers the whole action.
-            restoring.value = false
+            action.value = ActionState.IDLE
         }
     }
 
     companion object {
+        internal const val VERIFY_TIMEOUT_MS = 10_000L
+        internal const val SKU_QUERY_TIMEOUT_MS = 15_000L
         internal const val RESTORE_TIMEOUT_MS = 15_000L
+        internal const val RESTORE_MIN_VISIBLE_MS = 1_500L
+        internal const val SETTLE_FALLBACK_MS = 10_000L
+        internal const val GRACE_DIAGNOSTICS_AFTER_MS = 24 * 60 * 60 * 1000L
+        private const val GRACE_TICK_INTERVAL_MS = 60_000L
         private val TAG = logTag("Upgrade", "Gplay", "VM")
     }
 }

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -17,4 +17,38 @@
     <string name="upgrade_screen_restore_banner_body">It looks like you upgraded to Pro on this device before. Restore your purchase to unlock it again.</string>
     <string name="upgrade_screen_options_description">Subscriptions renew automatically. You can cancel anytime.</string>
     <string name="upgrade_title_suffix">Pro</string>
+
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">You\'re Pro — thank you!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Your one-time Pro purchase unlocks every Pro feature, forever.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Your subscription unlocks every Pro feature.</string>
+    <string name="upgrade_screen_owned_sub_title">Your subscription</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Your subscription is active and renews automatically.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Your subscription is set to expire and won\'t renew. You\'ll keep Pro until it ends.</string>
+    <string name="upgrade_screen_owned_both_warning">You own the one-time Pro upgrade and also have an active subscription. You don\'t need both — cancel the subscription in Google Play to avoid further charges.</string>
+    <string name="upgrade_screen_manage_subscription_action">Manage subscription</string>
+    <string name="upgrade_screen_owned_iap_title">Lifetime Pro</string>
+    <string name="upgrade_screen_owned_iap_body">You own the one-time Pro upgrade. No subscription, no renewals.</string>
+
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Switch to a one-time purchase</string>
+    <string name="upgrade_screen_switch_purchase_note">Your subscription won\'t renew, so you can move to the permanent one-time Pro purchase now.</string>
+    <string name="upgrade_screen_switch_locked_note">To switch to the one-time purchase, first cancel your subscription in Google Play. This offer unlocks once it\'s set not to renew.</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play only checks the account you\'re currently signed in with. The one-time purchase is separate from your subscription.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Your subscription is still active and renewing. Cancel it in Google Play first.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Couldn\'t verify your subscription with Google Play. Please try again.</string>
+
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">Confirming your purchase</string>
+    <string name="upgrade_screen_grace_body">Waiting for Google Play to re-confirm your Pro purchase. This usually resolves on its own.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">We still can\'t re-confirm your Pro purchase with Google Play. If this keeps happening, try restoring your purchase or contact support.</string>
+
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">Status looks wrong?</string>
+    <string name="upgrade_screen_restore_status_body">If you\'ve purchased Pro but it isn\'t showing, run a live check against Google Play.</string>
+    <string name="upgrade_screen_restore_success_message">Purchase restored.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Make sure you\'re signed in with the Google account you used to purchase. A live check against Google Play just ran.</string>
 </resources>

--- a/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsViewModel.kt
@@ -332,7 +332,7 @@ class AppDetailsViewModel @Inject constructor(
                 if (!current.canViewManifest) return
                 if (!upgradeRepo.upgradeInfo.value.isPro) {
                     log(TAG) { "Not pro, navigating to upgrade instead of manifest viewer" }
-                    navTo(Nav.Main.Upgrade)
+                    navTo(Nav.Main.Upgrade())
                     return
                 }
                 navTo(Nav.Details.AppManifest(pkgName = pkgName.value, appLabel = initialLabel))

--- a/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/list/AppsViewModel.kt
@@ -269,7 +269,7 @@ class AppsViewModel @Inject constructor(
     }
 
     fun onUpgrade() {
-        navTo(Nav.Main.Upgrade)
+        navTo(Nav.Main.Upgrade())
     }
 
     private fun buildInstallerLabelCache(apps: List<AppInfo>): Map<Pkg.Name, String> {

--- a/app/src/main/java/eu/darken/myperm/common/navigation/Nav.kt
+++ b/app/src/main/java/eu/darken/myperm/common/navigation/Nav.kt
@@ -8,7 +8,7 @@ object Nav {
         data object Onboarding : Main
 
         @Serializable
-        data object Upgrade : Main
+        data class Upgrade(val manage: Boolean = false) : Main
     }
 
     sealed interface Tab : NavigationDestination {

--- a/app/src/main/java/eu/darken/myperm/export/ui/ExportViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/export/ui/ExportViewModel.kt
@@ -352,7 +352,7 @@ class ExportViewModel @Inject constructor(
     }
 
     fun onUpgrade() {
-        navTo(Nav.Main.Upgrade)
+        navTo(Nav.Main.Upgrade())
     }
 
     private fun resolveApps(

--- a/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewViewModel.kt
@@ -195,7 +195,7 @@ class OverviewViewModel @Inject constructor(
     }
 
     fun onUpgrade() {
-        navTo(Nav.Main.Upgrade)
+        navTo(Nav.Main.Upgrade())
     }
 
     fun onCategoryClicked(filters: Set<AppsFilterOptions.Filter>) = launch {

--- a/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/list/PermissionsViewModel.kt
@@ -329,7 +329,7 @@ class PermissionsViewModel @Inject constructor(
     }
 
     fun onUpgrade() {
-        navTo(Nav.Main.Upgrade)
+        navTo(Nav.Main.Upgrade())
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/myperm/settings/ui/general/GeneralSettingsViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/settings/ui/general/GeneralSettingsViewModel.kt
@@ -50,7 +50,7 @@ class GeneralSettingsViewModel @Inject constructor(
     }
 
     fun onUpgrade() {
-        navTo(Nav.Main.Upgrade)
+        navTo(Nav.Main.Upgrade())
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/myperm/settings/ui/index/SettingsIndexScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/settings/ui/index/SettingsIndexScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.twotone.ColorLens
 import androidx.compose.material.icons.twotone.FormatListNumbered
 import androidx.compose.material.icons.twotone.Favorite
 import androidx.compose.material.icons.twotone.Notifications
+import androidx.compose.material.icons.twotone.Stars
 import androidx.compose.material.icons.automirrored.twotone.HelpOutline
 import androidx.compose.material.icons.twotone.Info
 import androidx.compose.material3.Icon
@@ -45,6 +46,7 @@ fun SettingsIndexScreenHost() {
         onSupport = { navCtrl?.goTo(Nav.Settings.Support) },
         onAcknowledgements = { navCtrl?.goTo(Nav.Settings.Acknowledgements) },
         onPrivacyPolicy = { vm.openPrivacyPolicy() },
+        onUpgradeStatus = { navCtrl?.goTo(Nav.Main.Upgrade(manage = true)) },
     )
 }
 
@@ -57,6 +59,7 @@ fun SettingsIndexScreen(
     onSupport: () -> Unit,
     onAcknowledgements: () -> Unit,
     onPrivacyPolicy: () -> Unit,
+    onUpgradeStatus: () -> Unit = {},
     versionSubtitle: String = BuildConfigWrap.VERSION_DESCRIPTION,
 ) {
     Scaffold(
@@ -93,6 +96,13 @@ fun SettingsIndexScreen(
 
             SettingsCategoryHeader(text = stringResource(R.string.settings_category_other_label))
 
+            SettingsBaseItem(
+                title = stringResource(R.string.settings_upgrade_status_title),
+                subtitle = stringResource(R.string.settings_upgrade_description),
+                icon = Icons.TwoTone.Stars,
+                onClick = onUpgradeStatus,
+            )
+            SettingsDivider()
             SettingsBaseItem(
                 title = stringResource(R.string.settings_support_label),
                 subtitle = "\u00AF\\_(ツ)_/\u00AF",

--- a/app/src/main/java/eu/darken/myperm/settings/ui/watcher/WatcherSettingsViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/settings/ui/watcher/WatcherSettingsViewModel.kt
@@ -50,7 +50,7 @@ class WatcherSettingsViewModel @Inject constructor(
     }
 
     fun onUpgrade() {
-        navTo(Nav.Main.Upgrade)
+        navTo(Nav.Main.Upgrade())
     }
 
     fun setWatcherScope(scope: WatcherScope) = launch {

--- a/app/src/main/java/eu/darken/myperm/watcher/ui/dashboard/WatcherDashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/watcher/ui/dashboard/WatcherDashboardViewModel.kt
@@ -143,7 +143,7 @@ class WatcherDashboardViewModel @Inject constructor(
     fun onReportClicked(item: WatcherReportItem) = launch {
         if (!upgradeRepo.upgradeInfo.value.isPro) {
             log(TAG) { "Not pro, navigating to upgrade instead of detail" }
-            navTo(Nav.Main.Upgrade)
+            navTo(Nav.Main.Upgrade())
             return@launch
         }
         changeDao.markSeen(item.id)
@@ -152,7 +152,7 @@ class WatcherDashboardViewModel @Inject constructor(
     }
 
     fun goToUpgrade() {
-        navTo(Nav.Main.Upgrade)
+        navTo(Nav.Main.Upgrade())
     }
 
     fun refreshNow() = launch {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -603,6 +603,9 @@
     <string name="general_upgrade_action">Upgrade</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
 
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Upgrade status and options</string>
+
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">Watcher</string>
     <string name="watcher_dashboard_feature_title">Permission Watcher</string>

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/client/BillingClientConnectionTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/client/BillingClientConnectionTest.kt
@@ -7,6 +7,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import testhelper.BaseTest
 
@@ -84,5 +85,66 @@ class BillingClientConnectionTest : BaseTest() {
 
         // A negative age is never an echo (clock anomalies must not suppress real failures).
         BillingClientConnection.isSyncLaunchFailureEcho(result(code), code to now + 1_000, now) shouldBe false
+    }
+
+    private fun purchasedSub(token: String = "tok", time: Long = 1_000L) = mockk<Purchase> {
+        every { purchaseToken } returns token
+        every { purchaseState } returns Purchase.PurchaseState.PURCHASED
+        every { purchaseTime } returns time
+    }
+
+    @Test
+    fun `verifyStable - a read with no racing callback is authoritative`() = runBlocking {
+        val subs = listOf(purchasedSub())
+        BillingClientConnection.verifyStableSubscriptions(
+            maxAttempts = 4,
+            generation = { 7L },
+            query = { subs },
+        ) shouldBe subs
+    }
+
+    @Test
+    fun `verifyStable - retries when a callback races the query, then succeeds`() = runBlocking {
+        var gen = 0L
+        var racesLeft = 1
+        val subs = listOf(purchasedSub())
+        val result = BillingClientConnection.verifyStableSubscriptions(
+            maxAttempts = 4,
+            generation = { gen },
+            query = {
+                if (racesLeft > 0) { racesLeft--; gen++ } // a purchase callback lands during the first read
+                subs
+            },
+        )
+        result shouldBe subs
+    }
+
+    @Test
+    fun `verifyStable - fails closed when it never stabilizes`() {
+        shouldThrow<BillingException> {
+            runBlocking {
+                var gen = 0L
+                BillingClientConnection.verifyStableSubscriptions(
+                    maxAttempts = 3,
+                    generation = { gen },
+                    query = { gen++; emptyList() },
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `verifyStable - filters to PURCHASED only`() = runBlocking {
+        val purchased = purchasedSub()
+        val pending = mockk<Purchase> {
+            every { purchaseToken } returns "pending"
+            every { purchaseState } returns Purchase.PurchaseState.PENDING
+            every { purchaseTime } returns 1_000L
+        }
+        BillingClientConnection.verifyStableSubscriptions(
+            maxAttempts = 4,
+            generation = { 0L },
+            query = { listOf(purchased, pending) },
+        ) shouldBe listOf(purchased)
     }
 }

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeUiStateTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeUiStateTest.kt
@@ -1,0 +1,130 @@
+package eu.darken.myperm.common.upgrade.ui
+
+import com.android.billingclient.api.Purchase
+import eu.darken.myperm.common.upgrade.core.MyPermSku
+import eu.darken.myperm.common.upgrade.core.UpgradeRepoGplay
+import eu.darken.myperm.common.upgrade.core.data.BillingData
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import testhelper.BaseTest
+
+class UpgradeUiStateTest : BaseTest() {
+
+    private val hour = 60 * 60 * 1000L
+    private val diagnosticsAfter = 24 * hour
+
+    private fun purchase(productId: String, autoRenew: Boolean = false) = mockk<Purchase> {
+        every { products } returns listOf(productId)
+        every { purchaseState } returns Purchase.PurchaseState.PURCHASED
+        every { purchaseTime } returns 1_000L
+        every { isAutoRenewing } returns autoRenew
+        every { isAcknowledged } returns true
+    }
+
+    private fun infoOwning(vararg purchases: Purchase) =
+        UpgradeRepoGplay.Info(billingData = BillingData(purchases.toSet()))
+
+    private fun graceInfo() = UpgradeRepoGplay.Info(gracePeriod = true, billingData = null)
+
+    @Test
+    fun `ownership - iap only`() {
+        val info = infoOwning(purchase(MyPermSku.Iap.PRO_UPGRADE.id))
+        val ownership = info.toOwnership()
+        ownership.hasIap shouldBe true
+        ownership.subscription shouldBe null
+    }
+
+    @Test
+    fun `ownership - renewing subscription`() {
+        val info = infoOwning(purchase(MyPermSku.Sub.PRO_UPGRADE.id, autoRenew = true))
+        val ownership = info.toOwnership()
+        ownership.hasIap shouldBe false
+        ownership.subscription?.isAutoRenewing shouldBe true
+    }
+
+    @Test
+    fun `ownership - conservative, renewing if ANY record renews`() {
+        val info = infoOwning(
+            purchase(MyPermSku.Sub.PRO_UPGRADE.id, autoRenew = false),
+            purchase(MyPermSku.Sub.PRO_UPGRADE.id, autoRenew = true),
+        )
+        info.toOwnership().subscription?.isAutoRenewing shouldBe true
+    }
+
+    @Test
+    fun `switch unlocked only when a subscription is owned and not renewing`() {
+        val notRenewing = toLoadedState(
+            manageMode = true,
+            info = infoOwning(purchase(MyPermSku.Sub.PRO_UPGRADE.id, autoRenew = false)),
+            pricing = Pricing(),
+            lastProConfirmedAt = 0L,
+            now = 0L,
+            isSettled = true,
+            action = ActionState.IDLE,
+            wasEverPro = true,
+            graceDiagnosticsAfterMs = diagnosticsAfter,
+        )
+        notRenewing.switchUnlocked shouldBe true
+
+        val renewing = notRenewing.copy(
+            ownership = infoOwning(purchase(MyPermSku.Sub.PRO_UPGRADE.id, autoRenew = true)).toOwnership(),
+        )
+        renewing.switchUnlocked shouldBe false
+    }
+
+    @Test
+    fun `grace within window does not show diagnostics`() {
+        val now = 100 * hour
+        val state = toLoadedState(
+            manageMode = true,
+            info = graceInfo(),
+            pricing = Pricing(),
+            lastProConfirmedAt = now - hour, // 1h ago, well within 24h
+            now = now,
+            isSettled = true,
+            action = ActionState.IDLE,
+            wasEverPro = true,
+            graceDiagnosticsAfterMs = diagnosticsAfter,
+        )
+        state.gracePeriod shouldBe true
+        state.graceHint?.showDiagnostics shouldBe false
+    }
+
+    @Test
+    fun `grace past 24h shows diagnostics`() {
+        val now = 100 * hour
+        val state = toLoadedState(
+            manageMode = true,
+            info = graceInfo(),
+            pricing = Pricing(),
+            lastProConfirmedAt = now - 25 * hour,
+            now = now,
+            isSettled = true,
+            action = ActionState.IDLE,
+            wasEverPro = true,
+            graceDiagnosticsAfterMs = diagnosticsAfter,
+        )
+        state.graceHint?.showDiagnostics shouldBe true
+    }
+
+    @Test
+    fun `wasPreviouslyPro only when ever-pro and not currently pro`() {
+        fun build(info: UpgradeRepoGplay.Info, wasEverPro: Boolean) = toLoadedState(
+            manageMode = false,
+            info = info,
+            pricing = Pricing(),
+            lastProConfirmedAt = 0L,
+            now = 0L,
+            isSettled = true,
+            action = ActionState.IDLE,
+            wasEverPro = wasEverPro,
+            graceDiagnosticsAfterMs = diagnosticsAfter,
+        )
+
+        build(UpgradeRepoGplay.Info(billingData = null), wasEverPro = true).wasPreviouslyPro shouldBe true
+        build(UpgradeRepoGplay.Info(billingData = null), wasEverPro = false).wasPreviouslyPro shouldBe false
+        build(infoOwning(purchase(MyPermSku.Iap.PRO_UPGRADE.id)), wasEverPro = true).wasPreviouslyPro shouldBe false
+    }
+}

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModelTest.kt
@@ -4,6 +4,9 @@ import android.app.Activity
 import com.android.billingclient.api.BillingClient.BillingResponseCode
 import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.ProductDetails
+import com.android.billingclient.api.Purchase
+import eu.darken.myperm.common.WebpageTool
+import eu.darken.myperm.common.navigation.NavEvent
 import eu.darken.myperm.common.upgrade.UpgradeRepo
 import eu.darken.myperm.common.upgrade.core.MyPermSku
 import eu.darken.myperm.common.upgrade.core.UpgradeRepoGplay
@@ -12,13 +15,11 @@ import eu.darken.myperm.common.upgrade.core.client.UserCanceledBillingException
 import eu.darken.myperm.common.upgrade.core.data.BillingData
 import eu.darken.myperm.common.upgrade.core.data.SkuDetails
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
@@ -38,6 +39,7 @@ class UpgradeViewModelTest : BaseTest() {
 
     private val testDispatcher = StandardTestDispatcher()
     private val activity = mockk<Activity>()
+    private val webpageTool = mockk<WebpageTool>(relaxed = true)
 
     @BeforeEach
     fun setup() {
@@ -49,23 +51,18 @@ class UpgradeViewModelTest : BaseTest() {
         Dispatchers.resetMain()
     }
 
-    private fun info(isPro: Boolean) = UpgradeRepoGplay.Info(
-        gracePeriod = isPro,
-        billingData = null,
-    )
-
-    private fun mockRepo(
-        isPro: Boolean = false,
-        wasEverPro: Boolean = false,
-    ): UpgradeRepoGplay = mockk<UpgradeRepoGplay>(relaxed = true).apply {
-        every { upgradeInfo } returns MutableStateFlow(info(isPro))
-        every { this@apply.wasEverPro } returns MutableStateFlow(wasEverPro)
-        coEvery { querySkus() } returns emptyList()
+    private fun purchase(productId: String, autoRenew: Boolean = false) = mockk<Purchase> {
+        every { products } returns listOf(productId)
+        every { purchaseState } returns Purchase.PurchaseState.PURCHASED
+        every { purchaseTime } returns 1_000L
+        every { isAutoRenewing } returns autoRenew
+        every { isAcknowledged } returns true
     }
 
-    private fun buildVm(repo: UpgradeRepoGplay): UpgradeViewModel = UpgradeViewModel(
-        dispatcherProvider = TestDispatcherProvider(testDispatcher),
-        upgradeRepo = repo,
+    private fun notProInfo() = UpgradeRepoGplay.Info(billingData = null)
+    private fun graceInfo() = UpgradeRepoGplay.Info(gracePeriod = true, billingData = null)
+    private fun iapOwnedInfo() = UpgradeRepoGplay.Info(
+        billingData = BillingData(setOf(purchase(MyPermSku.Iap.PRO_UPGRADE.id))),
     )
 
     private fun iapSkuDetails(): SkuDetails = SkuDetails(
@@ -78,145 +75,191 @@ class UpgradeViewModelTest : BaseTest() {
 
     private fun result(code: Int): BillingResult = BillingResult.newBuilder().setResponseCode(code).build()
 
+    private fun mockRepo(
+        info: UpgradeRepoGplay.Info = notProInfo(),
+        wasEverPro: Boolean = false,
+        skus: List<SkuDetails> = emptyList(),
+    ): UpgradeRepoGplay = mockk<UpgradeRepoGplay>(relaxed = true).apply {
+        every { upgradeInfo } returns MutableStateFlow<UpgradeRepo.Info>(info)
+        every { this@apply.wasEverPro } returns MutableStateFlow(wasEverPro)
+        every { lastProConfirmedAt } returns MutableStateFlow(0L)
+        coEvery { querySkus() } returns skus
+        coEvery { refresh() } returns Unit
+        coEvery { queryCurrentSubscriptions() } returns emptyList()
+    }
+
+    private fun buildVm(repo: UpgradeRepoGplay): UpgradeViewModel = UpgradeViewModel(
+        dispatcherProvider = TestDispatcherProvider(testDispatcher),
+        upgradeRepo = repo,
+        webpageTool = webpageTool,
+    )
+
+    private suspend fun UpgradeViewModel.loaded(): UpgradeUiState.Loaded =
+        state.first { it is UpgradeUiState.Loaded } as UpgradeUiState.Loaded
+
+    // --- restore -------------------------------------------------------------------------------
+
     @Test
     fun `restore with no purchase emits RestoreFailed`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        coEvery { repo.restorePurchaseNow() } returns info(isPro = false)
-        val vm = buildVm(repo)
+        coEvery { repo.restorePurchaseNow() } returns notProInfo()
+        val vm = buildVm(repo).also { it.init(manage = false) }
 
-        vm.restorePurchase()
+        vm.onRestore()
         advanceUntilIdle()
 
         vm.events.first() shouldBe UpgradeViewModel.UpgradeEvent.RestoreFailed
     }
 
     @Test
-    fun `restore that finds pro emits no failure`() = runTest2(context = testDispatcher) {
+    fun `restore that returns an actual purchase emits RestoreSucceeded`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        coEvery { repo.restorePurchaseNow() } returns info(isPro = true)
-        val vm = buildVm(repo)
+        coEvery { repo.restorePurchaseNow() } returns iapOwnedInfo()
+        val vm = buildVm(repo).also { it.init(manage = true) }
 
-        val events = mutableListOf<UpgradeViewModel.UpgradeEvent>()
-        val collector = launch { vm.events.collect { events.add(it) } }
-        vm.restorePurchase()
+        vm.onRestore()
         advanceUntilIdle()
 
-        events shouldBe emptyList()
-        collector.cancel()
+        vm.events.first() shouldBe UpgradeViewModel.UpgradeEvent.RestoreSucceeded
     }
 
     @Test
-    fun `restore that times out emits RestoreFailed`() = runTest2(context = testDispatcher) {
+    fun `grace-only pro is not a successful restore`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        coEvery { repo.restorePurchaseNow() } coAnswers {
-            delay(30_000) // longer than the 15s restore timeout
-            info(isPro = true)
-        }
-        val vm = buildVm(repo)
+        coEvery { repo.restorePurchaseNow() } returns graceInfo()
+        val vm = buildVm(repo).also { it.init(manage = true) }
 
-        vm.restorePurchase()
+        vm.onRestore()
         advanceUntilIdle()
 
         vm.events.first() shouldBe UpgradeViewModel.UpgradeEvent.RestoreFailed
     }
 
     @Test
-    fun `restore that errors forwards the error instead of RestoreFailed`() = runTest2(context = testDispatcher) {
+    fun `restore that errors forwards the error`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
         val boom = IllegalStateException("Play unavailable")
         coEvery { repo.restorePurchaseNow() } throws boom
-        val vm = buildVm(repo)
+        val vm = buildVm(repo).also { it.init(manage = false) }
 
-        vm.restorePurchase()
+        vm.onRestore()
         advanceUntilIdle()
 
         vm.errorEvents.first() shouldBe boom
     }
 
     @Test
-    fun `restore is single-flight, taps during a running restore are ignored`() = runTest2(context = testDispatcher) {
+    fun `restore is single-flight`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
         coEvery { repo.restorePurchaseNow() } coAnswers {
             delay(5_000)
-            info(isPro = true)
+            notProInfo()
         }
-        val vm = buildVm(repo)
+        val vm = buildVm(repo).also { it.init(manage = false) }
 
-        vm.restorePurchase()
-        vm.restorePurchase()
-        vm.restorePurchase()
+        vm.onRestore()
+        vm.onRestore()
+        vm.onRestore()
         advanceUntilIdle()
 
         coVerify(exactly = 1) { repo.restorePurchaseNow() }
     }
 
+    // --- switch gate ---------------------------------------------------------------------------
+
     @Test
-    fun `a finished restore allows a new attempt`() = runTest2(context = testDispatcher) {
-        val repo = mockRepo()
-        coEvery { repo.restorePurchaseNow() } returns info(isPro = false)
-        val vm = buildVm(repo)
-
-        vm.restorePurchase()
-        advanceUntilIdle()
-        vm.restorePurchase()
+    fun `switch blocked while a subscription is still renewing`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo(skus = listOf(iapSkuDetails()))
+        coEvery { repo.queryCurrentSubscriptions() } returns listOf(purchase(MyPermSku.Sub.PRO_UPGRADE.id, autoRenew = true))
+        val vm = buildVm(repo).also { it.init(manage = true) }
+        vm.loaded()
         advanceUntilIdle()
 
-        coVerify(exactly = 2) { repo.restorePurchaseNow() }
+        vm.onSwitchToIap(activity)
+        advanceUntilIdle()
+
+        vm.events.first() shouldBe UpgradeViewModel.UpgradeEvent.SubscriptionStillRenewing
+        coVerify(exactly = 0) { repo.launchBillingFlow(any(), any(), any()) }
     }
 
     @Test
-    fun `restore progress flows into the ui state and resets`() = runTest2(context = testDispatcher) {
-        val repo = mockRepo()
-        coEvery { repo.restorePurchaseNow() } coAnswers {
-            delay(5_000)
-            info(isPro = false)
+    fun `switch fails closed when the verify times out`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo(skus = listOf(iapSkuDetails()))
+        coEvery { repo.queryCurrentSubscriptions() } coAnswers {
+            delay(20_000) // longer than VERIFY_TIMEOUT_MS
+            emptyList()
         }
-        val vm = buildVm(repo)
-
-        val inProgress = async { vm.state.first { it.restoreInProgress } }
-        vm.restorePurchase()
-        inProgress.await().restoreInProgress shouldBe true
-
+        val vm = buildVm(repo).also { it.init(manage = true) }
+        vm.loaded()
         advanceUntilIdle()
-        vm.state.first { !it.restoreInProgress }.restoreInProgress shouldBe false
+
+        vm.onSwitchToIap(activity)
+        advanceUntilIdle()
+
+        vm.events.first() shouldBe UpgradeViewModel.UpgradeEvent.SubscriptionCheckFailed
+        coVerify(exactly = 0) { repo.launchBillingFlow(any(), any(), any()) }
     }
 
     @Test
-    fun `previously-pro on this device flows into the banner flag`() = runTest2(context = testDispatcher) {
-        val vm = buildVm(mockRepo(isPro = false, wasEverPro = true))
-
-        val state = async { vm.state.first { it.pricing != null } }
+    fun `switch launches the one-time purchase when no subscription is renewing`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo(skus = listOf(iapSkuDetails()))
+        coEvery { repo.queryCurrentSubscriptions() } returns listOf(purchase(MyPermSku.Sub.PRO_UPGRADE.id, autoRenew = false))
+        val vm = buildVm(repo).also { it.init(manage = true) }
+        vm.loaded()
         advanceUntilIdle()
 
-        state.await().wasPreviouslyPro shouldBe true
+        vm.onSwitchToIap(activity)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { repo.launchBillingFlow(activity, match { it.sku == MyPermSku.Iap.PRO_UPGRADE }, null) }
+    }
+
+    // --- manage vs sales nav -------------------------------------------------------------------
+
+    @Test
+    fun `sales mode closes the screen once the user becomes pro`() = runTest2(context = testDispatcher) {
+        val infoFlow = MutableStateFlow<UpgradeRepo.Info>(notProInfo())
+        val repo = mockRepo().apply { every { upgradeInfo } returns infoFlow }
+        val vm = buildVm(repo).also { it.init(manage = false) }
+
+        val navEvents = mutableListOf<NavEvent>()
+        val collector = launch { vm.navEvents.collect { navEvents.add(it) } }
+        advanceUntilIdle()
+
+        infoFlow.value = iapOwnedInfo()
+        advanceUntilIdle()
+
+        navEvents.any { it is NavEvent.Up } shouldBe true
+        collector.cancel()
     }
 
     @Test
-    fun `banner flag stays off while grace still keeps the user pro`() = runTest2(context = testDispatcher) {
-        val vm = buildVm(mockRepo(isPro = true, wasEverPro = true))
+    fun `manage mode stays open when the user is pro`() = runTest2(context = testDispatcher) {
+        val infoFlow = MutableStateFlow<UpgradeRepo.Info>(iapOwnedInfo())
+        val repo = mockRepo().apply { every { upgradeInfo } returns infoFlow }
+        val vm = buildVm(repo).also { it.init(manage = true) }
 
-        val state = async { vm.state.first { it.pricing != null } }
+        val navEvents = mutableListOf<NavEvent>()
+        val collector = launch { vm.navEvents.collect { navEvents.add(it) } }
         advanceUntilIdle()
 
-        state.await().wasPreviouslyPro shouldBe false
+        navEvents.none { it is NavEvent.Up } shouldBe true
+        collector.cancel()
     }
+
+    // --- direct buy ----------------------------------------------------------------------------
 
     @Test
     fun `user cancel during the billing flow stays silent`() = runTest2(context = testDispatcher) {
-        val repo = mockRepo()
-        coEvery { repo.querySkus() } returns listOf(iapSkuDetails())
+        val repo = mockRepo(skus = listOf(iapSkuDetails()))
         coEvery { repo.launchBillingFlow(any(), any(), null) } throws
             UserCanceledBillingException(result(BillingResponseCode.USER_CANCELED))
-        val vm = buildVm(repo)
+        val vm = buildVm(repo).also { it.init(manage = false) }
+        vm.state.first { it is UpgradeUiState.Loaded && it.pricing.iap != null }
 
         val errors = mutableListOf<Throwable>()
         val collector = launch { vm.errorEvents.collect { errors.add(it) } }
-
-        val ready = async { vm.state.first { it.pricing?.iap != null } }
-        advanceUntilIdle()
-        ready.await()
-
-        vm.launchBillingIap(activity)
+        vm.onBuyIap(activity)
         advanceUntilIdle()
 
         errors shouldBe emptyList()
@@ -224,106 +267,37 @@ class UpgradeViewModelTest : BaseTest() {
     }
 
     @Test
-    fun `already-owned buy attempt silently restores the purchase instead of erroring`() =
-        runTest2(context = testDispatcher) {
-            val repo = mockRepo()
-            coEvery { repo.querySkus() } returns listOf(iapSkuDetails())
-            coEvery { repo.launchBillingFlow(any(), any(), null) } throws
-                ItemAlreadyOwnedBillingException(result(BillingResponseCode.ITEM_ALREADY_OWNED))
-            coEvery { repo.restorePurchaseNow() } returns info(isPro = true)
-            val vm = buildVm(repo)
+    fun `already-owned buy attempt restores when the exact sku comes back`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo(skus = listOf(iapSkuDetails()))
+        coEvery { repo.launchBillingFlow(any(), any(), null) } throws
+            ItemAlreadyOwnedBillingException(result(BillingResponseCode.ITEM_ALREADY_OWNED))
+        coEvery { repo.restorePurchaseNow() } returns iapOwnedInfo()
+        val vm = buildVm(repo).also { it.init(manage = false) }
+        vm.state.first { it is UpgradeUiState.Loaded && it.pricing.iap != null }
 
-            val errors = mutableListOf<Throwable>()
-            val collector = launch { vm.errorEvents.collect { errors.add(it) } }
-
-            val ready = async { vm.state.first { it.pricing?.iap != null } }
-            advanceUntilIdle()
-            ready.await()
-
-            vm.launchBillingIap(activity)
-            advanceUntilIdle()
-
-            errors shouldBe emptyList()
-            coVerify(exactly = 1) { repo.restorePurchaseNow() }
-            collector.cancel()
-        }
-
-    @Test
-    fun `already-owned buy attempt falls back to the error dialog when restore finds nothing`() =
-        runTest2(context = testDispatcher) {
-            val repo = mockRepo()
-            coEvery { repo.querySkus() } returns listOf(iapSkuDetails())
-            coEvery { repo.launchBillingFlow(any(), any(), null) } throws
-                ItemAlreadyOwnedBillingException(result(BillingResponseCode.ITEM_ALREADY_OWNED))
-            coEvery { repo.restorePurchaseNow() } returns info(isPro = false)
-            val vm = buildVm(repo)
-
-            val ready = async { vm.state.first { it.pricing?.iap != null } }
-            advanceUntilIdle()
-            ready.await()
-
-            vm.launchBillingIap(activity)
-            advanceUntilIdle()
-
-            vm.errorEvents.first().shouldBeInstanceOf<ItemAlreadyOwnedBillingException>()
-        }
-
-    @Test
-    fun `already-owned buy attempt falls back to the error dialog when restore itself errors`() =
-        runTest2(context = testDispatcher) {
-            val repo = mockRepo()
-            coEvery { repo.querySkus() } returns listOf(iapSkuDetails())
-            coEvery { repo.launchBillingFlow(any(), any(), null) } throws
-                ItemAlreadyOwnedBillingException(result(BillingResponseCode.ITEM_ALREADY_OWNED))
-            coEvery { repo.restorePurchaseNow() } throws RuntimeException("Play unavailable")
-            val vm = buildVm(repo)
-
-            val ready = async { vm.state.first { it.pricing?.iap != null } }
-            advanceUntilIdle()
-            ready.await()
-
-            vm.launchBillingIap(activity)
-            advanceUntilIdle()
-
-            vm.errorEvents.first().shouldBeInstanceOf<ItemAlreadyOwnedBillingException>()
-        }
-
-    @Test
-    fun `consecutive unequal pro emissions trigger a single navUp`() = runTest2(context = testDispatcher) {
-        val infoFlow = MutableStateFlow<UpgradeRepo.Info>(info(isPro = false))
-        val repo = mockRepo()
-        every { repo.upgradeInfo } returns infoFlow
-        val vm = buildVm(repo)
-
-        val navEvents = mutableListOf<Any>()
-        val collector = launch { vm.navEvents.collect { navEvents.add(it) } }
+        val errors = mutableListOf<Throwable>()
+        val collector = launch { vm.errorEvents.collect { errors.add(it) } }
+        vm.onBuyIap(activity)
         advanceUntilIdle()
 
-        // Two Pro Infos with different backing data — unequal objects, both isPro.
-        infoFlow.value = UpgradeRepoGplay.Info(gracePeriod = true, billingData = null)
-        advanceUntilIdle()
-        infoFlow.value = UpgradeRepoGplay.Info(gracePeriod = true, billingData = BillingData(emptySet()))
-        advanceUntilIdle()
-
-        navEvents.size shouldBe 1
+        errors shouldBe emptyList()
+        coVerify(exactly = 1) { repo.restorePurchaseNow() }
         collector.cancel()
     }
 
     @Test
-    fun `other launch failures are forwarded to the error dialog`() = runTest2(context = testDispatcher) {
-        val repo = mockRepo()
-        val boom = IllegalStateException("launch broke")
-        coEvery { repo.querySkus() } returns listOf(iapSkuDetails())
-        coEvery { repo.launchBillingFlow(any(), any(), null) } throws boom
-        val vm = buildVm(repo)
+    fun `direct buy is also gated and blocks while a subscription is renewing`() = runTest2(context = testDispatcher) {
+        // Even the ordinary "Buy" button (e.g. exposed during a grace window) must not launch the
+        // one-time purchase while a subscription is still auto-renewing.
+        val repo = mockRepo(skus = listOf(iapSkuDetails()))
+        coEvery { repo.queryCurrentSubscriptions() } returns listOf(purchase(MyPermSku.Sub.PRO_UPGRADE.id, autoRenew = true))
+        val vm = buildVm(repo).also { it.init(manage = false) }
+        vm.state.first { it is UpgradeUiState.Loaded && it.pricing.iap != null }
 
-        val ready = async { vm.state.first { it.pricing?.iap != null } }
-        advanceUntilIdle()
-        ready.await()
-
-        vm.launchBillingIap(activity)
+        vm.onBuyIap(activity)
         advanceUntilIdle()
 
-        vm.errorEvents.first() shouldBe boom
+        vm.events.first() shouldBe UpgradeViewModel.UpgradeEvent.SubscriptionStillRenewing
+        coVerify(exactly = 0) { repo.launchBillingFlow(any(), any(), any()) }
     }
 }


### PR DESCRIPTION
## What changed

Permission Pilot Pro can now be managed from a new entry in Settings. If you already have Pro, opening it shows your current status — whether you're on the subscription or the one-time purchase — instead of the screen immediately closing the moment you're recognised as Pro.

If you subscribed and later set the subscription not to renew, you can now switch to the permanent one-time purchase before it lapses. While the subscription is still renewing, that option stays locked with a note to cancel it in Google Play first — and the app re-checks with Google Play right before any purchase, so you're never charged for both.

The open-source (FOSS) build gets a matching status screen: whether you're a supporter, since when, and a gentle nudge to sponsor again.

## Technical Context

- **Switch gate (money path):** every one-time purchase — the sales "Buy" button and the ownership "switch" — is gated on a fresh, fail-closed Google Play subscription check that reads `Purchase.isAutoRenewing` (never read before). The check retries until it completes without a purchase/cancel callback racing it (tracked via a listener generation counter) and refuses to launch otherwise; it throws — and the caller fails closed — when it can't get a stable read. See `BillingClientConnection.verifyStableSubscriptions` and `UpgradeViewModel.verifyThenLaunchIap`.
- **Manage mode:** the upgrade route gains a `manage` flag. Feature-gate entries keep the old auto-close-on-Pro behaviour; the Settings entry opens in manage mode and stays open.
- **Grace presentation:** reuses the existing last-confirmed-Pro timestamp rather than adding a separate episode clock — it naturally ages during a Play outage, so the 24h "show diagnostics" boundary advances without a live refresh.
- **Acknowledgement:** re-acking a just-acked purchase is a documented Play no-op, so it stays unconditional (skipping a needed ack risks an auto-refund); a process-local token set only demotes the repeated logs to DEBUG.
- **Strings** are split by flavor: Play billing/status copy in `gplay`, supporter copy in `foss`, the neutral Settings description in `main`. English source only; translations arrive via Crowdin.
- Ported from `d4rken-org/sdmaid-se#2563`, with `d4rken-org/capod#638` and `d4rken-org/bluemusic#239` as references — including the follow-ups those PRs needed (restore feedback, grace-vs-pitch presentation, ack log spam, flavor string placement).
