### PR TITLE
General: Refine the upgrade screen and fix a clipped button

### DIFF
--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeOwnership.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeOwnership.kt
@@ -1,13 +1,17 @@
 package eu.darken.myperm.common.upgrade.ui
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.OpenInNew
 import androidx.compose.material.icons.twotone.Stars
@@ -16,7 +20,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -26,6 +30,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import eu.darken.myperm.R
@@ -54,6 +59,7 @@ fun OwnershipContent(
         OffersCard(
             pricing = state.pricing,
             enabled = state.isSettled && !state.actionBusy,
+            verificationInProgress = state.verificationInProgress,
             onSubscribe = onSubscribe,
             onBuyIap = onBuyIap,
         )
@@ -260,78 +266,131 @@ private fun GraceCard(
     }
 }
 
+// The "Upgrade options" card: header, subscription offer row, "or" divider, one-time offer row,
+// parity footnote. Subscription is the primary (filled) action, the one-time purchase is the
+// secondary (outlined) action — the button weight carries the hierarchy, no "recommended" badge.
 @Composable
 fun OffersCard(
     pricing: Pricing,
     enabled: Boolean,
+    verificationInProgress: Boolean,
     onSubscribe: () -> Unit,
     onBuyIap: () -> Unit,
 ) {
-    Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
-        if (pricing.subAvailable) {
-            Button(
-                onClick = onSubscribe,
-                enabled = enabled,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(52.dp),
-                shape = RoundedCornerShape(12.dp),
-            ) {
-                Icon(Icons.TwoTone.Stars, contentDescription = null, modifier = Modifier.size(20.dp))
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    text = stringResource(
-                        if (pricing.subscriptionAction == SubscriptionAction.TRIAL) {
-                            R.string.upgrade_screen_subscription_trial_action
-                        } else {
-                            R.string.upgrade_screen_subscription_action
-                        },
-                    ),
-                    style = MaterialTheme.typography.titleMedium,
+    if (!pricing.subAvailable && !pricing.iapAvailable) return
+
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(modifier = Modifier.padding(18.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    Icons.TwoTone.Stars,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
                 )
-            }
-            if (pricing.subPrice != null) {
+                Spacer(modifier = Modifier.width(10.dp))
                 Text(
-                    text = stringResource(R.string.upgrade_screen_subscription_action_hint_yearly, pricing.subPrice),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(top = 4.dp),
+                    text = stringResource(R.string.upgrade_screen_offers_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
                 )
             }
             Spacer(modifier = Modifier.height(12.dp))
-        }
 
-        if (pricing.iapAvailable) {
-            FilledTonalButton(
-                onClick = onBuyIap,
-                enabled = enabled,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(52.dp),
-                shape = RoundedCornerShape(12.dp),
-            ) {
-                Text(
-                    text = stringResource(R.string.upgrade_screen_iap_action),
-                    style = MaterialTheme.typography.titleMedium,
-                )
+            if (pricing.subAvailable) {
+                UpgradeOfferRow(
+                    title = stringResource(R.string.upgrade_screen_subscription_offer_title),
+                    price = pricing.subPrice,
+                    hint = stringResource(
+                        if (pricing.subscriptionAction == SubscriptionAction.TRIAL) {
+                            R.string.upgrade_screen_subscription_offer_body
+                        } else {
+                            R.string.upgrade_screen_subscription_offer_body_no_trial
+                        },
+                    ),
+                ) {
+                    Button(onClick = onSubscribe, enabled = enabled, modifier = Modifier.fillMaxWidth()) {
+                        Text(
+                            stringResource(
+                                if (pricing.subscriptionAction == SubscriptionAction.TRIAL) {
+                                    R.string.upgrade_screen_subscription_trial_action
+                                } else {
+                                    R.string.upgrade_screen_subscription_action
+                                },
+                            ),
+                        )
+                    }
+                }
             }
-            if (pricing.iapPrice != null) {
-                Text(
-                    text = stringResource(R.string.upgrade_screen_iap_action_hint, pricing.iapPrice),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(top = 4.dp),
-                )
-            }
-        }
 
-        Spacer(modifier = Modifier.height(8.dp))
+            if (pricing.subAvailable && pricing.iapAvailable) {
+                Spacer(modifier = Modifier.height(12.dp))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    HorizontalDivider(modifier = Modifier.weight(1f))
+                    Text(
+                        text = stringResource(R.string.upgrade_screen_offers_or),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    HorizontalDivider(modifier = Modifier.weight(1f))
+                }
+                Spacer(modifier = Modifier.height(12.dp))
+            }
+
+            if (pricing.iapAvailable) {
+                UpgradeOfferRow(
+                    title = stringResource(R.string.upgrade_screen_iap_offer_title),
+                    price = pricing.iapPrice,
+                    hint = stringResource(R.string.upgrade_screen_iap_offer_body),
+                ) {
+                    OutlinedButton(onClick = onBuyIap, enabled = enabled, modifier = Modifier.fillMaxWidth()) {
+                        if (verificationInProgress) {
+                            CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+                            Spacer(modifier = Modifier.width(8.dp))
+                        }
+                        Text(stringResource(R.string.upgrade_screen_iap_action))
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = stringResource(R.string.upgrade_screen_offers_body),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}
+
+// One offer: "title · price" on one line, a terms line, then the action button.
+@Composable
+private fun UpgradeOfferRow(
+    title: String,
+    price: String?,
+    hint: String,
+    content: @Composable () -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
         Text(
-            text = stringResource(R.string.upgrade_screen_options_description),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center,
+            text = listOfNotNull(title, price).joinToString(" · "),
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.SemiBold,
         )
+        Text(
+            text = hint,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        content()
     }
 }
 
@@ -406,23 +465,25 @@ fun RestoreBanner(
     }
 }
 
+// Shown after a restore comes up empty (or times out). Leads with the just-happened live Play
+// check, then the troubleshooting steps, and is the ONLY contact-support surface in the flow.
 @Composable
 fun FailedRestoreDialog(
     onContactSupport: () -> Unit,
     onDismiss: () -> Unit,
 ) {
+    val message = listOf(
+        stringResource(R.string.upgrade_screen_restore_checked_message),
+        stringResource(R.string.upgrade_screen_restore_multiaccount_hint),
+        stringResource(R.string.upgrade_screen_restore_sync_patience_hint),
+        stringResource(R.string.upgrade_screen_restore_contact_hint),
+    ).joinToString("\n\n")
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(stringResource(R.string.upgrade_screen_restore_status_title)) },
         text = {
-            Column {
-                Text(stringResource(R.string.upgrade_screen_restore_purchase_message))
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = stringResource(R.string.upgrade_screen_restore_webinstall_hint),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
+            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                Text(text = message, style = MaterialTheme.typography.bodyMedium)
             }
         },
         confirmButton = {
@@ -431,7 +492,44 @@ fun FailedRestoreDialog(
             }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) { Text(stringResource(R.string.general_cancel_action)) }
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.general_close_action)) }
+        },
+    )
+}
+
+// The switch was blocked because a subscription is still auto-renewing — offer the Play deep link
+// to cancel it there first.
+@Composable
+fun SubscriptionStillRenewingDialog(
+    onManageSubscription: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.upgrade_screen_sub_still_renewing_title)) },
+        text = { Text(stringResource(R.string.upgrade_screen_sub_still_renewing_message)) },
+        confirmButton = {
+            TextButton(onClick = { onDismiss(); onManageSubscription() }) {
+                Text(stringResource(R.string.upgrade_screen_manage_subscription_action))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.general_close_action)) }
+        },
+    )
+}
+
+// The pre-purchase subscription check couldn't complete (timeout/error) — fail closed and tell the
+// user to try again.
+@Composable
+fun SubscriptionCheckFailedDialog(
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        text = { Text(stringResource(R.string.upgrade_screen_sub_check_failed_message)) },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.general_close_action)) }
         },
     )
 }

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeScreen.kt
@@ -88,6 +88,8 @@ fun UpgradeScreenHost(
     val state by vm.state.collectAsState()
 
     var showRestoreFailedDialog by remember { mutableStateOf(false) }
+    var showStillRenewingDialog by remember { mutableStateOf(false) }
+    var showCheckFailedDialog by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) {
         vm.events.collect { event ->
             when (event) {
@@ -95,11 +97,8 @@ fun UpgradeScreenHost(
                 UpgradeViewModel.UpgradeEvent.RestoreSucceeded ->
                     Toast.makeText(context, R.string.upgrade_screen_restore_success_message, Toast.LENGTH_LONG).show()
 
-                UpgradeViewModel.UpgradeEvent.SubscriptionStillRenewing ->
-                    Toast.makeText(context, R.string.upgrade_screen_sub_still_renewing_message, Toast.LENGTH_LONG).show()
-
-                UpgradeViewModel.UpgradeEvent.SubscriptionCheckFailed ->
-                    Toast.makeText(context, R.string.upgrade_screen_sub_check_failed_message, Toast.LENGTH_LONG).show()
+                UpgradeViewModel.UpgradeEvent.SubscriptionStillRenewing -> showStillRenewingDialog = true
+                UpgradeViewModel.UpgradeEvent.SubscriptionCheckFailed -> showCheckFailedDialog = true
             }
         }
     }
@@ -109,6 +108,15 @@ fun UpgradeScreenHost(
             onContactSupport = { vm.onContactSupport() },
             onDismiss = { showRestoreFailedDialog = false },
         )
+    }
+    if (showStillRenewingDialog) {
+        SubscriptionStillRenewingDialog(
+            onManageSubscription = { vm.onManageSubscription() },
+            onDismiss = { showStillRenewingDialog = false },
+        )
+    }
+    if (showCheckFailedDialog) {
+        SubscriptionCheckFailedDialog(onDismiss = { showCheckFailedDialog = false })
     }
 
     UpgradeScreen(
@@ -257,6 +265,7 @@ private fun SalesContent(
     OffersCard(
         pricing = state.pricing,
         enabled = state.isSettled && !state.actionBusy,
+        verificationInProgress = state.verificationInProgress,
         onSubscribe = onSubscribe,
         onBuyIap = onBuyIap,
     )

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="upgrade_screen_subscription_trial_action">Start free trial</string>
     <string name="upgrade_screen_subscription_action">Subscribe</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/year, cancel anytime</string>
-    <string name="upgrade_screen_iap_action">Buy Pro</string>
+    <string name="upgrade_screen_iap_action">One-time purchase</string>
     <string name="upgrade_screen_iap_action_hint">One-time purchase of %s</string>
     <string name="upgrade_screen_restore_purchase_action">Restore purchase</string>
     <string name="upgrade_screen_restore_purchase_message">No purchases found. Check that you are signed in with the correct Google account.</string>
@@ -51,4 +51,23 @@
     <string name="upgrade_screen_restore_status_body">If you\'ve purchased Pro but it isn\'t showing, run a live check against Google Play.</string>
     <string name="upgrade_screen_restore_success_message">Purchase restored.</string>
     <string name="upgrade_screen_restore_webinstall_hint">Make sure you\'re signed in with the Google account you used to purchase. A live check against Google Play just ran.</string>
+
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Upgrade options</string>
+    <string name="upgrade_screen_offers_body">Same features, just different pricing models.</string>
+    <string name="upgrade_screen_offers_or">or</string>
+    <string name="upgrade_screen_subscription_offer_title">Yearly subscription</string>
+    <string name="upgrade_screen_subscription_offer_body">Renews yearly after the free trial. Cancel anytime in Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Renews yearly. Cancel anytime in Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Buy once</string>
+    <string name="upgrade_screen_iap_offer_body">One payment, no renewals.</string>
+
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">Subscription still active</string>
+
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Google Play was just checked, but no Pro purchase could be confirmed for the account it is using for this app.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Multiple accounts can confuse Google Play. Installing the app through the Google Play website forces it to associate with a specific account.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Google Play synchronization can take a while. Try rebooting, clearing the Google Play Store cache, or simply waiting.</string>
+    <string name="upgrade_screen_restore_contact_hint">Still stuck? Contact support from the email that made the purchase and include your Google Play order number.</string>
 </resources>

--- a/app/src/main/java/eu/darken/myperm/main/ui/MainScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/main/ui/MainScreen.kt
@@ -49,7 +49,14 @@ fun MainScreen(
         NavDisplay(
             modifier = Modifier
                 .weight(1f)
-                .consumeWindowInsets(WindowInsets.navigationBars),
+                // Only consume the navigation-bar inset when the bottom NavigationBar below actually
+                // occupies it (tab screens). Full-screen destinations (e.g. Upgrade) have no bottom
+                // bar, so they must keep the inset and pad their own content above the nav bar —
+                // otherwise the last element is clipped by the system navigation bar.
+                .then(
+                    if (isTabScreen) Modifier.consumeWindowInsets(WindowInsets.navigationBars)
+                    else Modifier,
+                ),
             backStack = backStack,
             onBack = {
                 if (!navCtrl.up()) {


### PR DESCRIPTION
## What changed

Polish for the Pro upgrade screen, bringing it closer to the sibling apps' look:

- **Upgrade options card.** The subscription and one-time purchase are now presented in a single "Upgrade options" card — each as an offer row with its title, price and terms, separated by an "or" divider, with the yearly subscription as the primary (filled) button and the one-time purchase as the secondary (outlined) button. Replaces the previous plain stacked buttons.
- **Better dialogs.** "Restore purchase" that comes up empty now shows a full troubleshooting sequence (what was just checked, the multiple-accounts / install-via-Play-website tip, sync patience, and how to contact support) instead of two lines. "Subscription still renewing" and "couldn't verify subscription" are now proper dialogs — the renewing one offers a **Manage subscription** shortcut — instead of quick toasts.
- **Fixed a clipped button.** On the upgrade screen (and other full-screen pages), the last button could sit partially under the system navigation bar. It now has the correct spacing above the nav bar.

## Technical Context

- **Inset fix (root cause):** `MainScreen` consumed the navigation-bar inset for *every* destination. That's correct for tab screens — the bottom `NavigationBar` occupies that space — but wrong for full-screen destinations like the upgrade screen, which then never re-applied it and drew content under the nav bar. Now the inset is consumed only for tab screens; the tab path is byte-for-byte unchanged, and full-screen destinations keep the inset and pad their own content.
- **UI only** — no billing or entitlement-logic changes. The offers card and dialogs are new presentation over the existing state/events.
- New strings are gplay-only (Play billing copy). The one-time button label is now "One-time purchase".
- Layout/wording follows `d4rken-org/sdmaid-se`'s upgrade screen (offer rows, "or" divider, filled/outlined button hierarchy, 4-step restore troubleshooting dialog), adapted to Permission Pilot's components and mascot.
