### PR TITLE
General: Add an offers-unavailable retry state to the Pro upgrade screen

### DIFF
--- a/app/src/foss/java/eu/darken/myperm/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/foss/java/eu/darken/myperm/common/upgrade/ui/UpgradeScreen.kt
@@ -3,7 +3,6 @@ package eu.darken.myperm.common.upgrade.ui
 import android.text.format.DateFormat
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -11,17 +10,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
-import androidx.compose.material.icons.twotone.Code
 import androidx.compose.material.icons.twotone.Favorite
-import androidx.compose.material.icons.twotone.FileDownload
-import androidx.compose.material.icons.twotone.Notifications
-import androidx.compose.material.icons.twotone.Palette
-import androidx.compose.material.icons.twotone.Tune
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -33,7 +26,6 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -43,20 +35,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import eu.darken.myperm.R
-import eu.darken.myperm.common.compose.PermPilotMascot
 import eu.darken.myperm.common.error.ErrorEventHandler
 import eu.darken.myperm.common.navigation.NavigationEventHandler
 import java.time.Instant
@@ -103,17 +89,6 @@ fun UpgradeScreenHost(
     )
 }
 
-private data class Benefit(val icon: ImageVector, val textRes: Int)
-
-private val upgradeBenefits = listOf(
-    Benefit(Icons.TwoTone.Palette, R.string.upgrade_benefit_themes),
-    Benefit(Icons.TwoTone.Tune, R.string.upgrade_benefit_filtering),
-    Benefit(Icons.TwoTone.FileDownload, R.string.upgrade_benefit_export),
-    Benefit(Icons.TwoTone.Notifications, R.string.upgrade_benefit_monitoring),
-    Benefit(Icons.TwoTone.Code, R.string.upgrade_benefit_manifest_viewer),
-    Benefit(Icons.TwoTone.Favorite, R.string.upgrade_benefit_support),
-)
-
 @Composable
 fun UpgradeScreen(
     state: UpgradeViewModel.State,
@@ -134,7 +109,11 @@ fun UpgradeScreen(
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 Spacer(modifier = Modifier.height(16.dp))
-                UpgradeHeader()
+                UpgradeMascotHeader(
+                    circleColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.5f),
+                    suffixColor = MaterialTheme.colorScheme.secondary,
+                    titleColor = MaterialTheme.colorScheme.onSurface,
+                )
                 Spacer(modifier = Modifier.height(24.dp))
 
                 when (state.view) {
@@ -162,34 +141,16 @@ fun UpgradeScreen(
 }
 
 @Composable
-private fun UpgradeHeader() {
-    Box(contentAlignment = Alignment.Center) {
-        Surface(
-            modifier = Modifier.size(120.dp),
-            shape = CircleShape,
-            color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.5f),
-        ) {}
-        PermPilotMascot(size = 80.dp)
-    }
-    Spacer(modifier = Modifier.height(16.dp))
-    Text(
-        text = buildAnnotatedString {
-            append(stringResource(R.string.upgrade_title_prefix))
-            append(" ")
-            withStyle(SpanStyle(color = MaterialTheme.colorScheme.secondary, fontWeight = FontWeight.Bold)) {
-                append(stringResource(R.string.upgrade_title_suffix))
-            }
-        },
-        style = MaterialTheme.typography.headlineLarge,
-        color = MaterialTheme.colorScheme.onSurface,
-    )
-}
-
-@Composable
 private fun PitchContent(onSponsor: () -> Unit) {
-    PreambleCard(R.string.upgrade_foss_preamble)
+    UpgradePreambleCard(
+        text = stringResource(R.string.upgrade_foss_preamble),
+        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+    )
     Spacer(modifier = Modifier.height(16.dp))
-    BenefitsCard()
+    UpgradeBenefitsCard(
+        chipColor = MaterialTheme.colorScheme.secondaryContainer,
+        chipContentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+    )
     Spacer(modifier = Modifier.height(16.dp))
     SponsorButton(labelRes = R.string.upgrade_foss_sponsor_action, onClick = onSponsor)
     Text(
@@ -207,7 +168,10 @@ private fun FreeStatusContent(onSponsor: () -> Unit) {
         bodyRes = R.string.upgrade_screen_status_free_body,
     )
     Spacer(modifier = Modifier.height(16.dp))
-    BenefitsCard()
+    UpgradeBenefitsCard(
+        chipColor = MaterialTheme.colorScheme.secondaryContainer,
+        chipContentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+    )
     Spacer(modifier = Modifier.height(16.dp))
     SponsorButton(labelRes = R.string.upgrade_screen_status_free_action, onClick = onSponsor)
 }
@@ -265,59 +229,12 @@ private fun UpgradedStatusContent(
 }
 
 @Composable
-private fun PreambleCard(bodyRes: Int) {
-    Card(
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer),
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        Text(
-            text = stringResource(bodyRes),
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.padding(16.dp),
-        )
-    }
-}
-
-@Composable
 private fun StatusCard(titleRes: Int, bodyRes: Int) {
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(16.dp)) {
             Text(text = stringResource(titleRes), style = MaterialTheme.typography.titleMedium)
             Spacer(modifier = Modifier.height(8.dp))
             Text(text = stringResource(bodyRes), style = MaterialTheme.typography.bodyMedium)
-        }
-    }
-}
-
-@Composable
-private fun BenefitsCard() {
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(modifier = Modifier.padding(vertical = 4.dp)) {
-            upgradeBenefits.forEach { benefit ->
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 12.dp, vertical = 4.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Surface(
-                        shape = RoundedCornerShape(8.dp),
-                        color = MaterialTheme.colorScheme.secondaryContainer,
-                        modifier = Modifier.size(28.dp),
-                    ) {
-                        Box(contentAlignment = Alignment.Center) {
-                            Icon(
-                                imageVector = benefit.icon,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                                modifier = Modifier.size(16.dp),
-                            )
-                        }
-                    }
-                    Spacer(modifier = Modifier.width(12.dp))
-                    Text(text = stringResource(benefit.textRes), style = MaterialTheme.typography.bodyLarge)
-                }
-            }
         }
     }
 }

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/UpgradeRepoGplay.kt
@@ -27,7 +27,9 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
@@ -86,6 +88,20 @@ class UpgradeRepoGplay @Inject constructor(
             },
         manualInfo,
     ).stateIn(scope, SharingStarted.Eagerly, cachedInfo())
+
+    // True once billing has published its first real reconciliation (a value beyond the cached seed),
+    // so callers can trust upgradeInfo as authoritative rather than a cold-cache guess. Derived from
+    // upgradeInfo itself and started Eagerly at the same time, so `drop(1)` skips only the seed and the
+    // flag can never be observed true before the value it certifies is already upgradeInfo.value — this
+    // is what prevents pairing "settled" with a stale non-Pro snapshot on a cold start. A fallback timer
+    // flips it during a total outage (no emission at all) so purchase actions can't stay disabled forever.
+    val isSettled: StateFlow<Boolean> = merge(
+        upgradeInfo.drop(1).map { true },
+        flow {
+            delay(SETTLE_FALLBACK_MS)
+            emit(true)
+        },
+    ).stateIn(scope, SharingStarted.Eagerly, false)
 
     // True once this install has ever confirmed a known Pro purchase; drives the proactive restore
     // banner. Local signal only — a fresh install or a switched Google account starts false.
@@ -300,6 +316,10 @@ class UpgradeRepoGplay @Inject constructor(
         private const val RETRY_DELAY_MS = 60_000L                         // 1min before re-subscribing
         private const val RESTORE_ON_OWNED_TIMEOUT_MS = 15_000L
         private const val REFRESH_TIMEOUT_MS = 30_000L
+
+        // Fallback for isSettled during a total Play outage (no billing emission at all), so purchase
+        // actions don't stay disabled forever.
+        internal const val SETTLE_FALLBACK_MS = 10_000L
 
         private fun BillingData.getProSku(): PurchasedSku? = purchasedSkus
             .firstOrNull { it.sku in MyPermSku.PRO_SKUS }

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeOwnership.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeOwnership.kt
@@ -84,7 +84,10 @@ fun OwnershipContent(
                 iapPrice = state.pricing.iapPrice,
                 switchUnlocked = state.switchUnlocked,
                 verificationInProgress = state.verificationInProgress,
-                enabled = state.isSettled && !state.actionBusy,
+                // Also require the one-time SkuDetails to be loaded: without it the launch can't run,
+                // so an enabled button would be a dead tap (the catalog may have failed to load for a
+                // Pro user, who still reaches this ownership screen).
+                enabled = state.isSettled && !state.actionBusy && state.pricing.iapAvailable,
                 onSwitchToIap = onSwitchToIap,
             )
         }

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeScreen.kt
@@ -5,36 +5,20 @@ import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
-import androidx.compose.material.icons.twotone.Code
-import androidx.compose.material.icons.twotone.Favorite
-import androidx.compose.material.icons.twotone.FileDownload
-import androidx.compose.material.icons.twotone.Notifications
-import androidx.compose.material.icons.twotone.Palette
-import androidx.compose.material.icons.twotone.Tune
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -44,13 +28,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
@@ -58,7 +37,6 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.runtime.DisposableEffect
 import eu.darken.myperm.R
-import eu.darken.myperm.common.compose.PermPilotMascot
 import eu.darken.myperm.common.error.ErrorEventHandler
 import eu.darken.myperm.common.navigation.NavigationEventHandler
 
@@ -131,17 +109,6 @@ fun UpgradeScreenHost(
     )
 }
 
-private data class Benefit(val icon: ImageVector, val textRes: Int)
-
-private val upgradeBenefits = listOf(
-    Benefit(Icons.TwoTone.Palette, R.string.upgrade_benefit_themes),
-    Benefit(Icons.TwoTone.Tune, R.string.upgrade_benefit_filtering),
-    Benefit(Icons.TwoTone.FileDownload, R.string.upgrade_benefit_export),
-    Benefit(Icons.TwoTone.Notifications, R.string.upgrade_benefit_monitoring),
-    Benefit(Icons.TwoTone.Code, R.string.upgrade_benefit_manifest_viewer),
-    Benefit(Icons.TwoTone.Favorite, R.string.upgrade_benefit_support),
-)
-
 @Composable
 fun UpgradeScreen(
     state: UpgradeUiState,
@@ -161,7 +128,11 @@ fun UpgradeScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Spacer(modifier = Modifier.height(16.dp))
-            UpgradeHeader()
+            UpgradeMascotHeader(
+                circleColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f),
+                suffixColor = MaterialTheme.colorScheme.tertiary,
+                titleColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
             Spacer(modifier = Modifier.height(24.dp))
 
             when (state) {
@@ -208,30 +179,6 @@ fun UpgradeScreen(
 }
 
 @Composable
-private fun UpgradeHeader() {
-    Box(contentAlignment = Alignment.Center) {
-        Surface(
-            modifier = Modifier.size(120.dp),
-            shape = CircleShape,
-            color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f),
-        ) {}
-        PermPilotMascot(size = 80.dp)
-    }
-    Spacer(modifier = Modifier.height(16.dp))
-    Text(
-        text = buildAnnotatedString {
-            append(stringResource(R.string.upgrade_title_prefix))
-            append(" ")
-            withStyle(SpanStyle(color = MaterialTheme.colorScheme.tertiary, fontWeight = FontWeight.Bold)) {
-                append(stringResource(R.string.upgrade_title_suffix))
-            }
-        },
-        style = MaterialTheme.typography.headlineLarge,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-    )
-}
-
-@Composable
 private fun SalesContent(
     state: UpgradeUiState.Loaded,
     onSubscribe: () -> Unit,
@@ -247,19 +194,16 @@ private fun SalesContent(
         Spacer(modifier = Modifier.height(24.dp))
     }
 
-    Card(
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer),
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        Text(
-            text = stringResource(R.string.upgrade_screen_preamble),
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.padding(16.dp),
-        )
-    }
+    UpgradePreambleCard(
+        text = stringResource(R.string.upgrade_screen_preamble),
+        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+    )
 
     Spacer(modifier = Modifier.height(24.dp))
-    BenefitsCard()
+    UpgradeBenefitsCard(
+        chipColor = MaterialTheme.colorScheme.primaryContainer,
+        chipContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+    )
     Spacer(modifier = Modifier.height(24.dp))
 
     OffersCard(
@@ -276,40 +220,4 @@ private fun SalesContent(
         enabled = state.isSettled && !state.actionBusy,
         onRestore = onRestore,
     )
-}
-
-@Composable
-private fun BenefitsCard() {
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(modifier = Modifier.padding(vertical = 4.dp)) {
-            upgradeBenefits.forEach { benefit ->
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 12.dp, vertical = 4.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Surface(
-                        shape = RoundedCornerShape(8.dp),
-                        color = MaterialTheme.colorScheme.primaryContainer,
-                        modifier = Modifier.size(28.dp),
-                    ) {
-                        Box(contentAlignment = Alignment.Center) {
-                            Icon(
-                                imageVector = benefit.icon,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                                modifier = Modifier.size(16.dp),
-                            )
-                        }
-                    }
-                    Spacer(modifier = Modifier.width(12.dp))
-                    Text(
-                        text = stringResource(benefit.textRes),
-                        style = MaterialTheme.typography.bodyLarge,
-                    )
-                }
-            }
-        }
-    }
 }

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeScreen.kt
@@ -3,10 +3,13 @@ package eu.darken.myperm.common.upgrade.ui
 import android.app.Activity
 import android.util.Log
 import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
@@ -15,10 +18,15 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
+import androidx.compose.material.icons.twotone.WarningAmber
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -106,6 +114,7 @@ fun UpgradeScreenHost(
         onRestore = { vm.onRestore() },
         onManageSubscription = { vm.onManageSubscription() },
         onContactSupport = { vm.onContactSupport() },
+        onRetry = { vm.retrySkuQuery() },
     )
 }
 
@@ -119,6 +128,7 @@ fun UpgradeScreen(
     onRestore: () -> Unit,
     onManageSubscription: () -> Unit,
     onContactSupport: () -> Unit,
+    onRetry: () -> Unit,
 ) {
     Box(modifier = Modifier.windowInsetsPadding(WindowInsets.systemBars)) {
         Column(
@@ -139,6 +149,8 @@ fun UpgradeScreen(
                 UpgradeUiState.Loading -> {
                     CircularProgressIndicator(modifier = Modifier.padding(16.dp))
                 }
+
+                is UpgradeUiState.Unavailable -> UnavailableContent(onRetry = onRetry)
 
                 is UpgradeUiState.Loaded -> {
                     if (state.showOwnership) {
@@ -194,16 +206,7 @@ private fun SalesContent(
         Spacer(modifier = Modifier.height(24.dp))
     }
 
-    UpgradePreambleCard(
-        text = stringResource(R.string.upgrade_screen_preamble),
-        containerColor = MaterialTheme.colorScheme.secondaryContainer,
-    )
-
-    Spacer(modifier = Modifier.height(24.dp))
-    UpgradeBenefitsCard(
-        chipColor = MaterialTheme.colorScheme.primaryContainer,
-        chipContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-    )
+    SalesPitch()
     Spacer(modifier = Modifier.height(24.dp))
 
     OffersCard(
@@ -220,4 +223,73 @@ private fun SalesContent(
         enabled = state.isSettled && !state.actionBusy,
         onRestore = onRestore,
     )
+}
+
+// The purchase options couldn't be loaded and the user isn't Pro. The pitch still renders (nothing is
+// owned), with an inline warning + retry in place of the offers — and no restore section, matching the
+// "nothing to reconcile yet" framing.
+@Composable
+private fun UnavailableContent(onRetry: () -> Unit) {
+    SalesPitch()
+    Spacer(modifier = Modifier.height(24.dp))
+    UpgradeInlineStateCard(
+        title = stringResource(R.string.upgrade_screen_offers_unavailable_title),
+        body = stringResource(R.string.upgrade_screen_offers_unavailable_message),
+        onRetry = onRetry,
+    )
+}
+
+// Shared preamble + benefits pitch, rendered on both the sales and the offers-unavailable screens.
+@Composable
+private fun SalesPitch() {
+    UpgradePreambleCard(
+        text = stringResource(R.string.upgrade_screen_preamble),
+        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+    )
+    Spacer(modifier = Modifier.height(24.dp))
+    UpgradeBenefitsCard(
+        chipColor = MaterialTheme.colorScheme.primaryContainer,
+        chipContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+    )
+}
+
+@Composable
+private fun UpgradeInlineStateCard(
+    title: String,
+    body: String,
+    onRetry: () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer,
+            contentColor = MaterialTheme.colorScheme.onErrorContainer,
+        ),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(18.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.TwoTone.WarningAmber,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onErrorContainer,
+                )
+                Text(text = title, style = MaterialTheme.typography.titleMedium)
+            }
+            Text(text = body, style = MaterialTheme.typography.bodyMedium)
+            OutlinedButton(
+                onClick = onRetry,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.general_retry_action))
+            }
+        }
+    }
 }

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeUiState.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeUiState.kt
@@ -47,6 +47,11 @@ data class Pricing(
 sealed interface UpgradeUiState {
     data object Loading : UpgradeUiState
 
+    // The purchase-option query failed (or Google Play returned no usable offers) and the user is not
+    // already Pro, so there is nothing to buy and no status to show — the screen offers a retry. Owners
+    // and grace users never reach this: a failed price query is not their problem (see the ViewModel).
+    data class Unavailable(val error: Throwable) : UpgradeUiState
+
     data class Loaded(
         val manageMode: Boolean,
         val isPro: Boolean,

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModel.kt
@@ -16,6 +16,7 @@ import eu.darken.myperm.common.navigation.Nav
 import eu.darken.myperm.common.uix.ViewModel4
 import eu.darken.myperm.common.upgrade.core.MyPermSku
 import eu.darken.myperm.common.upgrade.core.UpgradeRepoGplay
+import eu.darken.myperm.common.upgrade.core.client.GplayServiceUnavailableException
 import eu.darken.myperm.common.upgrade.core.client.ItemAlreadyOwnedBillingException
 import eu.darken.myperm.common.upgrade.core.client.UserCanceledBillingException
 import eu.darken.myperm.common.upgrade.core.data.Sku
@@ -28,11 +29,13 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
@@ -60,11 +63,21 @@ class UpgradeViewModel @Inject constructor(
     // Single money-path guard: restore, switch-verification and purchase launch are mutually exclusive.
     private val action = MutableStateFlow(ActionState.IDLE)
 
-    // Billing has completed its first reconciliation (or the fallback elapsed). Purchase actions stay
-    // disabled until then so a cold-start empty snapshot can't offer acquisition to an existing owner.
-    private val settled = MutableStateFlow(false)
+    // Bumped to re-run the offer query (manual retry, or an on-resume retry after a failure).
+    private val retryTrigger = MutableStateFlow(0)
 
-    private val pricing = MutableStateFlow<Pricing?>(null)
+    // Query-status of the purchase offers. Kept as a VM-lifetime hot flow (Eagerly), NOT a cold flow
+    // folded into the combined UI state: that way backgrounding the screen (which drops the state
+    // subscription after 5s) can't discard a loaded catalog and re-query with a loading flash on
+    // return. flatMapLatest cancels an in-flight query when a newer retry supersedes it.
+    private val pricingState: StateFlow<PricingState> = retryTrigger
+        .flatMapLatest {
+            flow {
+                emit(PricingState.Pending)
+                emit(queryPricing())
+            }
+        }
+        .stateIn(vmScope, SharingStarted.Eagerly, PricingState.Pending)
 
     // Re-evaluates the 24h grace-diagnostics boundary while the screen is open (the boundary is
     // derived from a wall-clock timestamp, so combined flows alone won't re-fire when it elapses).
@@ -76,17 +89,31 @@ class UpgradeViewModel @Inject constructor(
     }
 
     val state: StateFlow<UpgradeUiState> = combine(
-        pricing,
+        pricingState,
         upgradeRepo.upgradeInfo,
         upgradeRepo.wasEverPro,
         upgradeRepo.lastProConfirmedAt,
-        combine(settled, action, manageMode.filterNotNull(), graceTick) { s, a, m, _ -> Triple(s, a, m) },
-    ) { pricing, info, wasEverPro, lastProAt, (isSettled, action, manage) ->
-        val gplayInfo = info as? UpgradeRepoGplay.Info ?: UpgradeRepoGplay.Info(billingData = null)
-        toLoadedState(
+        combine(upgradeRepo.isSettled, action, manageMode.filterNotNull(), graceTick) { s, a, m, _ -> Triple(s, a, m) },
+    ) { pricing, _, wasEverPro, lastProAt, (isSettled, action, manage) ->
+        // Resolve the freshest upgradeInfo rather than trusting this combine slot's value. isSettled
+        // is derived from upgradeInfo and flips true only AFTER upgradeInfo.value is reconciled, but
+        // `combine` provides no ordering between its branches — the isSettled branch can fire while the
+        // info branch still holds the pre-reconciliation snapshot. Reading .value guarantees that
+        // whenever isSettled is true we pair it with the reconciled Info, never a stale non-Pro one
+        // (which would briefly flash Unavailable, or enabled sales actions, to an owner on cold start).
+        // The upgradeInfo branch is still present in combine() above solely to trigger recomputation
+        // when the Info changes.
+        val gplayInfo = upgradeRepo.upgradeInfo.value as? UpgradeRepoGplay.Info
+            ?: UpgradeRepoGplay.Info(billingData = null)
+        // Owners AND grace users are Pro: their status/management surface renders regardless of the
+        // offer catalog, so a pending or failed price query never blocks them (Loading) nor errors
+        // them out (Unavailable). Only a genuine, settled, non-Pro buyer sees Unavailable.
+        val priceIndependent = gplayInfo.isPro
+
+        fun loaded(resolved: Pricing) = toLoadedState(
             manageMode = manage,
             info = gplayInfo,
-            pricing = pricing ?: Pricing(),
+            pricing = resolved,
             lastProConfirmedAt = lastProAt,
             now = System.currentTimeMillis(),
             isSettled = isSettled,
@@ -94,11 +121,30 @@ class UpgradeViewModel @Inject constructor(
             wasEverPro = wasEverPro,
             graceDiagnosticsAfterMs = GRACE_DIAGNOSTICS_AFTER_MS,
         )
+
+        when (pricing) {
+            is PricingState.Ready -> loaded(pricing.pricing)
+            PricingState.Pending -> if (isSettled && priceIndependent) loaded(Pricing()) else UpgradeUiState.Loading
+            is PricingState.Failed -> when {
+                priceIndependent -> loaded(Pricing())
+                !isSettled -> UpgradeUiState.Loading
+                else -> UpgradeUiState.Unavailable(pricing.error)
+            }
+        }
     }.stateIn(vmScope, SharingStarted.WhileSubscribed(5_000), UpgradeUiState.Loading)
 
     init {
-        launch { loadPricingNow() }
-        settle()
+        // Kick off the first billing reconciliation; the repo's isSettled flips once it publishes.
+        // (The offer query is started separately by pricingState's Eagerly sharing.)
+        launch {
+            try {
+                upgradeRepo.refresh()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log(TAG, WARN) { "Initial refresh failed: ${e.asLog()}" }
+            }
+        }
     }
 
     fun init(manage: Boolean) {
@@ -127,49 +173,56 @@ class UpgradeViewModel @Inject constructor(
         } catch (e: Exception) {
             log(TAG, WARN) { "onResume refresh failed: ${e.asLog()}" }
         }
-        val current = pricing.value
-        if (current == null || (!current.subAvailable && !current.iapAvailable)) {
-            loadPricingNow()
-        }
+        // Retry the offer query only if the last attempt failed. Ready = usable offers already loaded;
+        // Pending = a query is in flight, restarting it would only cause a needless loading flash.
+        if (pricingState.value is PricingState.Failed) retrySkuQuery()
     }
 
-    private suspend fun loadPricingNow() {
+    // Re-run the offer query (from the Unavailable card's retry button, or on-resume after a failure).
+    fun retrySkuQuery() {
+        log(TAG) { "retrySkuQuery()" }
+        retryTrigger.update { it + 1 }
+    }
+
+    private suspend fun queryPricing(): PricingState {
         val skuDetails = try {
             withTimeoutOrNull(SKU_QUERY_TIMEOUT_MS) { upgradeRepo.querySkus() }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             log(TAG, WARN) { "Failed to query SKUs: ${e.asLog()}" }
-            null
+            return PricingState.Failed(GplayServiceUnavailableException(e))
+        } ?: run {
+            log(TAG, WARN) { "SKU query timed out" }
+            return PricingState.Failed(GplayServiceUnavailableException(RuntimeException("SKU query timed out")))
         }
 
-        val iapDetails = skuDetails?.firstOrNull { it.sku.type == Sku.Type.IAP }
-        val subDetails = skuDetails?.firstOrNull { it.sku.type == Sku.Type.SUBSCRIPTION }
+        val iapDetails = skuDetails.firstOrNull { it.sku.type == Sku.Type.IAP }
+        val subDetails = skuDetails.firstOrNull { it.sku.type == Sku.Type.SUBSCRIPTION }
         val subOffers = subDetails?.details?.subscriptionOfferDetails
         val baseOffer = subOffers?.firstOrNull { MyPermSku.Sub.BASE_OFFER.matches(it) }
         val hasTrialOffer = subOffers?.any { MyPermSku.Sub.TRIAL_OFFER.matches(it) } == true
 
-        pricing.value = Pricing(
+        val pricing = Pricing(
             iap = iapDetails,
             sub = subDetails,
             subPrice = baseOffer?.pricingPhases?.pricingPhaseList?.lastOrNull()?.formattedPrice,
             iapPrice = iapDetails?.details?.oneTimePurchaseOfferDetails?.formattedPrice,
             hasTrialOffer = hasTrialOffer,
         )
-    }
-
-    private fun settle() = launch {
-        // Flip settled after the first reconciliation, or after a bounded fallback so actions can't
-        // stay disabled forever during a Play outage.
-        try {
-            withTimeoutOrNull(SETTLE_FALLBACK_MS) { upgradeRepo.refresh() }
-        } finally {
-            settled.value = true
+        // Both configured products must come back. A response missing either the subscription or the
+        // one-time offer is, to the buyer, a half-broken screen — treat it as a failure so we show a
+        // retry instead of a partial catalog (Play normally returns both; one missing signals a glitch).
+        return if (pricing.subAvailable && pricing.iapAvailable) {
+            PricingState.Ready(pricing)
+        } else {
+            log(TAG, WARN) { "SKU query returned an incomplete offer set (sub=${pricing.subAvailable}, iap=${pricing.iapAvailable})" }
+            PricingState.Failed(GplayServiceUnavailableException(RuntimeException("Incomplete purchase offer set")))
         }
     }
 
     fun onSubscribe(activity: Activity) {
-        val current = pricing.value ?: return
+        val current = pricingState.value.readyPricing ?: return
         val skuDetails = current.sub ?: return
         val offer = if (current.hasTrialOffer) MyPermSku.Sub.TRIAL_OFFER else MyPermSku.Sub.BASE_OFFER
         // Acquire the guard synchronously on the caller (main) thread BEFORE launching, so two rapid
@@ -220,9 +273,13 @@ class UpgradeViewModel @Inject constructor(
                     }
 
                     else -> {
-                        val iap = pricing.value?.iap
+                        val iap = pricingState.value.readyPricing?.iap
                         if (iap == null) {
-                            log(TAG, WARN) { "No IAP SkuDetails available" }
+                            // The IAP catalog isn't loaded. The UI gates the buy/switch buttons on IAP
+                            // availability (OffersCard / SwitchOfferCard), so this is only reachable if
+                            // the catalog dropped between render and tap — abort quietly rather than
+                            // launch a broken flow or pop a dialog.
+                            log(TAG, WARN) { "No IAP SkuDetails available -> aborting purchase launch" }
                         } else {
                             launchBillingFlow(activity, iap, null)
                         }
@@ -338,12 +395,25 @@ class UpgradeViewModel @Inject constructor(
         }
     }
 
+    private sealed interface PricingState {
+        // A query is in flight (initial load or a retry generation).
+        data object Pending : PricingState
+
+        // The query failed, timed out, or returned no usable offer. Non-Pro buyers see the Unavailable
+        // retry card; owners/grace users ignore it.
+        data class Failed(val error: Throwable) : PricingState
+
+        // At least one usable offer (subscription or one-time) is available.
+        data class Ready(val pricing: Pricing) : PricingState
+
+        val readyPricing: Pricing? get() = (this as? Ready)?.pricing
+    }
+
     companion object {
         internal const val VERIFY_TIMEOUT_MS = 10_000L
         internal const val SKU_QUERY_TIMEOUT_MS = 15_000L
         internal const val RESTORE_TIMEOUT_MS = 15_000L
         internal const val RESTORE_MIN_VISIBLE_MS = 1_500L
-        internal const val SETTLE_FALLBACK_MS = 10_000L
         internal const val GRACE_DIAGNOSTICS_AFTER_MS = 24 * 60 * 60 * 1000L
         private const val GRACE_TICK_INTERVAL_MS = 60_000L
         private val TAG = logTag("Upgrade", "Gplay", "VM")

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -6,6 +6,8 @@
     <string name="upgrades_gplay_already_owned_error">Google Play reports that you already own this upgrade, but it could not be restored. Check that you are signed in with the Google account used for the original purchase, then try “Restore purchase”.</string>
 
     <string name="upgrade_screen_preamble">Permission Pilot is ad-free and respects your privacy. Upgrading supports continued development.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play unavailable</string>
+    <string name="upgrade_screen_offers_unavailable_message">Couldn\'t load the purchase options. Google Play might be temporarily unavailable — check your connection and try again.</string>
     <string name="upgrade_screen_subscription_trial_action">Start free trial</string>
     <string name="upgrade_screen_subscription_action">Subscribe</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/year, cancel anytime</string>

--- a/app/src/main/java/eu/darken/myperm/common/upgrade/ui/UpgradeContent.kt
+++ b/app/src/main/java/eu/darken/myperm/common/upgrade/ui/UpgradeContent.kt
@@ -1,0 +1,148 @@
+package eu.darken.myperm.common.upgrade.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Code
+import androidx.compose.material.icons.twotone.Favorite
+import androidx.compose.material.icons.twotone.FileDownload
+import androidx.compose.material.icons.twotone.Notifications
+import androidx.compose.material.icons.twotone.Palette
+import androidx.compose.material.icons.twotone.Tune
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import eu.darken.myperm.R
+import eu.darken.myperm.common.compose.PermPilotMascot
+
+private data class Benefit(val icon: ImageVector, val textRes: Int)
+
+private val upgradeBenefits = listOf(
+    Benefit(Icons.TwoTone.Palette, R.string.upgrade_benefit_themes),
+    Benefit(Icons.TwoTone.Tune, R.string.upgrade_benefit_filtering),
+    Benefit(Icons.TwoTone.FileDownload, R.string.upgrade_benefit_export),
+    Benefit(Icons.TwoTone.Notifications, R.string.upgrade_benefit_monitoring),
+    Benefit(Icons.TwoTone.Code, R.string.upgrade_benefit_manifest_viewer),
+    Benefit(Icons.TwoTone.Favorite, R.string.upgrade_benefit_support),
+)
+
+// The mascot-in-a-circle header plus the "prefix Suffix" headline, shared by both flavors. Colors are
+// passed in so each flavor keeps its own palette (gplay tints the circle/suffix differently to foss).
+@Composable
+internal fun UpgradeMascotHeader(
+    circleColor: Color,
+    suffixColor: Color,
+    titleColor: Color,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Surface(
+                modifier = Modifier.size(120.dp),
+                shape = CircleShape,
+                color = circleColor,
+            ) {}
+            PermPilotMascot(size = 80.dp)
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = buildAnnotatedString {
+                append(stringResource(R.string.upgrade_title_prefix))
+                append(" ")
+                withStyle(SpanStyle(color = suffixColor, fontWeight = FontWeight.Bold)) {
+                    append(stringResource(R.string.upgrade_title_suffix))
+                }
+            },
+            style = MaterialTheme.typography.headlineLarge,
+            color = titleColor,
+        )
+    }
+}
+
+// The list of Pro benefits with icon chips. The chip colors are flavor-provided so the card matches
+// the surrounding palette.
+@Composable
+internal fun UpgradeBenefitsCard(
+    chipColor: Color,
+    chipContentColor: Color,
+    modifier: Modifier = Modifier,
+) {
+    Card(modifier = modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(vertical = 4.dp)) {
+            upgradeBenefits.forEach { benefit ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 12.dp, vertical = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Surface(
+                        shape = RoundedCornerShape(8.dp),
+                        color = chipColor,
+                        modifier = Modifier.size(28.dp),
+                    ) {
+                        Box(contentAlignment = Alignment.Center) {
+                            Icon(
+                                imageVector = benefit.icon,
+                                contentDescription = null,
+                                tint = chipContentColor,
+                                modifier = Modifier.size(16.dp),
+                            )
+                        }
+                    }
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text(
+                        text = stringResource(benefit.textRes),
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                }
+            }
+        }
+    }
+}
+
+// A simple tinted preamble card. The body text is passed as a resolved String so the composable stays
+// flavor-agnostic (the two flavors use different preamble strings).
+@Composable
+internal fun UpgradePreambleCard(
+    text: String,
+    containerColor: Color,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = containerColor),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/UpgradeRepoGplayTest.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import org.junit.jupiter.api.Test
 import testhelper.BaseTest
@@ -240,6 +241,21 @@ class UpgradeRepoGplayTest : BaseTest() {
         )
 
         coVerify(exactly = 0) { billingDataRepo.refresh() }
+    }
+
+    @Test fun `isSettled is false until billing publishes a real value, then true`() = runTest2 {
+        // MutableSharedFlow (no replay) so nothing is published at construction: isSettled must stay
+        // false until a real billing emission arrives, then flip true — and it flips only after
+        // upgradeInfo already reflects that value (drop(1) skips the cached seed).
+        val billingData = MutableSharedFlow<BillingData>()
+        val repo = repo(billingData = billingData)
+
+        repo.isSettled.value shouldBe false
+
+        billingData.emit(BillingData(setOf(proPurchase())))
+
+        repo.isSettled.first { it } shouldBe true
+        repo.upgradeInfo.value.isPro shouldBe true
     }
 
     @Test fun `preferredProSku prefers the permanent IAP when both are owned`() {

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModelTest.kt
@@ -73,6 +73,17 @@ class UpgradeViewModelTest : BaseTest() {
         },
     )
 
+    private fun subSkuDetails(): SkuDetails = SkuDetails(
+        sku = MyPermSku.Sub.PRO_UPGRADE,
+        details = mockk<ProductDetails> {
+            every { oneTimePurchaseOfferDetails } returns null
+            every { subscriptionOfferDetails } returns null
+        },
+    )
+
+    // A fully-loaded catalog: Ready requires BOTH the subscription and the one-time offer.
+    private fun bothSkus(): List<SkuDetails> = listOf(iapSkuDetails(), subSkuDetails())
+
     private fun result(code: Int): BillingResult = BillingResult.newBuilder().setResponseCode(code).build()
 
     private fun mockRepo(
@@ -81,6 +92,7 @@ class UpgradeViewModelTest : BaseTest() {
         skus: List<SkuDetails> = emptyList(),
     ): UpgradeRepoGplay = mockk<UpgradeRepoGplay>(relaxed = true).apply {
         every { upgradeInfo } returns MutableStateFlow<UpgradeRepo.Info>(info)
+        every { isSettled } returns MutableStateFlow(true)
         every { this@apply.wasEverPro } returns MutableStateFlow(wasEverPro)
         every { lastProConfirmedAt } returns MutableStateFlow(0L)
         coEvery { querySkus() } returns skus
@@ -169,7 +181,7 @@ class UpgradeViewModelTest : BaseTest() {
 
     @Test
     fun `switch blocked while a subscription is still renewing`() = runTest2(context = testDispatcher) {
-        val repo = mockRepo(skus = listOf(iapSkuDetails()))
+        val repo = mockRepo(skus = bothSkus())
         coEvery { repo.queryCurrentSubscriptions() } returns listOf(purchase(MyPermSku.Sub.PRO_UPGRADE.id, autoRenew = true))
         val vm = buildVm(repo).also { it.init(manage = true) }
         vm.loaded()
@@ -184,7 +196,7 @@ class UpgradeViewModelTest : BaseTest() {
 
     @Test
     fun `switch fails closed when the verify times out`() = runTest2(context = testDispatcher) {
-        val repo = mockRepo(skus = listOf(iapSkuDetails()))
+        val repo = mockRepo(skus = bothSkus())
         coEvery { repo.queryCurrentSubscriptions() } coAnswers {
             delay(20_000) // longer than VERIFY_TIMEOUT_MS
             emptyList()
@@ -202,7 +214,7 @@ class UpgradeViewModelTest : BaseTest() {
 
     @Test
     fun `switch launches the one-time purchase when no subscription is renewing`() = runTest2(context = testDispatcher) {
-        val repo = mockRepo(skus = listOf(iapSkuDetails()))
+        val repo = mockRepo(skus = bothSkus())
         coEvery { repo.queryCurrentSubscriptions() } returns listOf(purchase(MyPermSku.Sub.PRO_UPGRADE.id, autoRenew = false))
         val vm = buildVm(repo).also { it.init(manage = true) }
         vm.loaded()
@@ -251,7 +263,7 @@ class UpgradeViewModelTest : BaseTest() {
 
     @Test
     fun `user cancel during the billing flow stays silent`() = runTest2(context = testDispatcher) {
-        val repo = mockRepo(skus = listOf(iapSkuDetails()))
+        val repo = mockRepo(skus = bothSkus())
         coEvery { repo.launchBillingFlow(any(), any(), null) } throws
             UserCanceledBillingException(result(BillingResponseCode.USER_CANCELED))
         val vm = buildVm(repo).also { it.init(manage = false) }
@@ -268,7 +280,7 @@ class UpgradeViewModelTest : BaseTest() {
 
     @Test
     fun `already-owned buy attempt restores when the exact sku comes back`() = runTest2(context = testDispatcher) {
-        val repo = mockRepo(skus = listOf(iapSkuDetails()))
+        val repo = mockRepo(skus = bothSkus())
         coEvery { repo.launchBillingFlow(any(), any(), null) } throws
             ItemAlreadyOwnedBillingException(result(BillingResponseCode.ITEM_ALREADY_OWNED))
         coEvery { repo.restorePurchaseNow() } returns iapOwnedInfo()
@@ -289,7 +301,7 @@ class UpgradeViewModelTest : BaseTest() {
     fun `direct buy is also gated and blocks while a subscription is renewing`() = runTest2(context = testDispatcher) {
         // Even the ordinary "Buy" button (e.g. exposed during a grace window) must not launch the
         // one-time purchase while a subscription is still auto-renewing.
-        val repo = mockRepo(skus = listOf(iapSkuDetails()))
+        val repo = mockRepo(skus = bothSkus())
         coEvery { repo.queryCurrentSubscriptions() } returns listOf(purchase(MyPermSku.Sub.PRO_UPGRADE.id, autoRenew = true))
         val vm = buildVm(repo).also { it.init(manage = false) }
         vm.state.first { it is UpgradeUiState.Loaded && it.pricing.iap != null }
@@ -299,5 +311,123 @@ class UpgradeViewModelTest : BaseTest() {
 
         vm.events.first() shouldBe UpgradeViewModel.UpgradeEvent.SubscriptionStillRenewing
         coVerify(exactly = 0) { repo.launchBillingFlow(any(), any(), any()) }
+    }
+
+    // --- offer availability / unavailable state ------------------------------------------------
+
+    @Test
+    fun `non-pro with no usable offers shows Unavailable`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo() // querySkus returns an empty list -> no usable offer
+        val vm = buildVm(repo).also { it.init(manage = false) }
+
+        val state = vm.state.first { it is UpgradeUiState.Unavailable }
+
+        (state is UpgradeUiState.Unavailable) shouldBe true
+    }
+
+    @Test
+    fun `non-pro with only the one-time offer shows Unavailable`() = runTest2(context = testDispatcher) {
+        // A partial catalog (subscription offer missing) is treated as unavailable, not shown as a
+        // half-broken screen. Would be Loaded under an OR condition; must be Unavailable under AND.
+        val repo = mockRepo(skus = listOf(iapSkuDetails()))
+        val vm = buildVm(repo).also { it.init(manage = false) }
+
+        val state = vm.state.first { it is UpgradeUiState.Unavailable }
+
+        (state is UpgradeUiState.Unavailable) shouldBe true
+    }
+
+    @Test
+    fun `non-pro with only the subscription offer shows Unavailable`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo(skus = listOf(subSkuDetails()))
+        val vm = buildVm(repo).also { it.init(manage = false) }
+
+        val state = vm.state.first { it is UpgradeUiState.Unavailable }
+
+        (state is UpgradeUiState.Unavailable) shouldBe true
+    }
+
+    @Test
+    fun `owner with a failed sku query still sees the ownership screen`() = runTest2(context = testDispatcher) {
+        // The offer catalog is a non-pro concern; an owner must never be dropped into Unavailable
+        // because Play couldn't return prices.
+        val repo = mockRepo(info = iapOwnedInfo()) // querySkus empty -> Failed, but IAP is owned
+        val vm = buildVm(repo).also { it.init(manage = true) }
+
+        val loaded = vm.loaded()
+
+        loaded.isPro shouldBe true
+    }
+
+    @Test
+    fun `grace user with a failed sku query stays on the status screen`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo(info = graceInfo())
+        val vm = buildVm(repo).also { it.init(manage = true) }
+
+        val loaded = vm.loaded()
+
+        loaded.isPro shouldBe true
+        loaded.gracePeriod shouldBe true
+    }
+
+    @Test
+    fun `retry re-runs the sku query`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        val vm = buildVm(repo).also { it.init(manage = false) }
+        vm.state.first { it is UpgradeUiState.Unavailable }
+
+        vm.retrySkuQuery()
+        advanceUntilIdle()
+
+        coVerify(atLeast = 2) { repo.querySkus() }
+    }
+
+    @Test
+    fun `onResume retries the query after a failure`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        val vm = buildVm(repo).also { it.init(manage = false) }
+        vm.state.first { it is UpgradeUiState.Unavailable }
+
+        vm.onResume()
+        advanceUntilIdle()
+
+        coVerify(atLeast = 2) { repo.querySkus() }
+    }
+
+    @Test
+    fun `onResume does not re-query when offers are already loaded`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo(skus = bothSkus())
+        val vm = buildVm(repo).also { it.init(manage = false) }
+        vm.state.first { it is UpgradeUiState.Loaded }
+
+        vm.onResume()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { repo.querySkus() }
+    }
+
+    @Test
+    fun `switch is a silent no-op when the iap catalog is unavailable`() = runTest2(context = testDispatcher) {
+        // Owner of a non-renewing subscription with a failed price query. The UI disables the switch
+        // button here (pricing.iapAvailable is false); if it is invoked anyway, the VM must neither
+        // launch a broken flow nor pop an error dialog — it just quietly aborts.
+        val subInfo = UpgradeRepoGplay.Info(
+            billingData = BillingData(setOf(purchase(MyPermSku.Sub.PRO_UPGRADE.id, autoRenew = false))),
+        )
+        val repo = mockRepo(info = subInfo) // querySkus empty -> no IAP details
+        coEvery { repo.queryCurrentSubscriptions() } returns
+            listOf(purchase(MyPermSku.Sub.PRO_UPGRADE.id, autoRenew = false))
+        val vm = buildVm(repo).also { it.init(manage = true) }
+        vm.loaded()
+        advanceUntilIdle()
+
+        val errors = mutableListOf<Throwable>()
+        val collector = launch { vm.errorEvents.collect { errors.add(it) } }
+        vm.onSwitchToIap(activity)
+        advanceUntilIdle()
+
+        errors shouldBe emptyList()
+        coVerify(exactly = 0) { repo.launchBillingFlow(any(), any(), any()) }
+        collector.cancel()
     }
 }


### PR DESCRIPTION
## What changed

Two improvements to the Google Play "Get Pro" upgrade screen:

- When Google Play can't load the purchase options — an outage, no connection, or an incomplete response — the screen now shows a clear **"Google Play unavailable"** message with a **Retry** button, instead of a blank pitch with no purchase buttons. If you already own Pro (or you're in the grace period after a transient Play issue), your status is always shown and your plan stays manageable; a price-loading problem never hides it.
- Internal cleanup with **no visual change**: the upgrade screen's mascot header, benefits list, and intro card are now defined once and shared by both the Google Play and F-Droid/GitHub (FOSS) builds instead of being duplicated.

## Technical Context

- Two commits: (1) extract the shared Compose atoms to a common file (zero behavior change; both flavors build), then (2) the new Unavailable state plus billing-state hardening.
- **Inline-only** unavailability: a failed / timed-out / incomplete SKU query surfaces as the inline retry card, never a modal dialog. "Incomplete" is deliberate — a Ready catalog requires *both* the subscription and the one-time offer; a one-sided response is treated as a glitch and shows Retry rather than a partial screen.
- **Cold-start race hardened.** "Purchases reconciled" (`isSettled`) moved into the billing repo and is derived from `upgradeInfo` itself; the ViewModel resolves the freshest `upgradeInfo` value at combine time, so the reconciled flag can never be paired with a stale pre-reconciliation snapshot. This closes a window where an owner could briefly be shown acquisition UI (or the new retry card) on a cold start before ownership resolved. A fallback timer preserves the prior "don't leave actions disabled forever during an outage" behavior. Root cause: the previous `settled` flag flipped when `refresh()` returned, but the reconciled `Info` propagates asynchronously.
- Owners and grace-period users are `priceIndependent` — never stuck on Loading or shown Unavailable because of a failed price query. The ownership "switch to one-time" button is additionally gated on the one-time offer being loaded, so it can't be a dead tap.

### Review guidance

- The non-obvious bit is `UpgradeViewModel`'s combine reading `upgradeRepo.upgradeInfo.value` instead of the branch parameter — this is intentional and load-bearing for the race fix (`combine` gives no ordering between the `isSettled` and `upgradeInfo` branches). Comment in place explains it.
- `UpgradeRepoGplay.isSettled` uses `upgradeInfo.drop(1)` to skip the cached seed; correct because production billing emits asynchronously after the repo attaches its collector.
