### PR TITLE
General: Update translations from Crowdin

### DIFF
--- a/app/src/foss/res/values-af-rZA/strings.xml
+++ b/app/src/foss/res/values-af-rZA/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">Word \'n borgskappe</string>
     <string name="upgrade_foss_sponsor_subtitle">Maak GitHub-borge oop</string>
     <string name="upgrade_foss_sponsor_returned_early">Neem asseblief \'n oomblik om die borgblad te besoek!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Vrye weergawe</string>
+    <string name="upgrade_screen_status_free_body">U gebruik die vrye, oopbronkode-weergawe. Ondersteun die ontwikkeling om die Pro-funksies te ontsluit.</string>
+    <string name="upgrade_screen_status_free_action">Word \'n Borger</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">Dankie vir u ondersteuning!</string>
+    <string name="upgrade_screen_status_upgraded_body">U het alle Pro-funksies ontsluit. U ondersteuning hou Permission Pilot vry en oopbronkode.</string>
+    <string name="upgrade_screen_supporter_since">Borger sedert %1$s</string>
+    <string name="upgrade_screen_recurring_title">Ondersteun weer</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot word in die openheid ontwikkel. Oorweeg \'n herhalende borgskap om dit te help volhou.</string>
+    <string name="upgrade_screen_recurring_action">Maak GitHub Sponsors oop</string>
 </resources>

--- a/app/src/foss/res/values-am/strings.xml
+++ b/app/src/foss/res/values-am/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">የግል አስነሯ</string>
     <string name="upgrade_foss_sponsor_subtitle">የ GitHub Sponsors ይዘርቹ</string>
     <string name="upgrade_foss_sponsor_returned_early">የግል ቃኩልን አክበ ለመከፈት የጓል ደቁወቢ።</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">ነጻ ስሪት</string>
+    <string name="upgrade_screen_status_free_body">የነጻ፣ ከተመረቀ ምንጭ ግንባታ እየተጠቀሙ ነው። Pro ባህሪያትን ለመክፈት ልማትን ይደግፉ።</string>
+    <string name="upgrade_screen_status_free_action">ስፖንሰር ይሁኑ</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">ለድጋፍዎ አመሰግናለሁ!</string>
+    <string name="upgrade_screen_status_upgraded_body">ሁሉንም Pro ባህሪያት አክፍተዋል። ድጋፍዎ Permission Pilot ነጻ እና ከተመረቀ ምንጭ ያቆየዋል።</string>
+    <string name="upgrade_screen_supporter_since">ከ%1$s ጀምሮ ደጋፊ</string>
+    <string name="upgrade_screen_recurring_title">ደግመው ድጋፍ ስጥ</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot በክፍት ተሰራ። ሚስክ ለመርዳት ተደጋጋሚ ስፖንሰርሺፕ ያስቡ።</string>
+    <string name="upgrade_screen_recurring_action">GitHub Sponsors ይክፈቱ</string>
 </resources>

--- a/app/src/foss/res/values-ar/strings.xml
+++ b/app/src/foss/res/values-ar/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">كن راعياً</string>
     <string name="upgrade_foss_sponsor_subtitle">يفتح GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">يُرجى تخصيص لحظة للاطلاع على صفحة الراعيين!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">النسخة المجانية</string>
+    <string name="upgrade_screen_status_free_body">أنت تستخدم الإصدار المجاني مفتوح المصدر. ادعم التطوير لفتح ميزات Pro.</string>
+    <string name="upgrade_screen_status_free_action">كن راعياً</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">شكراً لدعمك!</string>
+    <string name="upgrade_screen_status_upgraded_body">لقد فتحت جميع ميزات Pro. دعمك يحافظ على Permission Pilot مجاني ومفتوح المصدر.</string>
+    <string name="upgrade_screen_supporter_since">راعي منذ %1$s</string>
+    <string name="upgrade_screen_recurring_title">ادعم مرة أخرى</string>
+    <string name="upgrade_screen_recurring_body">يتم تطوير Permission Pilot بشكل علني. فكر في رعاية متكررة للمساعدة على استدامته.</string>
+    <string name="upgrade_screen_recurring_action">افتح GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-az/strings.xml
+++ b/app/src/foss/res/values-az/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">Sponsor ol</string>
     <string name="upgrade_foss_sponsor_subtitle">GitHub Sponsors açır</string>
     <string name="upgrade_foss_sponsor_returned_early">Zəhmət olmasa sponsor səhifəsinə bir baxın!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Pulsuz versiya</string>
+    <string name="upgrade_screen_status_free_body">Siz pulsuz, açıq mənbəli versiyadan istifadə edirsiniz. Pro funksiyalarını aktivləşdirmək üçün inkişafı dəstəkləyin.</string>
+    <string name="upgrade_screen_status_free_action">Sponsor olun</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">Dəstəyiniz üçün təşəkkür edirik!</string>
+    <string name="upgrade_screen_status_upgraded_body">Bütün Pro funksiyalarını aktivləşdirdiniz. Dəstəyiniz Permission Pilot-u pulsuz və açıq mənbəli saxlayır.</string>
+    <string name="upgrade_screen_supporter_since">Dəstəkçi %1$s-dən</string>
+    <string name="upgrade_screen_recurring_title">Yenidən dəstəkləyin</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot açıq şəkildə inkişaf etdirilir. Onu dəstəkləmək üçün dövri sponsorluğu nəzərdən keçirin.</string>
+    <string name="upgrade_screen_recurring_action">GitHub Sponsors-u açın</string>
 </resources>

--- a/app/src/foss/res/values-be/strings.xml
+++ b/app/src/foss/res/values-be/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">Стаць спонсарам</string>
     <string name="upgrade_foss_sponsor_subtitle">Адкрывае GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Калі ласка, зазірніце на старонку спонсараў!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Бясплатная версія</string>
+    <string name="upgrade_screen_status_free_body">Вы карыстаецеся бясплатнай зборкай з адкрытым зыходным кодам. Падтрымайце распрацоўку, каб адкрыць функцыі Pro.</string>
+    <string name="upgrade_screen_status_free_action">Станьце спонсарам</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">Дзякуй за вашу падтрымку!</string>
+    <string name="upgrade_screen_status_upgraded_body">Вы адкрылі ўсе функцыі Pro. Ваша падтрымка захоўвае Permission Pilot бясплатным і з адкрытым зыходным кодам.</string>
+    <string name="upgrade_screen_supporter_since">Спонсар з %1$s</string>
+    <string name="upgrade_screen_recurring_title">Падтрымаць яшчэ раз</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot распрацоўваецца адкрыта. Разгледзьце рэгулярнае спонсарства, каб дапамагчы яго падтрымаць.</string>
+    <string name="upgrade_screen_recurring_action">Адкрыць GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-bg/strings.xml
+++ b/app/src/foss/res/values-bg/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">Станете спонсор</string>
     <string name="upgrade_foss_sponsor_subtitle">Отваря GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Моля, отделете момент да разгледате страницата на спонсорите!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Безплатна версия</string>
+    <string name="upgrade_screen_status_free_body">Използвате безплатната версия с отворен код. Подкрепете разработката, за да отключите Pro функциите.</string>
+    <string name="upgrade_screen_status_free_action">Станете спонсор</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">Благодаря ви за вашата подкрепа!</string>
+    <string name="upgrade_screen_status_upgraded_body">Отключихте всички Pro функции. Вашата подкрепа поддържа Permission Pilot безплатен и с отворен код.</string>
+    <string name="upgrade_screen_supporter_since">Поддържник от %1$s</string>
+    <string name="upgrade_screen_recurring_title">Подкрепете отново</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot е разработен открито. Помислете за периодична спонсорска подкрепа, за да помогнете за неговото развитие.</string>
+    <string name="upgrade_screen_recurring_action">Отворете GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-bn-rBD/strings.xml
+++ b/app/src/foss/res/values-bn-rBD/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">স্পনসর হন</string>
     <string name="upgrade_foss_sponsor_subtitle">GitHub Sponsors খুলবে</string>
     <string name="upgrade_foss_sponsor_returned_early">দয়া করে স্পনসর পেজটি দেখুন!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">বিনামূল্যে সংস্করণ</string>
+    <string name="upgrade_screen_status_free_body">আপনি বিনামূল্যের, ওপেন-সোর্স বিল্ড ব্যবহার করছেন। প্রো বৈশিষ্ট্যগুলি আনলক করতে উন্নয়নকে সমর্থন করুন।</string>
+    <string name="upgrade_screen_status_free_action">একজন স্পন্সর হন</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">আপনার সমর্থনের জন্য ধন্যবাদ!</string>
+    <string name="upgrade_screen_status_upgraded_body">আপনি সমস্ত প্রো বৈশিষ্ট্য আনলক করেছেন। আপনার সমর্থন Permission Pilot কে বিনামূল্যে এবং ওপেন-সোর্স রাখে।</string>
+    <string name="upgrade_screen_supporter_since">%1$s থেকে সমর্থক</string>
+    <string name="upgrade_screen_recurring_title">আবার সমর্থন করুন</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot খোলামেলাভাবে তৈরি করা হয়েছে। এটি টিকিয়ে রাখতে সাহায্য করার জন্য নিয়মিত স্পন্সরশিপ বিবেচনা করুন।</string>
+    <string name="upgrade_screen_recurring_action">GitHub Sponsors খুলুন</string>
 </resources>

--- a/app/src/foss/res/values-ca/strings.xml
+++ b/app/src/foss/res/values-ca/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">Convertiu-vos en patrocinador</string>
     <string name="upgrade_foss_sponsor_subtitle">Obre els patrocinadors del GitHub</string>
     <string name="upgrade_foss_sponsor_returned_early">Dediqueu un moment a consultar la pàgina del patrocinador!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Versió gratuïta</string>
+    <string name="upgrade_screen_status_free_body">Esteu utilitzant la compilació gratuïta i de codi obert. Doneu suport al desenvolupament per desbloquejar les funcions Pro.</string>
+    <string name="upgrade_screen_status_free_action">Convertiu-vos en patrocinador</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">Gràcies pel vostre suport!</string>
+    <string name="upgrade_screen_status_upgraded_body">Heu desbloquejat totes les funcions Pro. El vostre suport manté el Permission Pilot gratuït i de codi obert.</string>
+    <string name="upgrade_screen_supporter_since">Col·laborador des de %1$s</string>
+    <string name="upgrade_screen_recurring_title">Torneu a donar suport</string>
+    <string name="upgrade_screen_recurring_body">El Permission Pilot es desenvolupa en obert. Considereu un patrocini recurrent per ajudar a mantenir-lo.</string>
+    <string name="upgrade_screen_recurring_action">Obre els patrocinadors del GitHub</string>
 </resources>

--- a/app/src/foss/res/values-cs/strings.xml
+++ b/app/src/foss/res/values-cs/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">Stát se sponzorem</string>
     <string name="upgrade_foss_sponsor_subtitle">Otevře GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Prosím, věnujte chvíli prohlédnutí stránky sponzorů!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Bezplatná verze</string>
+    <string name="upgrade_screen_status_free_body">Používáte bezplatnou verzi s otevřeným zdrojovým kódem. Podpořte vývoj a odemkněte funkce Pro.</string>
+    <string name="upgrade_screen_status_free_action">Stát se sponzorem</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">Děkujeme za vaši podporu!</string>
+    <string name="upgrade_screen_status_upgraded_body">Odemkli jste všechny funkce Pro. Vaše podpora udržuje Permission Pilot bezplatný s otevřeným zdrojovým kódem.</string>
+    <string name="upgrade_screen_supporter_since">Podporovatel od %1$s</string>
+    <string name="upgrade_screen_recurring_title">Podpořit znovu</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot je vyvíjen otevřeně. Zvažte pravidelný sponzoring, který jej pomáhá udržovat.</string>
+    <string name="upgrade_screen_recurring_action">Otevřít GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-da/strings.xml
+++ b/app/src/foss/res/values-da/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">Bliv sponsor</string>
     <string name="upgrade_foss_sponsor_subtitle">Åbner GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Tag et øjeblik til at kigge på sponsorsiden!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Gratis version</string>
+    <string name="upgrade_screen_status_free_body">Du bruger den gratis open-source-udgave. Støt udviklingen for at låse Pro-funktionerne op.</string>
+    <string name="upgrade_screen_status_free_action">Bliv sponsor</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">Tak for din støtte!</string>
+    <string name="upgrade_screen_status_upgraded_body">Du har låst alle Pro-funktioner op. Din støtte holder Permission Pilot gratis og open-source.</string>
+    <string name="upgrade_screen_supporter_since">Tilhænger siden %1$s</string>
+    <string name="upgrade_screen_recurring_title">Støt igen</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot udvikles åbent. Overvej et tilbagevendende sponsorat for at hjælpe med at opretholde det.</string>
+    <string name="upgrade_screen_recurring_action">Åbn GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-de/strings.xml
+++ b/app/src/foss/res/values-de/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">Sponsor werden</string>
     <string name="upgrade_foss_sponsor_subtitle">Öffnet GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Bitte nimm dir einen Moment, um die Sponsor-Seite zu besuchen!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Kostenlose Version</string>
+    <string name="upgrade_screen_status_free_body">Sie verwenden den kostenlosen Open-Source-Build. Unterstützen Sie die Entwicklung, um die Pro-Funktionen freizuschalten.</string>
+    <string name="upgrade_screen_status_free_action">Sponsor werden</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">Vielen Dank für Ihre Unterstützung!</string>
+    <string name="upgrade_screen_status_upgraded_body">Sie haben alle Pro-Funktionen freigeschaltet. Ihre Unterstützung hält Permission Pilot kostenlos und Open-Source.</string>
+    <string name="upgrade_screen_supporter_since">Unterstützer seit %1$s</string>
+    <string name="upgrade_screen_recurring_title">Erneut unterstützen</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot wird offen entwickelt. Ziehen Sie ein wiederkehrendes Sponsoring in Betracht, um es zu unterstützen.</string>
+    <string name="upgrade_screen_recurring_action">GitHub Sponsors öffnen</string>
 </resources>

--- a/app/src/foss/res/values-el/strings.xml
+++ b/app/src/foss/res/values-el/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">Γίνετε Χορηγός</string>
     <string name="upgrade_foss_sponsor_subtitle">Ανοίγει το GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Αφιερώστε λίγο χρόνο για να δείτε τη σελίδα χορηγών!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Δωρεάν έκδοση</string>
+    <string name="upgrade_screen_status_free_body">Χρησιμοποιείτε την δωρεάν, ανοιχτού κώδικα έκδοση. Υποστηρίξτε την ανάπτυξη για να ξεκλειδώσετε τις Pro δυνατότητες.</string>
+    <string name="upgrade_screen_status_free_action">Γίνετε Χορηγός</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">Ευχαριστώ για την υποστήριξή σας!</string>
+    <string name="upgrade_screen_status_upgraded_body">Έχετε ξεκλειδώσει όλες τις Pro δυνατότητες. Η υποστήριξή σας κρατά το Permission Pilot δωρεάν και ανοιχτού κώδικα.</string>
+    <string name="upgrade_screen_supporter_since">Χορηγός από %1$s</string>
+    <string name="upgrade_screen_recurring_title">Υποστηρίξτε ξανά</string>
+    <string name="upgrade_screen_recurring_body">Το Permission Pilot αναπτύσσεται δημοσίως. Σκέψου μια τακτική χορηγία για να βοηθήσεις στη διατήρησή του.</string>
+    <string name="upgrade_screen_recurring_action">Άνοιξε GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-es/strings.xml
+++ b/app/src/foss/res/values-es/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">Conviértete en patrocinador</string>
     <string name="upgrade_foss_sponsor_subtitle">Abre GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">¡Por favor, tómate un momento para visitar la página de patrocinadores!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Versión gratuita</string>
+    <string name="upgrade_screen_status_free_body">Estás usando la compilación gratuita de código abierto. Apoya el desarrollo para desbloquear las funciones Pro.</string>
+    <string name="upgrade_screen_status_free_action">Conviértete en patrocinador</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">¡Gracias por tu apoyo!</string>
+    <string name="upgrade_screen_status_upgraded_body">Has desbloqueado todas las funciones Pro. Tu apoyo mantiene Permission Pilot gratuito y de código abierto.</string>
+    <string name="upgrade_screen_supporter_since">Patrocinador desde %1$s</string>
+    <string name="upgrade_screen_recurring_title">Apoya de nuevo</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot se desarrolla de forma abierta. Considera un patrocinio recurrente para ayudar a sostenerlo.</string>
+    <string name="upgrade_screen_recurring_action">Abrir Patrocinadores de GitHub</string>
 </resources>

--- a/app/src/foss/res/values-fi/strings.xml
+++ b/app/src/foss/res/values-fi/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">Tule sponsoriksi</string>
     <string name="upgrade_foss_sponsor_subtitle">Avaa GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Käy katsomassa sponsorointisivua!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Ilmainen versio</string>
+    <string name="upgrade_screen_status_free_body">Käytät ilmaista, avoimen lähdekoodin versiota. Tue kehitystä vapauttaaksesi Pro-ominaisuudet.</string>
+    <string name="upgrade_screen_status_free_action">Tule sponsoriksi</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">Kiitos tuestasi!</string>
+    <string name="upgrade_screen_status_upgraded_body">Olet avannut kaikki Pro-ominaisuudet. Tukesi pitää Permission Pilotin ilmaisena ja avoimen lähdekoodin projektina.</string>
+    <string name="upgrade_screen_supporter_since">Tukija %1$s alkaen</string>
+    <string name="upgrade_screen_recurring_title">Tue uudelleen</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot kehitetään avoimesti. Harkitse toistuvaa tukea sen jatkuvuuden turvaamiseksi.</string>
+    <string name="upgrade_screen_recurring_action">Avaa GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-fr/strings.xml
+++ b/app/src/foss/res/values-fr/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">Devenir sponsor</string>
     <string name="upgrade_foss_sponsor_subtitle">Ouvre GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Prenez un moment pour consulter la page des sponsors !</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Version gratuite</string>
+    <string name="upgrade_screen_status_free_body">Vous utilisez la version libre et open-source. Soutenez le développement pour débloquer les fonctionnalités Pro.</string>
+    <string name="upgrade_screen_status_free_action">Devenir sponsor</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">Merci pour votre soutien !</string>
+    <string name="upgrade_screen_status_upgraded_body">Vous avez déverrouillé toutes les fonctionnalités Pro. Votre soutien maintient Permission Pilot gratuit et open-source.</string>
+    <string name="upgrade_screen_supporter_since">Soutien depuis %1$s</string>
+    <string name="upgrade_screen_recurring_title">Soutenir à nouveau</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot est développé en open source. Envisagez un parrainage récurrent pour aider à le maintenir.</string>
+    <string name="upgrade_screen_recurring_action">Ouvrir GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-hi-rIN/strings.xml
+++ b/app/src/foss/res/values-hi-rIN/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">स्पॉन्सर बनें</string>
     <string name="upgrade_foss_sponsor_subtitle">GitHub Sponsors खोलता है</string>
     <string name="upgrade_foss_sponsor_returned_early">कृपया स्पॉन्सर पेज एक बार जरूर देखें!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">मुफ्त संस्करण</string>
+    <string name="upgrade_screen_status_free_body">आप मुफ्त, ओपन-सोर्स संस्करण का उपयोग कर रहे हैं। प्रो सुविधाओं को अनलॉक करने के लिए विकास का समर्थन करें।</string>
+    <string name="upgrade_screen_status_free_action">प्रायोजक बनें</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">आपके समर्थन के लिए धन्यवाद!</string>
+    <string name="upgrade_screen_status_upgraded_body">आपने सभी प्रो सुविधाओं को अनलॉक कर दिया है। आपका समर्थन Permission Pilot को मुफ्त और ओपन-सोर्स रखता है।</string>
+    <string name="upgrade_screen_supporter_since">%1$s से समर्थक</string>
+    <string name="upgrade_screen_recurring_title">फिर से समर्थन करें</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot को खुले तरीके से विकसित किया गया है। इसे जारी रखने में मदद के लिए आवर्ती प्रायोजन पर विचार करें।</string>
+    <string name="upgrade_screen_recurring_action">GitHub Sponsors खोलें</string>
 </resources>

--- a/app/src/foss/res/values-hr/strings.xml
+++ b/app/src/foss/res/values-hr/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">Postani sponzor</string>
     <string name="upgrade_foss_sponsor_subtitle">Otvara GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Molim odvojite trenutak i pogledajte stranicu sponzora!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Besplatna verzija</string>
+    <string name="upgrade_screen_status_free_body">Koristite besplatnu inačicu otvorenog koda. Podržite razvoj da otključate Pro značajke.</string>
+    <string name="upgrade_screen_status_free_action">Postanite sponzor</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">Hvala vam na podršci!</string>
+    <string name="upgrade_screen_status_upgraded_body">Otključali ste sve Pro značajke. Vaša podrška održava Permission Pilot besplatnim i otvorenog koda.</string>
+    <string name="upgrade_screen_supporter_since">Sponzor od %1$s</string>
+    <string name="upgrade_screen_recurring_title">Podržite ponovno</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot razvija se otvoreno. Razmotrite ponavljajuće sponzorstvo kako biste pomogli održati ga.</string>
+    <string name="upgrade_screen_recurring_action">Otvori GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-hu/strings.xml
+++ b/app/src/foss/res/values-hu/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">Legyen szponzor</string>
     <string name="upgrade_foss_sponsor_subtitle">GitHub Sponsors megnyitása</string>
     <string name="upgrade_foss_sponsor_returned_early">Kérlek, szánj egy pillanatot a szponzor oldal megtekintésére!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Ingyenes verzió</string>
+    <string name="upgrade_screen_status_free_body">Az ingyenes, nyílt forráskódú verziót használod. Támogasd a fejlesztést a Pro funkciók feloldásához.</string>
+    <string name="upgrade_screen_status_free_action">Legyél szponzor</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">Köszönjük a támogatást!</string>
+    <string name="upgrade_screen_status_upgraded_body">Feloldottad az összes Pro funkciót. A támogatásod megtartja a Permission Pilot-ot ingyenesnek és nyílt forráskódúnak.</string>
+    <string name="upgrade_screen_supporter_since">Támogató %1$s óta</string>
+    <string name="upgrade_screen_recurring_title">Támogass újra</string>
+    <string name="upgrade_screen_recurring_body">A Permission Pilot nyílt forráskódban fejlesztik. Fontold meg az ismétlődő szponzorálást a fenntartásának segítésére.</string>
+    <string name="upgrade_screen_recurring_action">GitHub Sponsors megnyitása</string>
 </resources>

--- a/app/src/foss/res/values-it/strings.xml
+++ b/app/src/foss/res/values-it/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">Diventa uno sponsor</string>
     <string name="upgrade_foss_sponsor_subtitle">Apre GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Per favore, prenditi un momento per visitare la pagina degli sponsor!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Versione gratuita</string>
+    <string name="upgrade_screen_status_free_body">Stai usando la versione gratuita e open-source. Sostieni lo sviluppo per sbloccare le funzionalità Pro.</string>
+    <string name="upgrade_screen_status_free_action">Diventa sostenitore</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">Grazie per il tuo supporto!</string>
+    <string name="upgrade_screen_status_upgraded_body">Hai sbloccato tutte le funzionalità Pro. Il tuo supporto mantiene Permission Pilot gratuito e open-source.</string>
+    <string name="upgrade_screen_supporter_since">Sostenitore dal %1$s</string>
+    <string name="upgrade_screen_recurring_title">Sostieni di nuovo</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot è sviluppato in modo aperto. Considera un contributo ricorrente per aiutare a sostenerlo.</string>
+    <string name="upgrade_screen_recurring_action">Apri GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-iw/strings.xml
+++ b/app/src/foss/res/values-iw/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">הפוך לספונסר</string>
     <string name="upgrade_foss_sponsor_subtitle">פותח את GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">אנא קדישי רגע לבדוק את דף הספונסרים!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">גרסה חינמית</string>
+    <string name="upgrade_screen_status_free_body">אתה משתמש בבנייה חינמית וקוד פתוח. תמוך בפיתוח כדי לפתוח את תכונות Pro.</string>
+    <string name="upgrade_screen_status_free_action">הפוך לתומך</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">תודה על התמיכה שלך!</string>
+    <string name="upgrade_screen_status_upgraded_body">פתחת את כל תכונות Pro. התמיכה שלך שומרת על Permission Pilot כחינמית וקוד פתוח.</string>
+    <string name="upgrade_screen_supporter_since">תומך מאז %1$s</string>
+    <string name="upgrade_screen_recurring_title">תמוך שוב</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot מפותח בצורה פתוחה. שקול חסות חוזרת כדי לעזור בשמירה עליו.</string>
+    <string name="upgrade_screen_recurring_action">פתח את GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-ja/strings.xml
+++ b/app/src/foss/res/values-ja/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">スポンサーになる</string>
     <string name="upgrade_foss_sponsor_subtitle">GitHub Sponsorsを開く</string>
     <string name="upgrade_foss_sponsor_returned_early">スポンサーページをご覧ください！</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">無料版</string>
+    <string name="upgrade_screen_status_free_body">無料のオープンソースビルドを使用しています。開発を支援して Pro 機能をロック解除してください。</string>
+    <string name="upgrade_screen_status_free_action">スポンサーになる</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">ご支援いただきありがとうございます！</string>
+    <string name="upgrade_screen_status_upgraded_body">すべての Pro 機能のロックを解除しました。あなたのご支援によって Permission Pilot は無料でオープンソースであり続けます。</string>
+    <string name="upgrade_screen_supporter_since">%1$s からのサポーター</string>
+    <string name="upgrade_screen_recurring_title">もう一度サポートする</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot はオープンな形で開発されています。継続的なスポンサーシップをご検討ください。</string>
+    <string name="upgrade_screen_recurring_action">GitHub スポンサーを開く</string>
 </resources>

--- a/app/src/foss/res/values-ko/strings.xml
+++ b/app/src/foss/res/values-ko/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">스폰서 되기</string>
     <string name="upgrade_foss_sponsor_subtitle">GitHub Sponsors 열기</string>
     <string name="upgrade_foss_sponsor_returned_early">스폰서 페이지를 일찍 확인해 주세요!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">무료 버전</string>
+    <string name="upgrade_screen_status_free_body">무료 오픈소스 빌드를 사용 중입니다. 개발을 지원하여 Pro 기능을 잠금 해제하세요.</string>
+    <string name="upgrade_screen_status_free_action">스폰서 되기</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">지원해 주셔서 감사합니다!</string>
+    <string name="upgrade_screen_status_upgraded_body">모든 Pro 기능이 잠금 해제되었습니다. 귀하의 지원이 Permission Pilot을 무료 오픈소스로 유지시킵니다.</string>
+    <string name="upgrade_screen_supporter_since">%1$s부터 후원자</string>
+    <string name="upgrade_screen_recurring_title">다시 후원하기</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot는 공개적으로 개발되고 있습니다. 지속을 위해 정기 후원을 고려해주세요.</string>
+    <string name="upgrade_screen_recurring_action">GitHub Sponsors 열기</string>
 </resources>

--- a/app/src/foss/res/values-ku-rTR/strings.xml
+++ b/app/src/foss/res/values-ku-rTR/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">بوونهەڵبەستكەری بھە</string>
     <string name="upgrade_foss_sponsor_subtitle">کرانەوەی GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">تکایە کاتێک لەبەر دووری بخوێنەوە بۆ پەڕەی سپۆنسەرەکان!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Guhertoya azad</string>
+    <string name="upgrade_screen_status_free_body">Tu guhertoya azad û open-source ya bikar tînî. Pêşve tînana vê sepê piştgirî bike ji bo der kirina taybetmendiyên Pro.</string>
+    <string name="upgrade_screen_status_free_action">Piştevandar bibe</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">Spas ji bo piştgiriya te!</string>
+    <string name="upgrade_screen_status_upgraded_body">Tu hemû taybetmendiyên Pro\'yî vekir. Piştgiriya te Permission Pilot\'î azad û çavkanî vekirî diparêze.</string>
+    <string name="upgrade_screen_supporter_since">Piştgirê ji %1$s ve</string>
+    <string name="upgrade_screen_recurring_title">Dîsa piştgirî bike</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot di demildestî de pêşve tê xistin. Mêvandarê dubarekirî bîr bike da ku ew berdewam bimîne.</string>
+    <string name="upgrade_screen_recurring_action">GitHub Sponsors Vekir</string>
 </resources>

--- a/app/src/foss/res/values-nb/strings.xml
+++ b/app/src/foss/res/values-nb/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">Bli sponsor</string>
     <string name="upgrade_foss_sponsor_subtitle">Åpner GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Ta et øyeblikk til å sjekke ut sponsorsiden!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Gratis versjon</string>
+    <string name="upgrade_screen_status_free_body">Du bruker den gratis, åpen kildekode-versjonen. Støtt utviklingen for å låse opp Pro-funksjonene.</string>
+    <string name="upgrade_screen_status_free_action">Bli en sponsor</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">Takk for støtten din!</string>
+    <string name="upgrade_screen_status_upgraded_body">Du har låst opp alle Pro-funksjoner. Støtten din holder Permission Pilot gratis og åpen kildekode.</string>
+    <string name="upgrade_screen_supporter_since">Støtter siden %1$s</string>
+    <string name="upgrade_screen_recurring_title">Støtt igjen</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot er utviklet åpent. Vurder et gjentakende sponsorskap for å hjelpe til med å opprettholde det.</string>
+    <string name="upgrade_screen_recurring_action">Åpne GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-nl/strings.xml
+++ b/app/src/foss/res/values-nl/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">Word sponsor</string>
     <string name="upgrade_foss_sponsor_subtitle">Opent GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Neem even een moment om de sponsorpagina te bekijken!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Gratis versie</string>
+    <string name="upgrade_screen_status_free_body">Je gebruikt de gratis, opensource-versie. Ondersteun de ontwikkeling om de Pro-functies te ontgrendelen.</string>
+    <string name="upgrade_screen_status_free_action">Word een sponsor</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">Bedankt voor je steun!</string>
+    <string name="upgrade_screen_status_upgraded_body">Je hebt alle Pro-functies ontgrendeld. Jouw steun houdt Permission Pilot gratis en opensource.</string>
+    <string name="upgrade_screen_supporter_since">Supporter sinds %1$s</string>
+    <string name="upgrade_screen_recurring_title">Opnieuw ondersteunen</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot wordt open source ontwikkeld. Overweeg een terugkerende sponsoring om het in stand te houden.</string>
+    <string name="upgrade_screen_recurring_action">GitHub Sponsors openen</string>
 </resources>

--- a/app/src/foss/res/values-pl/strings.xml
+++ b/app/src/foss/res/values-pl/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">Zostań sponsorem</string>
     <string name="upgrade_foss_sponsor_subtitle">Otwieranie strony sponsorów GitHub</string>
     <string name="upgrade_foss_sponsor_returned_early">Poświęć chwilę na odwiedzenie strony sponsorów!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Pilot Uprawnień Foss</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Wersja darmowa</string>
+    <string name="upgrade_screen_status_free_body">Korzystasz z bezpłatnej wersji otwarto-źródłowej. Wesprzyj rozwój, aby odblokować funkcje wersji Pro.</string>
+    <string name="upgrade_screen_status_free_action">Zostań wspierającym</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">Dziękuję za wsparcie!</string>
+    <string name="upgrade_screen_status_upgraded_body">Odblokowałeś wszystkie funkcje Pro. Dzięki Twojemu wsparciu Pilot Uprawnień pozostaje darmowy i ma otwarte oprogramowanie.</string>
+    <string name="upgrade_screen_supporter_since">Wspierający od %1$s</string>
+    <string name="upgrade_screen_recurring_title">Ponowne wsparcie</string>
+    <string name="upgrade_screen_recurring_body">Pilot Uprawnień jest rozwijany w sposób otwarty. Rozważ stałe wspieranie, aby go utrzymać.</string>
+    <string name="upgrade_screen_recurring_action">Otwórz GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-pt-rBR/strings.xml
+++ b/app/src/foss/res/values-pt-rBR/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">Torne-se um patrocinador</string>
     <string name="upgrade_foss_sponsor_subtitle">Abre o GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Por favor, reserve um momento para visitar a página de patrocinadores!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Versão gratuita</string>
+    <string name="upgrade_screen_status_free_body">Você está usando a versão gratuita e de código aberto. Apoie o desenvolvimento para desbloquear os recursos Pro.</string>
+    <string name="upgrade_screen_status_free_action">Torne-se um Patrocinador</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">Obrigado pelo seu apoio!</string>
+    <string name="upgrade_screen_status_upgraded_body">Você desbloqueou todos os recursos Pro. Seu apoio mantém Permission Pilot gratuito e de código aberto.</string>
+    <string name="upgrade_screen_supporter_since">Apoiador desde %1$s</string>
+    <string name="upgrade_screen_recurring_title">Apoiar novamente</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot é desenvolvido de forma aberta. Considere um patrocínio recorrente para ajudar a sustentá-lo.</string>
+    <string name="upgrade_screen_recurring_action">Abrir GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-pt/strings.xml
+++ b/app/src/foss/res/values-pt/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">Tornar-se Patrocinador</string>
     <string name="upgrade_foss_sponsor_subtitle">Abre os Patrocinadores do GitHub</string>
     <string name="upgrade_foss_sponsor_returned_early">Por favor reserve um momento para visitar a página de patrocinadores!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Versão gratuita</string>
+    <string name="upgrade_screen_status_free_body">Está a usar a versão gratuita e de código aberto. Apoie o desenvolvimento para desbloquear as funcionalidades Pro.</string>
+    <string name="upgrade_screen_status_free_action">Seja um Patrocinador</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">Obrigado pelo seu apoio!</string>
+    <string name="upgrade_screen_status_upgraded_body">Desbloqueou todas as funcionalidades Pro. O seu apoio mantém Permission Pilot gratuito e de código aberto.</string>
+    <string name="upgrade_screen_supporter_since">Patrocinador desde %1$s</string>
+    <string name="upgrade_screen_recurring_title">Apoie novamente</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot é desenvolvido de forma aberta. Considere um patrocínio recorrente para ajudar a sustentá-lo.</string>
+    <string name="upgrade_screen_recurring_action">Abrir GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-ro/strings.xml
+++ b/app/src/foss/res/values-ro/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">Devino sponsor</string>
     <string name="upgrade_foss_sponsor_subtitle">Deschide GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Te rugăm să arunci o privire la pagina de sponsori!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Versiunea gratuită</string>
+    <string name="upgrade_screen_status_free_body">Folosești versiunea gratuită, cu sursă deschisă. Sprijină dezvoltarea pentru a debloca funcțiile Pro.</string>
+    <string name="upgrade_screen_status_free_action">Devino sponsor</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">Îți mulțumim pentru sprijin!</string>
+    <string name="upgrade_screen_status_upgraded_body">Ai deblocat toate funcțiile Pro. Sprijinul tău menține Permission Pilot gratuit și cu sursă deschisă.</string>
+    <string name="upgrade_screen_supporter_since">Suporter din %1$s</string>
+    <string name="upgrade_screen_recurring_title">Sprijină din nou</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot este dezvoltat deschis. Ia în considerare o sponsorizare recurentă pentru a-l susține.</string>
+    <string name="upgrade_screen_recurring_action">Deschide GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-ru/strings.xml
+++ b/app/src/foss/res/values-ru/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">Стать спонсором</string>
     <string name="upgrade_foss_sponsor_subtitle">Открывает GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Пожалуйста, уделите момент и посетите страницу спонсора!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Бесплатная версия</string>
+    <string name="upgrade_screen_status_free_body">Вы используете бесплатную, открытую версию. Поддержите разработку, чтобы разблокировать функции Pro.</string>
+    <string name="upgrade_screen_status_free_action">Стать спонсором</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">Спасибо за вашу поддержку!</string>
+    <string name="upgrade_screen_status_upgraded_body">Вы разблокировали все функции Pro. Ваша поддержка делает Permission Pilot бесплатным и открытым.</string>
+    <string name="upgrade_screen_supporter_since">Вы нас поддерживаете с %1$s</string>
+    <string name="upgrade_screen_recurring_title">Поддержать снова</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot разрабатывается открыто. Подумайте о регулярной поддержке, чтобы помочь нам развиваться.</string>
+    <string name="upgrade_screen_recurring_action">Открыть GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-sk/strings.xml
+++ b/app/src/foss/res/values-sk/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">Stať sa sponzorom</string>
     <string name="upgrade_foss_sponsor_subtitle">Otvorí GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Prosím, ven\'te chvíľu na prezrenie stránky sponzorov!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Bezplatná verzia</string>
+    <string name="upgrade_screen_status_free_body">Používate bezplatnú, otvorenú verziu. Podporte vývoj a odomknite funkcie Pro.</string>
+    <string name="upgrade_screen_status_free_action">Staňte sa sponzorom</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">Ďakujeme za vašu podporu!</string>
+    <string name="upgrade_screen_status_upgraded_body">Odomkli ste všetky funkcie Pro. Vaša podpora udržuje Permission Pilot bezplatný a otvorený.</string>
+    <string name="upgrade_screen_supporter_since">Podporovateľ od %1$s</string>
+    <string name="upgrade_screen_recurring_title">Podporte znova</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot sa vyvíja otvorene. Zvážte opakovaný sponzorský príspevok, aby ste pomohli ho udržať.</string>
+    <string name="upgrade_screen_recurring_action">Otvoriť GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-sr/strings.xml
+++ b/app/src/foss/res/values-sr/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">Постаните спонзор</string>
     <string name="upgrade_foss_sponsor_subtitle">Отвара GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Посветите тренутак да погледате страницу спонзора!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Бесплатна верзија</string>
+    <string name="upgrade_screen_status_free_body">Користите бесплатну верзију отвореног кода. Подржите развој да откључате Pro функције.</string>
+    <string name="upgrade_screen_status_free_action">Постаните спонзор</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">Хвала вам на подршци!</string>
+    <string name="upgrade_screen_status_upgraded_body">Откључали сте све Pro функције. Ваша подршка одржава Permission Pilot бесплатним и отвореним.</string>
+    <string name="upgrade_screen_supporter_since">Подржавач од %1$s</string>
+    <string name="upgrade_screen_recurring_title">Поново подржи</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot се развија отворено. Размотри редовно спонзорство да помогнеш у његовом одржавању.</string>
+    <string name="upgrade_screen_recurring_action">Отвори GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-sv/strings.xml
+++ b/app/src/foss/res/values-sv/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">Bli sponsor</string>
     <string name="upgrade_foss_sponsor_subtitle">Öppnar GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Ta gärna en stund att kolla in sponsorsidan!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Gratis version</string>
+    <string name="upgrade_screen_status_free_body">Du använder den kostnadsfria, öppen källkods-versionen. Stöd utvecklingen för att låsa upp Pro-funktionerna.</string>
+    <string name="upgrade_screen_status_free_action">Bli en sponsor</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">Tack för ditt stöd!</string>
+    <string name="upgrade_screen_status_upgraded_body">Du har låst upp alla Pro-funktioner. Ditt stöd håller Permission Pilot kostnadsfritt och öppen källkod.</string>
+    <string name="upgrade_screen_supporter_since">Supporter sedan %1$s</string>
+    <string name="upgrade_screen_recurring_title">Stödja igen</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot utvecklas öppet. Överväg ett återkommande sponsorskap för att hjälpa till att upprätthålla det.</string>
+    <string name="upgrade_screen_recurring_action">Öppna GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-th/strings.xml
+++ b/app/src/foss/res/values-th/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">เป็นผู้สนับสนุน</string>
     <string name="upgrade_foss_sponsor_subtitle">เปิด GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">โปรดใช้เวลาสักครู่เช็คหน้าผู้สนับสนุน!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">เวอร์ชันฟรี</string>
+    <string name="upgrade_screen_status_free_body">คุณใช้บิลด์ฟรีและโอเพนซอร์ส สนับสนุนการพัฒนาเพื่อปลดล็อคฟีเจอร์ Pro</string>
+    <string name="upgrade_screen_status_free_action">เป็นผู้สนับสนุน</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">ขอบคุณสำหรับการสนับสนุนของคุณ!</string>
+    <string name="upgrade_screen_status_upgraded_body">คุณได้ปลดล็อคฟีเจอร์ Pro ทั้งหมดแล้ว การสนับสนุนของคุณทำให้ Permission Pilot ยังคงเป็นแบบฟรีและโอเพนซอร์ส</string>
+    <string name="upgrade_screen_supporter_since">ผู้สนับสนุนตั้งแต่ %1$s</string>
+    <string name="upgrade_screen_recurring_title">สนับสนุนอีกครั้ง</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot ได้รับการพัฒนาแบบเปิด ลองพิจารณาการสนับสนุนแบบประจำเพื่อช่วยรักษาแอปไว้</string>
+    <string name="upgrade_screen_recurring_action">เปิด GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-tr/strings.xml
+++ b/app/src/foss/res/values-tr/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">Sponsor Ol</string>
     <string name="upgrade_foss_sponsor_subtitle">GitHub Sponsors\'u açar</string>
     <string name="upgrade_foss_sponsor_returned_early">Lütfen bir dakikanızı ayırıp sponsor sayfasına göz atın!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Ücretsiz sürüm</string>
+    <string name="upgrade_screen_status_free_body">Ücretsiz, açık kaynaklı sürümü kullanıyorsunuz. Pro özelliklerinin kilidini açmak için geliştirmeyi destekleyin.</string>
+    <string name="upgrade_screen_status_free_action">Destekçi Olun</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">Desteğiniz için teşekkürler!</string>
+    <string name="upgrade_screen_status_upgraded_body">Tüm Pro özelliklerinin kilidini açtınız. Desteğiniz Permission Pilot\'u ücretsiz ve açık kaynaklı tutuyor.</string>
+    <string name="upgrade_screen_supporter_since">%1$s\'den beri destekçi</string>
+    <string name="upgrade_screen_recurring_title">Tekrar Destekle</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot açık olarak geliştirilmektedir. Bunu sürdürmeye yardımcı olmak için yinelenen bir sponsorluk düşünün.</string>
+    <string name="upgrade_screen_recurring_action">GitHub Sponsors\'ı Aç</string>
 </resources>

--- a/app/src/foss/res/values-uk/strings.xml
+++ b/app/src/foss/res/values-uk/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">Стати спонсором</string>
     <string name="upgrade_foss_sponsor_subtitle">Відкриває сторінку GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Будь ласка, ознайомтеся зі сторінкою спонсора!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Безплатна версія</string>
+    <string name="upgrade_screen_status_free_body">Ви використовуєте безплатну версію з відкритим кодом. Підтримайте розробку, щоб розблокувати функції Pro.</string>
+    <string name="upgrade_screen_status_free_action">Стати спонсором</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">Дякуємо за вашу підтримку!</string>
+    <string name="upgrade_screen_status_upgraded_body">Ви розблокували всі функції Pro. Ваша підтримка утримує Permission Pilot безплатним та з відкритим кодом.</string>
+    <string name="upgrade_screen_supporter_since">Спонсор з %1$s</string>
+    <string name="upgrade_screen_recurring_title">Підтримати знову</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot розробляється відкрито. Розгляньте регулярне спонсорство, щоб підтримати його розвиток.</string>
+    <string name="upgrade_screen_recurring_action">Відкрити GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-vi/strings.xml
+++ b/app/src/foss/res/values-vi/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">Trở thành nhà tài trợ</string>
     <string name="upgrade_foss_sponsor_subtitle">Mở GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Vui lòng dành chút thời gian ghé thăm trang nhà tài trợ!</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">Phiên bản miễn phí</string>
+    <string name="upgrade_screen_status_free_body">Bạn đang dùng phiên bản miễn phí, mã nguồn mở. Hỗ trợ phát triển để mở khóa tính năng Pro.</string>
+    <string name="upgrade_screen_status_free_action">Trở thành nhà tài trợ</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">Cảm ơn bạn đã ủng hộ!</string>
+    <string name="upgrade_screen_status_upgraded_body">Bạn đã mở khóa tất cả các tính năng Pro. Sự ủng hộ của bạn giúp Permission Pilot luôn miễn phí và mã nguồn mở.</string>
+    <string name="upgrade_screen_supporter_since">Người ủng hộ từ %1$s</string>
+    <string name="upgrade_screen_recurring_title">Ủng hộ lại</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot được phát triển công khai. Hãy xem xét một chương trình tài trợ định kỳ để giúp duy trì nó.</string>
+    <string name="upgrade_screen_recurring_action">Mở GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-zh-rCN/strings.xml
+++ b/app/src/foss/res/values-zh-rCN/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">成为赞助者</string>
     <string name="upgrade_foss_sponsor_subtitle">打开 GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">请花点时间查看赞助页面！</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">免费版本</string>
+    <string name="upgrade_screen_status_free_body">您正在使用免费的开源版本。支持开发以解锁 Pro 功能。</string>
+    <string name="upgrade_screen_status_free_action">成为赞助者</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">感谢您的支持！</string>
+    <string name="upgrade_screen_status_upgraded_body">您已解锁所有 Pro 功能。您的支持让 Permission Pilot 保持免费和开源。</string>
+    <string name="upgrade_screen_supporter_since">自 %1$s 以来的支持者</string>
+    <string name="upgrade_screen_recurring_title">再次支持</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot 是公开开发的。请考虑定期赞助以帮助维持其运营。</string>
+    <string name="upgrade_screen_recurring_action">打开 GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-zh-rTW/strings.xml
+++ b/app/src/foss/res/values-zh-rTW/strings.xml
@@ -4,4 +4,17 @@
     <string name="upgrade_foss_sponsor_action">成為贊助者</string>
     <string name="upgrade_foss_sponsor_subtitle">開啟 GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">請花一點時間查看贊助頁面！</string>
+    <!-- Settings entry title (FOSS flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
+    <!-- Free status -->
+    <string name="upgrade_screen_status_free_title">免費版本</string>
+    <string name="upgrade_screen_status_free_body">您正在使用免費的開源版本。請支持開發以解鎖 Pro 功能。</string>
+    <string name="upgrade_screen_status_free_action">成為贊助者</string>
+    <!-- Supporter status -->
+    <string name="upgrade_screen_status_upgraded_title">感謝您的支持！</string>
+    <string name="upgrade_screen_status_upgraded_body">您已解鎖所有 Pro 功能。感謝您的支持，使 Permission Pilot 保持免費且開源。</string>
+    <string name="upgrade_screen_supporter_since">自 %1$s 起的支持者</string>
+    <string name="upgrade_screen_recurring_title">再次支持</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot 是以開源方式開發的。請考慮定期贊助以幫助維持它的發展。</string>
+    <string name="upgrade_screen_recurring_action">開啟 GitHub Sponsors</string>
 </resources>

--- a/app/src/gplay/res/values-af-rZA/strings.xml
+++ b/app/src/gplay/res/values-af-rZA/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play-dienste is nie beskikbaar nie.</string>
     <string name="upgrades_no_purchases_found_check_account">Geen aankope gevind nie. Gebruik jy die regte rekening?</string>
+    <string name="upgrades_gplay_already_owned_title">Reeds gekoop</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play rapporteer dat u reeds hierdie opgradering besit, maar dit kon nie herstel word nie. Kyk dat u aangemeld is met die Google-rekening wat vir die oorspronklike aankoop gebruik is, en probeer dan \"Aankoop herstel\".</string>
     <string name="upgrade_screen_preamble">Permission Pilot is sonder advertensies en respekteer jou privaatheid. Opgradering ondersteun voortgesette ontwikkeling.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play is nie beskikbaar nie</string>
+    <string name="upgrade_screen_offers_unavailable_message">Kon nie die aankoop-opsies laai nie. Google Play kan tydelik nie beskikbaar wees nie — kyk u verbinding en probeer weer.</string>
     <string name="upgrade_screen_subscription_trial_action">Begin gratis proeftydperk</string>
     <string name="upgrade_screen_subscription_action">Teken in</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/jaar, kanselleer enige tyd</string>
-    <string name="upgrade_screen_iap_action">Koop Pro</string>
+    <string name="upgrade_screen_iap_action">Eenmalige aankoop</string>
     <string name="upgrade_screen_iap_action_hint">Eenmalige aankoop van %s</string>
     <string name="upgrade_screen_restore_purchase_action">Herstel aankoop</string>
     <string name="upgrade_screen_restore_purchase_message">Geen aankope gevind nie. Maak seker jy is met die korrekte Google-rekening aangemeld.</string>
+    <string name="upgrade_screen_restore_banner_title">Reeds Pro gekoop?</string>
+    <string name="upgrade_screen_restore_banner_body">Dit lyk asof u hierdie toestel reeds na Pro opgegradering gedoen het. Herstel u aankoop om dit weer te ontgrendel.</string>
     <string name="upgrade_screen_options_description">Intekeninge vernuwe outomaties. Jy kan enige tyd kanselleer.</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">U is Pro — dankie!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">U eenmalige Pro-aankoop ontsluit alle Pro-funksies, voorgoed.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">U abonnement ontsluit alle Pro-funksies.</string>
+    <string name="upgrade_screen_owned_sub_title">U abonnement</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">U abonnement is aktief en word outomaties vernuwe.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">U abonnement sal verval en word nie vernuwe nie. U behou Pro totdat dit afloop.</string>
+    <string name="upgrade_screen_owned_both_warning">U het die eenmalige Pro-opgradering en ook \'n aktiewe abonnement. U benodig nie albei — kanselleer die abonnement in Google Play om verdere koste te vermy.</string>
+    <string name="upgrade_screen_manage_subscription_action">Bestuur abonnement</string>
+    <string name="upgrade_screen_owned_iap_title">Lewenslange Pro</string>
+    <string name="upgrade_screen_owned_iap_body">U het die eenmalige Pro-opgradering. Geen abonnement, geen vernuewings nie.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Omskakel na \'n eenmalige aankoop</string>
+    <string name="upgrade_screen_switch_purchase_note">U abonnement sal nie vernuwe nie, sodat u nou na die permanente eenmalige Pro-aankoop kan oorgaan.</string>
+    <string name="upgrade_screen_switch_locked_note">Om na die eenmalige aankoop oor te skakel, kanselleer eers u abonnement in Google Play. Hierdie aanbieding ontsluit sodra dit ingestel word om nie te vernuwe nie.</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play kontroleer slegs die rekening waarmee u tans aangemeld is. Die eenmalige aankoop is afsonderlik van u abonnement.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">U abonnement is steeds aktief en vernuwe. Kanselleer dit eers in Google Play.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Kon nie u abonnement met Google Play verifieer nie. Probeer asseblief weer.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">Bevestig u aankoop</string>
+    <string name="upgrade_screen_grace_body">Wag vir Google Play om u Pro-aankoop weer te bevestig. Dit los gewoonlik vanself op.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Ons kan u Pro-aankoop nog steeds nie met Google Play weer bevestig nie. As dit aanhou gebeur, probeer u aankoop herstel of kontak ondersteuning.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">Lyk die status verkeerd?</string>
+    <string name="upgrade_screen_restore_status_body">As u Pro gekoop het maar dit wys nie, voer \'n lewendige kontrole teen Google Play uit.</string>
+    <string name="upgrade_screen_restore_success_message">Aankoop herstel.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Maak seker u is aangemeld met die Google-rekening wat u vir die aankoop gebruik het. \'n Lewendige kontrole teen Google Play het pas plaasgevind.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Opgradering-opsies</string>
+    <string name="upgrade_screen_offers_body">Dieselfde funksies, net verskillende prysmodelle.</string>
+    <string name="upgrade_screen_offers_or">of</string>
+    <string name="upgrade_screen_subscription_offer_title">Jaarlikse abonnement</string>
+    <string name="upgrade_screen_subscription_offer_body">Vernuwe jaarliks na die gratis proefperiode. Kanselleer enige tyd in Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Vernuwe jaarliks. Kanselleer enige tyd in Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Koop eenmaal</string>
+    <string name="upgrade_screen_iap_offer_body">Eenmalige betaling, geen vernuwings.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">Abonnement nog aktief</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Google Play is pas nagegaan, maar geen Pro-aankoop kon bevestig word vir die rekening wat hierdie toepassing gebruik nie.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Veelvuldige rekeninge kan Google Play verwar. Die installering van die toepassing deur die Google Play-webwerf dwing dit om met \'n spesifieke rekening geassosieer te word.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Google Play-sinkronisasie kan tyd neem. Probeer herlaai, maak die Google Play Store-kas skoon of wag net.</string>
+    <string name="upgrade_screen_restore_contact_hint">Steeds vasgevang? Kontak ondersteuning vanaf die e-posadres waarmee die aankoop gemaak is, en sluit u Google Play-ordernommer in.</string>
 </resources>

--- a/app/src/gplay/res/values-am/strings.xml
+++ b/app/src/gplay/res/values-am/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play አገልግሎቶች አይገኙም።</string>
     <string name="upgrades_no_purchases_found_check_account">ምንም ግዢዎች አልተገኙም። ትክክለኛውን መለያ እየተጠቀሙ ነው?</string>
+    <string name="upgrades_gplay_already_owned_title">ቀድሞ ተገዛ</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play ይህን ማሻሻያ ቀድሞ ይዤተዋል ይላል፣ ነገር ግን ሊመለስ አልተቻለም። ዋናውን ግዢ ለያዙ Google መለያ ገብተዋል መሆኑን ያረጋግጡ፣ ከዚያ \"ግዢ ወደ ነበር ሆኑ\" ሞክሩ።</string>
     <string name="upgrade_screen_preamble">Permission Pilot አዶዘቕ ዘርዘር እና ስሴያወን ይካባተኻላለ። ደርጉን ወደፈርም ብጅት ይደግፋለ።</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play አይገኝም</string>
+    <string name="upgrade_screen_offers_unavailable_message">ግዢ አማራጮችን መጫን አልተቻለም። Google Play በጊዜው አይገኝም ሊሆን ይችላል - ግንኙነትዎን ያረጋግጡ እና እንደገና ሞክሩ።</string>
     <string name="upgrade_screen_subscription_trial_action">የ፣የ ንብስት ይጀምሩ</string>
     <string name="upgrade_screen_subscription_action">ይመዝገቡ</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/ዓመት፣ በማንኛውም ጊዜ ይሰርዙ</string>
-    <string name="upgrade_screen_iap_action">Pro የጭንት</string>
+    <string name="upgrade_screen_iap_action">አንድ ጊዜ ግዢ</string>
     <string name="upgrade_screen_iap_action_hint">%s የአክ ሥዳን</string>
     <string name="upgrade_screen_restore_purchase_action">ግዢን ወደነበረበት መልስ</string>
     <string name="upgrade_screen_restore_purchase_message">ምንም የሥዳ አልተገኙም። በဍርው የ Google መገለጫዘርዘር ፣ ለዒል ዘስትወ።</string>
+    <string name="upgrade_screen_restore_banner_title">ቀድሞ Pro ገዝተዋል?</string>
+    <string name="upgrade_screen_restore_banner_body">በዚህ መሣሪያ ላይ በፊት Pro ገዝተዋል ይመስላል። ዳግም ለመክፈት ግዢዎን ወደ ነበር ሆኑ።</string>
     <string name="upgrade_screen_options_description">ኰይዘቶች በርስ ይተያያኳሉ። በአንደም መቀሰል ይቻላሉ።</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Pro ነዎ — አመሰግናለሁ!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">የአንድ ጊዜ Pro ግዢ ሁሉንም Pro ባህሪ ለዘላለም ይከፍታል።</string>
+    <string name="upgrade_screen_owned_hero_sub_body">ሰዋስክ ሁሉም ፕሮ ባህሪ ይከፍታል።</string>
+    <string name="upgrade_screen_owned_sub_title">ሰዋስክ</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">ሰዋስክ ንቁ ነው እና ራሱ በራሱ ይታደሳል።</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">ሰዋስክ ለመጨረስ ተዘጋጅቷል እና አይታደስም። እስከሚያልቅ ድረስ ፕሮ ይኖርዎታል።</string>
+    <string name="upgrade_screen_owned_both_warning">ለአንድ ጊዜ ፕሮ ማሻሻያ ይዞታል እንዲሁም ንቁ ሰዋስ አለዎት። ሁለቱን ስለማያስፈልግዎ — ተጨማሪ ክፍያ ለማስወገድ በGoogle Play ሰዋስን ይሰርዙ።</string>
+    <string name="upgrade_screen_manage_subscription_action">ሰዋስን ያስተዳድሩ</string>
+    <string name="upgrade_screen_owned_iap_title">ለዘላለም ፕሮ</string>
+    <string name="upgrade_screen_owned_iap_body">ለአንድ ጊዜ ፕሮ ማሻሻያ ይዞታል። ሰዋስ የለም፣ ምንም ታደሳ አይደለም።</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">ወደ አንድ ጊዜ ግዢ ይቀይሩ</string>
+    <string name="upgrade_screen_switch_purchase_note">ሰዋስክ አይታደስም፣ ስለዚህ አሁን ወደ ዘላለም ለአንድ ጊዜ ፕሮ ግዢ መዋወር ይችላሉ።</string>
+    <string name="upgrade_screen_switch_locked_note">ወደ አንድ ጊዜ ያለው ገዥ ለመቀየር በመጀመሪያ Google Play ላይ የእርስዎን ምዝገባ ይሰርዙ። ይህ አማራጭ አቁም ሲተገበር ይክፈታል።</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play በሚገቡበት ሂሳብዎ ብቻ ይከታተላል። አንድ ጊዜ ያለው ገዥ ከእርስዎ ምዝገባ ተለይቶ ነው።</string>
+    <string name="upgrade_screen_sub_still_renewing_message">የእርስዎ ምዝገባ አሁንም ንቁ እና ይታደሳል። በGoogle Play ውስጥ በመጀመሪያ ይሰርዙት።</string>
+    <string name="upgrade_screen_sub_check_failed_message">የእርስዎን ምዝገባ በGoogle Play ሊያረጋገ አልቻለም። እንደገና ይሞክሩ።</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">የእርስዎን ገዥ በማረጋገጥ ላይ ነው</string>
+    <string name="upgrade_screen_grace_body">Google Play የእርስዎን Pro ገዥ ለማረጋገጥ ጠብቋ ነው። ይህ ብዙውን ጊዜ በራሱ ይፈታል።</string>
+    <string name="upgrade_screen_grace_diagnostics_body">አሁንም የእርስዎን Pro ገዥ በGoogle Play ሊያረጋገ አልቻለም። ይህ ሆኖ ቢቆየ የእርስዎን ገዥ ወደነበረበት ይመልሱ ወይም ደገፍ ያነጋግሩ።</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">ሁኔታው ትክክል አይመስልም?</string>
+    <string name="upgrade_screen_restore_status_body">Pro ገዥ ወደሩ ነገር ግን ይታይ ካልሆነ Google Play ላይ አሁን ምርመራ ያሂዱ።</string>
+    <string name="upgrade_screen_restore_success_message">ገዥ ወደነበረበት መልስ ተደረገ።</string>
+    <string name="upgrade_screen_restore_webinstall_hint">ያረጋግጡ ወደ ያገዛሙት Google ሐሳብዎ ተመዝገበዋል። Google Play ላይ ቀጥተኛ ምርመራ አሁን ተሮጠ።</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">የማሻሻያ አማራጮች</string>
+    <string name="upgrade_screen_offers_body">ተመሳሳይ ባህሪያት፤ የተለየ የዋጋ ሞዴል ብቻ።</string>
+    <string name="upgrade_screen_offers_or">ወይም</string>
+    <string name="upgrade_screen_subscription_offer_title">ዓመታዊ ምዝገባ</string>
+    <string name="upgrade_screen_subscription_offer_body">ነፃ ሙከራ ከቋጣ ዓመታዊ ይታጀብራል። በማንኛውም ጊዜ Google Play ውስጥ ይሰርዙ።</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">ዓመታዊ ይታጀብራል። በማንኛውም ጊዜ Google Play ውስጥ ይሰርዙ።</string>
+    <string name="upgrade_screen_iap_offer_title">አንድ ጊዜ ይገዙ</string>
+    <string name="upgrade_screen_iap_offer_body">አንድ ክፍያ፤ ምንም ማታጀብር የለም።</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">ምዝገባ አሁንም ንቁ ነው።</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Google Play አሁን ተረጋገጧል፣ ግን ይህ መተግበሪያ ለሚጠቀሙት መለያ ምንም Pro ግዢ ማረጋገጥ አልተቻለም።</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">ብዙ መለያዎች Google Play ማምታታት ይችላሉ። መተግበሪያውን በGoogle Play ድርጣቢያ በኩል መጫን ከተወሰነ መለያ ጋር ግንኙነትን ያስገድዳል።</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Google Play ሲምሪዝሽን ጊዜ ሊወስድ ይችላል። እንደገና ማስጀመር፣ Google Play Store መሸጎጫ ማጥራት ወይም ብቻ መጠበቅ ይሞክሩ።</string>
+    <string name="upgrade_screen_restore_contact_hint">አሁንም ተጣበቀ? ግዢውን ያደረገውን ኢሜይል በመጠቀም ድጋፋን ያገናኙ እና የGoogle Play ትዕዛዝ ቁጥር ያካትቱ።</string>
 </resources>

--- a/app/src/gplay/res/values-ar/strings.xml
+++ b/app/src/gplay/res/values-ar/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">خدمات Google Play غير متوفرة.</string>
     <string name="upgrades_no_purchases_found_check_account">لم يتم العثور على مشتريات. أتستخدم الحساب الصحيح؟</string>
+    <string name="upgrades_gplay_already_owned_title">تم شراؤه بالفعل</string>
+    <string name="upgrades_gplay_already_owned_error">يفيد Google Play بأنك تمتلك هذه الترقية بالفعل، لكن لم يتمكن من استعادتها. تحقق من أنك مسجل الدخول بحساب Google الذي استخدمته في الشراء الأصلي، ثم جرّب \"استعادة الشراء\".</string>
     <string name="upgrade_screen_preamble">Permission Pilot خالي من الإعلانات ويحترم خصوصيتك. الترقية تدعم استمرار التطوير.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play غير متوفر</string>
+    <string name="upgrade_screen_offers_unavailable_message">تعذر تحميل خيارات الشراء. قد يكون Google Play غير متوفر مؤقتاً - تحقق من اتصالك وحاول مرة أخرى.</string>
     <string name="upgrade_screen_subscription_trial_action">ابدأ الإصدار التجريبي المجاني</string>
     <string name="upgrade_screen_subscription_action">اشتراك</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/سنة، إلغاء في أي وقت</string>
-    <string name="upgrade_screen_iap_action">شراء النسخة المدفوعة</string>
+    <string name="upgrade_screen_iap_action">شراء مرة واحدة</string>
     <string name="upgrade_screen_iap_action_hint">شراء لمرة واحدة بمبلغ %s</string>
     <string name="upgrade_screen_restore_purchase_action">استعادة المُشتَرَى</string>
     <string name="upgrade_screen_restore_purchase_message">لا توجد مشتريات. تأكد من تسجيل الدخول بحساب Google الصحيح.</string>
+    <string name="upgrade_screen_restore_banner_title">هل اشتريت Pro بالفعل؟</string>
+    <string name="upgrade_screen_restore_banner_body">يبدو أنك ترقيت إلى Pro على هذا الجهاز من قبل. استعد شراءك لفتح قفله مرة أخرى.</string>
     <string name="upgrade_screen_options_description">تتجدد الاشتراكات تلقائياً. يمكنك الإلغاء في أي وقت.</string>
     <string name="upgrade_title_suffix">احترافي</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">أنت Pro الآن - شكراً لك!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">شراء Pro لمرة واحدة يفتح كل ميزة Pro إلى الأبد.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">اشتراكك يفتح كل ميزة Pro.</string>
+    <string name="upgrade_screen_owned_sub_title">اشتراكك</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">اشتراكك نشط ويتم تجديده تلقائياً.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">تم ضبط اشتراكك للانتهاء ولن يتم تجديده. ستحتفظ بـ Pro حتى ينتهي.</string>
+    <string name="upgrade_screen_owned_both_warning">أنت تمتلك ترقية Pro لمرة واحدة وأيضاً لديك اشتراك نشط. أنت لا تحتاج إلى كليهما — ألغِ الاشتراك في Google Play لتجنب رسوم إضافية.</string>
+    <string name="upgrade_screen_manage_subscription_action">إدارة الاشتراك</string>
+    <string name="upgrade_screen_owned_iap_title">Pro مدى الحياة</string>
+    <string name="upgrade_screen_owned_iap_body">أنت تمتلك ترقية Pro لمرة واحدة. لا اشتراك، لا تجديدات.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">التبديل إلى الشراء لمرة واحدة</string>
+    <string name="upgrade_screen_switch_purchase_note">لن يتم تجديد اشتراكك، لذا يمكنك الآن الانتقال إلى شراء Pro لمرة واحدة دائم.</string>
+    <string name="upgrade_screen_switch_locked_note">للتبديل إلى الشراء لمرة واحدة، قم أولاً بإلغاء اشتراكك في Google Play. يصبح هذا العرض متاحاً عندما يتم إيقاف التجديد التلقائي.</string>
+    <string name="upgrade_screen_limitation_disclosure">يتحقق Google Play فقط من الحساب الذي تم تسجيل الدخول إليه حالياً. الشراء لمرة واحدة منفصل عن اشتراكك.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">اشتراكك لا يزال نشطاً ويتم تجديده. قم بإلغائه في Google Play أولاً.</string>
+    <string name="upgrade_screen_sub_check_failed_message">تعذر التحقق من اشتراكك مع Google Play. يرجى المحاولة مجدداً.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">جاري تأكيد عملية الشراء</string>
+    <string name="upgrade_screen_grace_body">جاري انتظار Google Play لإعادة تأكيد شراء Pro الخاص بك. عادة ما يتم حل هذا تلقائياً.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">لا يمكننا إعادة تأكيد شراء Pro الخاص بك مع Google Play حتى الآن. إذا استمرت هذه المشكلة، حاول استعادة عملية الشراء أو اتصل بالدعم.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">هل تبدو الحالة خاطئة؟</string>
+    <string name="upgrade_screen_restore_status_body">إذا اشتريت Pro لكنه لا يظهر، قم بإجراء فحص مباشر مقابل Google Play.</string>
+    <string name="upgrade_screen_restore_success_message">تم استعادة عملية الشراء.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">تأكد من تسجيل الدخول باستخدام حساب Google الذي استخدمته للشراء. تم تشغيل فحص مباشر مقابل Google Play للتو.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">خيارات الترقية</string>
+    <string name="upgrade_screen_offers_body">نفس الميزات، فقط نماذج تسعير مختلفة.</string>
+    <string name="upgrade_screen_offers_or">أو</string>
+    <string name="upgrade_screen_subscription_offer_title">اشتراك سنوي</string>
+    <string name="upgrade_screen_subscription_offer_body">يتجدد سنوياً بعد النسخة التجريبية المجانية. ألغِ في أي وقت في Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">يتجدد سنويًا. يمكنك الإلغاء في أي وقت من خلال Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">شراء مرة واحدة</string>
+    <string name="upgrade_screen_iap_offer_body">دفعة واحدة، بدون تجديدات.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">الاشتراك لا يزال نشطًا</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">تم التحقق من Google Play للتو، لكن تعذر تأكيد شراء Pro للحساب المستخدم.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">قد تسبب حسابات متعددة التباسًا في Google Play. يؤدي تثبيت التطبيق من موقع Google Play على الويب إلى ربطه بحساب معين.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">قد تستغرق مزامنة Google Play بعض الوقت. جرب إعادة تشغيل الجهاز أو مسح ذاكرة التخزين المؤقتة لمتجر Google Play أو ببساطة الانتظار.</string>
+    <string name="upgrade_screen_restore_contact_hint">لا تزال عالقًا؟ تواصل مع الدعم من البريد الإلكتروني الذي استخدمته للشراء وأرفق رقم طلب Google Play.</string>
 </resources>

--- a/app/src/gplay/res/values-az/strings.xml
+++ b/app/src/gplay/res/values-az/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play xidmətləri mövcud deyil.</string>
     <string name="upgrades_no_purchases_found_check_account">Heç bir satınalma tapılmadı. Doğru hesabı istifadə edirsiniz?</string>
+    <string name="upgrades_gplay_already_owned_title">Artıq satın alındı</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play bildirir ki, siz artıq bu yüksəltməyə sahibsiniz, lakin o bərpa olunmadı. Orijinal alış üçün istifadə etdiyiniz Google hesabına daxil olduğunuzu yoxlayın, sonra \"Satın almağı bərpa et\"-i cəhd edin.</string>
     <string name="upgrade_screen_preamble">Permission Pilot rəkləmsüzdür və məxfiliyinizə hörmət edir. Yüksəltmək davamlı gelişdirməni dəstəkləyir.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play əlçatan deyil</string>
+    <string name="upgrade_screen_offers_unavailable_message">Satın alma seçənəkləri yüklənə bilmədi. Google Play müvəqqəti olaraq əlçatan olmaya bilər — bağlantınızı yoxlayın və yenidən cəhd edin.</string>
     <string name="upgrade_screen_subscription_trial_action">Pülsüz sınaq başladın</string>
     <string name="upgrade_screen_subscription_action">Abunə olun</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/il, istənilən vaxt ləğv edin</string>
-    <string name="upgrade_screen_iap_action">Pro al</string>
+    <string name="upgrade_screen_iap_action">Birdəfəlik alış</string>
     <string name="upgrade_screen_iap_action_hint">%s dəyərində bir dəfəlik alış</string>
     <string name="upgrade_screen_restore_purchase_action">Alışı bərpa et</string>
     <string name="upgrade_screen_restore_purchase_message">Alış tapilmadı. Düzgün Google hesabıyla daxil olduğunuzu yoxlayın.</string>
+    <string name="upgrade_screen_restore_banner_title">Artıq Pro satın aldınız?</string>
+    <string name="upgrade_screen_restore_banner_body">Görünür ki, siz bu cihazda əvvəllər Pro-ya yüksəltdiniz. Bunu yenidən aktivləşdirmək üçün satın almağı bərpa edin.</string>
     <string name="upgrade_screen_options_description">Abunəliklər avtomatik olaraq yenilinər. Hər zaman ldö bilərsiniz.</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Siz Pro istifadəçisisiniz — təşəkkür edirik!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Sizin tek seferlik Pro alımı hər Pro xüsusiyyətini əbədi açır.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Sizin abonelik hər Pro xüsusiyyətini açır.</string>
+    <string name="upgrade_screen_owned_sub_title">Sizin abonelik</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Sizin abonelik aktiv və avtomatik olaraq yenilənir.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Sizin abonelik bitməyə təyin edilib və yenilənməyəcək. Pro\'yu bitənə qədər saxlayacaqsınız.</string>
+    <string name="upgrade_screen_owned_both_warning">Sizin tek seferlik Pro yüksəltməsi və həm də aktiv abonelik var. Hər ikisinə ehtiyacınız yoxdur — əlavə ödəniş təkrarlamamaq üçün Google Play-də aboneliyi ləğv edin.</string>
+    <string name="upgrade_screen_manage_subscription_action">Aboneliyi idarə edin</string>
+    <string name="upgrade_screen_owned_iap_title">Ömürlük Pro</string>
+    <string name="upgrade_screen_owned_iap_body">Sizin tek seferlik Pro yüksəltməsi var. Abonelik yoxdur, yenilənmə yoxdur.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Birdəfəlik satın almaya keçid</string>
+    <string name="upgrade_screen_switch_purchase_note">Sizin abunəlik yeniləməyəcəyindən, indi daimi birdefelik Pro satın almaya keçə bilərsiniz.</string>
+    <string name="upgrade_screen_switch_locked_note">Birdəfəlik satın almaya keçmək üçün əvvəlcə Google Play-də abunəliyinizi ləğv edin. Bu təklif abunəlik yeniləməsi söndürüldükdə açılacaq.</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play yalnız indi daxil olduğunuz hesabı yoxlayır. Birdəfəlik satın alma abunəlikdən ayrıdır.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Sizin abunəlik hələ də aktivdir və yenilənir. Əvvəlcə Google Play-də ləğv edin.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Sizin abunəlik Google Play ilə təsdiqlənə bilmədi. Lütfən yenidən cəhd edin.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">Alışınız təsdiqlənir</string>
+    <string name="upgrade_screen_grace_body">Google Play sizin Pro alışınızı yenidən təsdiqləməsi gözlənilir. Bu adətən öz-özünə həll olur.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Biz hələ də sizin Pro alışınızı Google Play ilə yenidən təsdiqlənə biləmirik. Əgər bu davam edərsə, alışınızı bərpa etməyi sınayın və ya dəstəklə əlaqə saxlayın.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">Vəziyyət səhv görünürmü?</string>
+    <string name="upgrade_screen_restore_status_body">Pro satın aldığınızı ancaq görünmürsə, Google Play-da canlı yoxlama aparın.</string>
+    <string name="upgrade_screen_restore_success_message">Satın alma bərpa edildi.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Satın alma üçün istifadə etdiyiniz Google hesabı ilə daxil olduğunuzdan əmin olun. Google Play-da canlı yoxlama yerinə yetirildi.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Yüksəltmə seçimləri</string>
+    <string name="upgrade_screen_offers_body">Eyni xüsusiyyətlər, sadəcə fərqli qiymət modelləri.</string>
+    <string name="upgrade_screen_offers_or">və ya</string>
+    <string name="upgrade_screen_subscription_offer_title">İllik abunəlik</string>
+    <string name="upgrade_screen_subscription_offer_body">Pulsuz sınaq dövründən sonra hər il yenilənir. Google Play-da istənilən vaxt ləğv edə bilərsiniz.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Hər il yenilənir. Google Play-də istənilən vaxt ləğv edin.</string>
+    <string name="upgrade_screen_iap_offer_title">Bir dəfəlik</string>
+    <string name="upgrade_screen_iap_offer_body">Bir ödəniş, yeniləmə yoxdur.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">Abunəlik hələ də fəaldır</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Google Play yeni yoxlanılmış, lakin bu tətbiq üçün istifadə olunan hesab üçün Pro satınalması təsdiq edilə bilmədi.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Çoxlu hesablar Google Play-i çaşdıra bilər. Tətbiqini Google Play veb saytı vasitəsilə quraşdırmaq onu müəyyən hesabla əlaqələndirməyi məcbur edir.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Google Play sinxronlaşdırması vaxt ala bilər. Yenidən başlatmağı, Google Play Store keşini təmizləməyi və ya sadəcə gözləməyi sınayın.</string>
+    <string name="upgrade_screen_restore_contact_hint">Hələ də problem yaşayırsınız? Satınalmaq üçün istifadə olunan e-poçt ünvanından dəstəyə müraciət edin və Google Play sifariş nömrənizi əlavə edin.</string>
 </resources>

--- a/app/src/gplay/res/values-be/strings.xml
+++ b/app/src/gplay/res/values-be/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Сэрвісы Google Play недаступныя.</string>
     <string name="upgrades_no_purchases_found_check_account">Пакупкі не знойдзены. Вы выкарыстоўваеце правільны ўліковы запіс?</string>
+    <string name="upgrades_gplay_already_owned_title">Ужо куплена</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play паведамляе, што вы ўжо валодаеце гэтым абнаўленнем, але яго не ўдалося аднавіць. Праверце, што вы ўвайшлі ў акаўнт Google, выкарыстаны для арыгінальнай пакупкі, а затым паспрабуйце «Аднавіць пакупку».</string>
     <string name="upgrade_screen_preamble">Permission Pilot не мае рэкламы і паважае вашу прыватнасць. Абнаўленне падтрымлівае далейшую распрацоўку.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play недаступны</string>
+    <string name="upgrade_screen_offers_unavailable_message">Не ўдалося загрузіць варыянты пакупкі. Google Play можа быць часова недаступны — праверце сувязь і паспрабуйце яшчэ раз.</string>
     <string name="upgrade_screen_subscription_trial_action">Пачаць бясплатны пробны перыяд</string>
     <string name="upgrade_screen_subscription_action">Падпісацца</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/год, можна скасаваць у любы час</string>
-    <string name="upgrade_screen_iap_action">Купіць Pro</string>
+    <string name="upgrade_screen_iap_action">Аднаразовая пакупка</string>
     <string name="upgrade_screen_iap_action_hint">Аднаразовая пакупка за %s</string>
     <string name="upgrade_screen_restore_purchase_action">Аднавіць пакупку</string>
     <string name="upgrade_screen_restore_purchase_message">Пакупкі не знойдзены. Пераканайцеся, што вы ўвайшлі з правільным уліковым запісам Google.</string>
+    <string name="upgrade_screen_restore_banner_title">Ужо куплілі Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Выглядае, што вы раней купілі Pro на гэтым прыладзе. Аднавіце сваю пакупку, каб адблакаваць яе яшчэ раз.</string>
     <string name="upgrade_screen_options_description">Падпіскі аўтаматычна абнаўляюцца. Вы можаце адмяніць іх у любы час.</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Вы маеце Pro — дзякуй!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Ваша аднаразовая пакупка Pro адкрывае ўсе функцыі Pro назаўжды.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Ваша падпіска адкрывае ўсе функцыі Pro.</string>
+    <string name="upgrade_screen_owned_sub_title">Ваша падпіска</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Ваша падпіска актыўная і аднаўляецца аўтаматычна.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Ваша падпіска не будзе адноўлена і хутка скончыцца. Вы будзеце карыстацца Pro да яе заканчэння.</string>
+    <string name="upgrade_screen_owned_both_warning">Вы маеце аднаразовую пакупку Pro, а таксама актыўную падпіску. Вам не патрэбны абодва варыянты — адмяніце падпіску ў Google Play, каб пазбегнуць далейшых спагнанняў.</string>
+    <string name="upgrade_screen_manage_subscription_action">Кіраваць падпіскай</string>
+    <string name="upgrade_screen_owned_iap_title">Pro назаўжды</string>
+    <string name="upgrade_screen_owned_iap_body">Вы маеце аднаразовую пакупку Pro. Без падпіскі, без аднаўленняў.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Перайсці на адзінаразовую пакупку</string>
+    <string name="upgrade_screen_switch_purchase_note">Ваша падпіска не будзе аднаўляцца, таму вы можаце цяпер перайсці на сталую адзінаразовую пакупку Pro.</string>
+    <string name="upgrade_screen_switch_locked_note">Каб перайсці на адзінаразовую пакупку, спачатку скасуйце вашу падпіску ў Google Play. Гэтая прапанова разблакуецца, калі падпіска будзе наладжана не аднаўляцца.</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play правярае толькі акаўнт, у які вы зараз увайшлі. Адзінаразовая пакупка не звязана з вашай падпіскай.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Ваша падпіска ўсё яшчэ актыўная і аднаўляецца. Спачатку скасуйце яе ў Google Play.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Не ўдалося праверыць вашу падпіску ў Google Play. Калі ласка, паспрабуйце яшчэ раз.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">Пацвярджэнне вашай пакупкі</string>
+    <string name="upgrade_screen_grace_body">Мы чакаем паўторнага пацвярджэння вашай пакупкі Pro ад Google Play. Звычайна гэта вырашаецца самастойна.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Мы ўсё яшчэ не можам паўторна пацвердзіць вашу пакупку Pro з Google Play. Калі гэта паўтараецца, паспрабуйце аднавіць вашу пакупку або звяжыцеся з падтрымкай.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">Стан выглядае неправільна?</string>
+    <string name="upgrade_screen_restore_status_body">Калі вы купілі Pro, але гэта не адлюстроўваецца, запусціце жывую праверку праз Google Play.</string>
+    <string name="upgrade_screen_restore_success_message">Пакупка адноўлена.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Пераканайцеся, што вы ўвайшлі ў акаўнт Google, які выкарыстоўвалі для пакупкі. Толькі што была выканана жывая праверка Google Play.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Варыянты абнаўлення</string>
+    <string name="upgrade_screen_offers_body">Тыя ж функцыі, толькі розныя мадэлі коштаў.</string>
+    <string name="upgrade_screen_offers_or">або</string>
+    <string name="upgrade_screen_subscription_offer_title">Гадавая падпіска</string>
+    <string name="upgrade_screen_subscription_offer_body">Аднаўляецца штогод пасля бясплатнага пробнага перыяду. Адмяніце ў любы час у Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Аднаўляецца штогод. Адмяніце у любы час у Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Купіць адзін раз</string>
+    <string name="upgrade_screen_iap_offer_body">Адзін плацёж, без аднаўленняў.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">Падпіска ўсё яшчэ актыўная</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Google Play быў толькі што правераны, але пакупку Pro не ўдалося пацвердзіць для акаўнта, які выкарыстоўвае гэтая праграма.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Некалькі акаўнтаў могуць заблытаць Google Play. Усталяванне праграмы праз вэб-сайт Google Play прывязвае яе да пэўнага акаўнта.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Сінхранізацыя Google Play можа заняць пэўны час. Паспрабуйце перазагрузіцца, ачысціць кэш Google Play Store або проста пачакаць.</string>
+    <string name="upgrade_screen_restore_contact_hint">Усё яшчэ не атрымліваецца? Звяжыцеся з падтрымкай з электроннай пошты, якую выкарыстоўвалі для пакупкі, і ўкажыце нумар замовы Google Play.</string>
 </resources>

--- a/app/src/gplay/res/values-bg/strings.xml
+++ b/app/src/gplay/res/values-bg/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Услугите на Google Play не са налични.</string>
     <string name="upgrades_no_purchases_found_check_account">Не са намерени покупки. Използвате ли правилния акаунт?</string>
+    <string name="upgrades_gplay_already_owned_title">Вече закупено</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play съобщава, че вече притежавате това обновление, но то не можа да бъде възстановено. Проверете дали сте влезли с Google акаунта, използван за първоначалната покупка, след което опитайте „Възстановяване на покупката“.</string>
     <string name="upgrade_screen_preamble">Permission Pilot е без реклами и защитава поверителността ви. Надградата подкрепя понататашното развитие.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play не е достъпен</string>
+    <string name="upgrade_screen_offers_unavailable_message">Не можаха да се заредат опциите за покупка. Google Play може да е временно недостъпен — проверете връзката си и опитайте отново.</string>
     <string name="upgrade_screen_subscription_trial_action">Стартирайте безплатен пробен период</string>
     <string name="upgrade_screen_subscription_action">Абонирайте се</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/година, анулиране по всяко време</string>
-    <string name="upgrade_screen_iap_action">Купете Pro</string>
+    <string name="upgrade_screen_iap_action">Еднократна покупка</string>
     <string name="upgrade_screen_iap_action_hint">Еднократно плащане от %s</string>
     <string name="upgrade_screen_restore_purchase_action">Възстановете покупката</string>
     <string name="upgrade_screen_restore_purchase_message">Няма намерени покупки. Уверете се, че сте влезли с правилния Google акаунт.</string>
+    <string name="upgrade_screen_restore_banner_title">Вече ли закупихте Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Изглежда, че преди сте надстроили към Pro на това устройство. Възстановете покупката си, за да я отключите отново.</string>
     <string name="upgrade_screen_options_description">Абонаментите се поднавят автоматично. Можете да откажете по всяко време.</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Вие сте Pro — благодаря!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Вашата еднократна Pro покупка отключва всяка Pro функция, завинаги.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Вашият абонамент отключва всички Pro функции.</string>
+    <string name="upgrade_screen_owned_sub_title">Вашият абонамент</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Вашият абонамент е активен и се подновява автоматично.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Вашият абонамент е настроен да изтече и няма да се подновява. Ще задържите Pro, докато не завърши.</string>
+    <string name="upgrade_screen_owned_both_warning">Притежавате еднократната Pro надстройка и имате активен абонамент. Не се нуждаете от двете — отменете абонамента в Google Play, за да избегнете допълнителни разходи.</string>
+    <string name="upgrade_screen_manage_subscription_action">Управление на абонамента</string>
+    <string name="upgrade_screen_owned_iap_title">Доживотен Pro</string>
+    <string name="upgrade_screen_owned_iap_body">Притежавате еднократната Pro надстройка. Без абонамент, без подновявания.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Преминете към еднократна покупка</string>
+    <string name="upgrade_screen_switch_purchase_note">Вашият абонамент няма да се подновява, така че можете да преминете към постоянната еднократна Pro покупка сега.</string>
+    <string name="upgrade_screen_switch_locked_note">За да преминете към еднократната покупка, първо отменете абонамента си в Google Play. Това предложение се отключва, след като е зададено да не се подновява.</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play проверява само акаунта, в който сте вписани в момента. Еднократната покупка е отделна от абонамента ви.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Абонаментът ви все още е активен и се подновява. Първо го отменете в Google Play.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Не можахме да потвърдим абонамента ви с Google Play. Моля, опитайте отново.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">Потвърждаване на покупката ви</string>
+    <string name="upgrade_screen_grace_body">Изчакване на Google Play да потвърди отново Pro покупката ви. Обикновено това се разрешава автоматично.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Още не можем да потвърдим отново Pro покупката ви с Google Play. Ако това продължава да се случва, опитайте да възстановите покупката или се свържете с поддръжката.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">Статусът изглежда неправилен?</string>
+    <string name="upgrade_screen_restore_status_body">Ако сте закупили Pro, но той не се показва, направете проверка на живо с Google Play.</string>
+    <string name="upgrade_screen_restore_success_message">Покупката е възстановена.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Убедете се, че сте влезли със Google акаунта, който използвахте за покупка. Проверка на живо с Google Play току-що завърши.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Опции за надстройка</string>
+    <string name="upgrade_screen_offers_body">Същите функции, само различни ценови модели.</string>
+    <string name="upgrade_screen_offers_or">или</string>
+    <string name="upgrade_screen_subscription_offer_title">Годишен абонамент</string>
+    <string name="upgrade_screen_subscription_offer_body">Подновява се годишно след безплатния пробен период. Отмяна по всяко време в Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Подновява се годишно. Отмяна по всяко време в Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Еднократна покупка</string>
+    <string name="upgrade_screen_iap_offer_body">Една платба, без подновявания.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">Абонаментът все още е активен</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Google Play е проверен наскоро, но Pro покупката не можа да се потвърди за акаунта, който приложението използва.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Множествените акаунти могат да объркат Google Play. Инсталирането на приложението чрез уебсайта на Google Play го принуждава да се асоциира с конкретен акаунт.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Синхронизацията на Google Play може да отнеме време. Опитайте рестартиране, изчистване на кеша на Google Play Store или просто изчакане.</string>
+    <string name="upgrade_screen_restore_contact_hint">Все още закъсали? Свържете се с поддръжката от имейла, с който е направена покупката, и посочете номера на поръчката си в Google Play.</string>
 </resources>

--- a/app/src/gplay/res/values-bn-rBD/strings.xml
+++ b/app/src/gplay/res/values-bn-rBD/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play পরিষেবা অনুপলব্ধ।</string>
     <string name="upgrades_no_purchases_found_check_account">কোনো কেনাকাটা পাওয়া যায়নি। আপনি কি সঠিক অ্যাকাউন্ট ব্যবহার করছেন?</string>
+    <string name="upgrades_gplay_already_owned_title">ইতিমধ্যে ক্রয় করা হয়েছে</string>
+    <string name="upgrades_gplay_already_owned_error">গুগল প্লে রিপোর্ট করে যে আপনি ইতিমধ্যে এই আপগ্রেডের মালিক, কিন্তু এটি পুনরুদ্ধার করা যায়নি। যাচাই করুন যে আপনি মূল ক্রয়ের জন্য ব্যবহৃত গুগল অ্যাকাউন্টে সাইন ইন করেছেন, তারপর \"ক্রয় পুনরুদ্ধার করুন\" চেষ্টা করুন।</string>
     <string name="upgrade_screen_preamble">Permission Pilot বিজ্ঞাপনমুক্ত এবং আপনার গোপনীয়তাকে সম্মান করে। আপগ্রেড করা চলমান ডিভেলপমেন্টকে সমর্থন করে।</string>
+    <string name="upgrade_screen_offers_unavailable_title">গুগল প্লে উপলব্ধ নয়</string>
+    <string name="upgrade_screen_offers_unavailable_message">ক্রয় বিকল্পগুলি লোড করা যায়নি। গুগল প্লে অস্থায়ীভাবে উপলব্ধ নাও হতে পারে — আপনার সংযোগ পরীক্ষা করুন এবং আবার চেষ্টা করুন।</string>
     <string name="upgrade_screen_subscription_trial_action">বিনামূল্যের ট্রায়াল শুরু করুন</string>
     <string name="upgrade_screen_subscription_action">সাবস্ক্রাইব করুন</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/বছর, যেকোনো সময় বাতিল করুন</string>
-    <string name="upgrade_screen_iap_action">Pro কিনুন</string>
+    <string name="upgrade_screen_iap_action">এককালীন ক্রয়</string>
     <string name="upgrade_screen_iap_action_hint">%s-র একবারের ক্রয়</string>
     <string name="upgrade_screen_restore_purchase_action">ক্রয় পুনরুদ্ধার</string>
     <string name="upgrade_screen_restore_purchase_message">কোনো ক্রয় পাওয়া যায়নি। সঠিক Google অ্যাকাউন্ট দিয়ে সাইন ইন করা আছে কিনা পরীক্ষা করুন।</string>
+    <string name="upgrade_screen_restore_banner_title">ইতিমধ্যে Pro কিনেছেন?</string>
+    <string name="upgrade_screen_restore_banner_body">মনে হচ্ছে আপনি এই ডিভাইসে আগে Pro-তে আপগ্রেড করেছেন। এটি আবার আনলক করতে আপনার ক্রয় পুনরুদ্ধার করুন।</string>
     <string name="upgrade_screen_options_description">সাবস্ক্রিপশন স্বয়ংক্রিয়ভাবে নবায়ন হয়। যেকোনো সময় বাতিল করতে পারেন।</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">আপনি Pro ব্যবহারকারী — ধন্যবাদ!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">আপনার একবারের Pro ক্রয় প্রতিটি Pro বৈশিষ্ট্য চিরকালের জন্য আনলক করে।</string>
+    <string name="upgrade_screen_owned_hero_sub_body">আপনার সাবস্ক্রিপশন প্রতিটি প্রো বৈশিষ্ট্য আনলক করে।</string>
+    <string name="upgrade_screen_owned_sub_title">আপনার সাবস্ক্রিপশন</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">আপনার সাবস্ক্রিপশন সক্রিয় এবং স্বয়ংক্রিয়ভাবে পুনর্নবীকরণ হয়।</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">আপনার সাবস্ক্রিপশন মেয়াদ শেষ হওয়ার জন্য নির্ধারিত এবং পুনর্নবীকরণ হবে না। আপনি এটি শেষ না হওয়া পর্যন্ত প্রো রাখবেন।</string>
+    <string name="upgrade_screen_owned_both_warning">আপনি একবার প্রো আপগ্রেড মালিক এবং একটি সক্রিয় সাবস্ক্রিপশনও রয়েছে। আপনার উভয়ের প্রয়োজন নেই — আরও চার্জ এড়াতে গুগল প্লেতে সাবস্ক্রিপশন বাতিল করুন।</string>
+    <string name="upgrade_screen_manage_subscription_action">সাবস্ক্রিপশন পরিচালনা করুন</string>
+    <string name="upgrade_screen_owned_iap_title">আজীবন প্রো</string>
+    <string name="upgrade_screen_owned_iap_body">আপনি একবার প্রো আপগ্রেড মালিক। কোন সাবস্ক্রিপশন নেই, কোন পুনর্নবীকরণ নেই।</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">একবার ক্রয়ে স্যুইচ করুন</string>
+    <string name="upgrade_screen_switch_purchase_note">আপনার সাবস্ক্রিপশন পুনর্নবীকরণ হবে না, তাই আপনি এখন স্থায়ী একবার প্রো ক্রয়ে যেতে পারেন।</string>
+    <string name="upgrade_screen_switch_locked_note">এককালীন ক্রয়ে সরানোর জন্য, প্রথমে Google Play-এ আপনার সাবস্ক্রিপশন বাতিল করুন। এই অফারটি আনলক হয় যখন এটি পুনর্নবীকরণ না করার জন্য সেট করা হয়।</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play শুধুমাত্র আপনি যে অ্যাকাউন্টে সাইন ইন করেছেন তা চেক করে। এককালীন ক্রয় আপনার সাবস্ক্রিপশন থেকে আলাদা।</string>
+    <string name="upgrade_screen_sub_still_renewing_message">আপনার সাবস্ক্রিপশন এখনও সক্রিয় এবং পুনর্নবীকরণ হচ্ছে। প্রথমে Google Play-এ এটি বাতিল করুন।</string>
+    <string name="upgrade_screen_sub_check_failed_message">Google Play-এর সাথে আপনার সাবস্ক্রিপশন যাচাই করা যায়নি। অনুগ্রহ করে আবার চেষ্টা করুন।</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">আপনার ক্রয় নিশ্চিত করছি</string>
+    <string name="upgrade_screen_grace_body">Google Play আপনার Pro ক্রয় পুনরায় নিশ্চিত করার অপেক্ষা করছি। এটি সাধারণত নিজে থেকেই সমাধান হয়।</string>
+    <string name="upgrade_screen_grace_diagnostics_body">আমরা এখনও Google Play-এর সাথে আপনার Pro ক্রয় পুনরায় নিশ্চিত করতে পারছি না। যদি এটি চলতে থাকে, আপনার ক্রয় পুনরুদ্ধার করার চেষ্টা করুন বা সহায়তার সাথে যোগাযোগ করুন।</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">স্থিতি ভুল দেখাচ্ছে?</string>
+    <string name="upgrade_screen_restore_status_body">যদি আপনি Pro ক্রয় করে থাকেন কিন্তু এটি দেখাচ্ছে না, Google Play-এর বিপরীতে একটি লাইভ চেক চালান।</string>
+    <string name="upgrade_screen_restore_success_message">ক্রয় পুনরুদ্ধার করা হয়েছে।</string>
+    <string name="upgrade_screen_restore_webinstall_hint">নিশ্চিত করুন যে আপনি যে Google অ্যাকাউন্ট দিয়ে ক্রয় করেছেন সেটি দিয়ে সাইন ইন করছেন। Google Play এর বিরুদ্ধে একটি লাইভ চেক সম্প্রতি চলেছে।</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">আপগ্রেড বিকল্পগুলি</string>
+    <string name="upgrade_screen_offers_body">একই বৈশিষ্ট্য, শুধুমাত্র বিভিন্ন মূল্য নির্ধারণ মডেল।</string>
+    <string name="upgrade_screen_offers_or">বা</string>
+    <string name="upgrade_screen_subscription_offer_title">বার্ষিক সাবস্ক্রিপশন</string>
+    <string name="upgrade_screen_subscription_offer_body">বিনামূল্যে ট্রায়ালের পরে বার্ষিক নবীকরণ হয়। Google Play এ যেকোনো সময় বাতিল করুন।</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">বার্ষিক নবীকরণ হয়। Google Play এ যেকোনো সময় বাতিল করুন।</string>
+    <string name="upgrade_screen_iap_offer_title">একবার কিনুন</string>
+    <string name="upgrade_screen_iap_offer_body">একটি পেমেন্ট, কোনো নবীকরণ নেই।</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">সাবস্ক্রিপশন এখনও সক্রিয়</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">গুগল প্লে এখনই চেক করা হয়েছে, কিন্তু এই অ্যাপটি যে অ্যাকাউন্টটি ব্যবহার করছে তার জন্য কোনো প্রো ক্রয় নিশ্চিত করা যায়নি।</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">একাধিক অ্যাকাউন্ট গুগল প্লেকে বিভ্রান্ত করতে পারে। গুগল প্লে ওয়েবসাইটের মাধ্যমে অ্যাপটি ইনস্টল করা এটিকে একটি নির্দিষ্ট অ্যাকাউন্টের সাথে যুক্ত করতে বাধ্য করে।</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">গুগল প্লে সিঙ্ক্রোনাইজেশন কিছু সময় লাগতে পারে। পুনরায় বুট করার চেষ্টা করুন, গুগল প্লে স্টোর ক্যাশ পরিষ্কার করুন, অথবা শুধুমাত্র অপেক্ষা করুন।</string>
+    <string name="upgrade_screen_restore_contact_hint">এখনও আটকে আছেন? ক্রয় করা ইমেল থেকে সহায়তার যোগাযোগ করুন এবং আপনার গুগল প্লে অর্ডার নম্বর অন্তর্ভুক্ত করুন।</string>
 </resources>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Els serveis del Google Play no estan disponibles.</string>
     <string name="upgrades_no_purchases_found_check_account">No s\'han trobat compres. Esteu fent servir el compte correcte?</string>
+    <string name="upgrades_gplay_already_owned_title">Ja ho heu comprat</string>
+    <string name="upgrades_gplay_already_owned_error">El Google Play indica que ja teniu aquesta actualització, però no s\'ha pogut restaurar. Comproveu que heu iniciat sessió amb el compte de Google que vau utilitzar per a la compra original i proveu «Restaura la compra».</string>
     <string name="upgrade_screen_preamble">El Permission Pilot no té anuncis i respecta la teva privadesa. L\'actualització permet el desenvolupament continu.</string>
+    <string name="upgrade_screen_offers_unavailable_title">El Google Play no està disponible</string>
+    <string name="upgrade_screen_offers_unavailable_message">No s\'han pogut carregar les opcions de compra. És possible qu eel Google Play no estigui disponible temporalment, comproveu la connexió i torneu-ho a provar.</string>
     <string name="upgrade_screen_subscription_trial_action">Inicia la prova gratuïta</string>
     <string name="upgrade_screen_subscription_action">Subscripció</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/any, cancel·leu en qualsevol moment</string>
-    <string name="upgrade_screen_iap_action">Compra Pro</string>
+    <string name="upgrade_screen_iap_action">Compra única</string>
     <string name="upgrade_screen_iap_action_hint">Compra única de %s</string>
     <string name="upgrade_screen_restore_purchase_action">Restaura la compra</string>
     <string name="upgrade_screen_restore_purchase_message">No s\'han trobat compres. Comproveu que heu iniciat la sessió amb el compte de Google correcte.</string>
+    <string name="upgrade_screen_restore_banner_title">Ja heu comprat Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Sembla que ja vau actualitzar al Pro en aquest dispositiu abans. Restaureu la vostra compra per tornar-la a desbloquejar.</string>
     <string name="upgrade_screen_options_description">Les subscripcions es renoven automàticament. Podeu cancel·lar-les en qualsevol moment.</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Sou Pro, gràcies!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">La vostra compra única desbloqueja totes les funcions de Pro, per sempre.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">La vostra subscripció desbloqueja totes les funcions de Pro.</string>
+    <string name="upgrade_screen_owned_sub_title">La vostra subscripció</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">La vostra subscripció està activa i es renova automàticament.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">La vostra subscripció està configurada per caducar i no es renovarà. Mantindreu el Pro fins que finalitzi.</string>
+    <string name="upgrade_screen_owned_both_warning">Teniu l\'actualització única al Pro i també una subscripció activa. No necessites totes dues coses: cancel·leu la subscripció al Google Play per evitar càrrecs addicionals.</string>
+    <string name="upgrade_screen_manage_subscription_action">Gestiona la subscripció</string>
+    <string name="upgrade_screen_owned_iap_title">Pro de per vida</string>
+    <string name="upgrade_screen_owned_iap_body">Teniu l\'actualització Pro única. Sense subscripcions, sense renovacions.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Canvieu a una compra única</string>
+    <string name="upgrade_screen_switch_purchase_note">La vostra subscripció no es renovarà, així que ara podeu canviar a la compra permanent única per al Pro.</string>
+    <string name="upgrade_screen_switch_locked_note">Per canviar a la compra única, primer cancel·leu la vostra subscripció al Google Play. Aquesta oferta es desbloqueja un cop està configurada per no renovar-se.</string>
+    <string name="upgrade_screen_limitation_disclosure">El Google Play només comprova el compte en el qual esteu actualment connectats. La compra única és independent de la vostra subscripció.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">La vostra subscripció segueix activa i es renova. Cancel·leu-la primer al Google Play.</string>
+    <string name="upgrade_screen_sub_check_failed_message">No s\'ha pogut verificar la vostra subscripció amb el Google Play. Torneu-ho a provar.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">S\'està confirmant la vostra compra</string>
+    <string name="upgrade_screen_grace_body">S\'està esperant que el Google Play confirmi novament la vostra compra del Pro. Això normalment es resol per si sol.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Encara no podem tornar a confirmar la vostra compra del Pro amb el Google Play. Si això continua passant, proveu de restaurar la compra o contacteu amb el servei d\'assistència.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">L\'estat sembla incorrecte?</string>
+    <string name="upgrade_screen_restore_status_body">Si has comprat la versió Pro però no es mostra, feu una comprovació en temps real al Google Play.</string>
+    <string name="upgrade_screen_restore_success_message">Compra restaurada.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Assegureu-vos que heu iniciat sessió amb el compte de Google que vau fer servir per a la compra. S\'acaba d\'executar una comprovació en directe al Google Play.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Opcions d\'actualització</string>
+    <string name="upgrade_screen_offers_body">Les mateixes funcions, només models de preus diferents.</string>
+    <string name="upgrade_screen_offers_or">o</string>
+    <string name="upgrade_screen_subscription_offer_title">Subscripció anual</string>
+    <string name="upgrade_screen_subscription_offer_body">Es renova anualment després del període de prova gratuït. Cancel·leu en qualsevol moment al Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Es renova anualment. Cancel·leu en qualsevol moment al Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Compra única</string>
+    <string name="upgrade_screen_iap_offer_body">Un sol pagament, sense renovacions.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">La subscripció encara està activa</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">S\'acaba de comprovar el Google Play, però no s\'ha pogut confirmar cap compra Pro per al compte que s\'utilitza per a aquesta aplicació.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Tenir diversos comptes pot generar confusió al Google Play. La instal·lació de l\'aplicació a través del lloc web del Google Play obliga a associar-lo amb un compte específic.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">La sincronització del Google Play pot trigar una estona. Proveu de reiniciar, esborreu la memòria cau del Google Play o simplement espereu.</string>
+    <string name="upgrade_screen_restore_contact_hint">Encara teniu problemes? Contacteu amb l\'assistència des del correu amb què heu fet la compra i incloeu el número de comanda del Google Play.</string>
 </resources>

--- a/app/src/gplay/res/values-cs/strings.xml
+++ b/app/src/gplay/res/values-cs/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Služby Google Play nenjsou k dispozici.</string>
     <string name="upgrades_no_purchases_found_check_account">Nebyly nalezeny žádné nákupy. Používáte správný účet?</string>
+    <string name="upgrades_gplay_already_owned_title">Již zakoupeno</string>
+    <string name="upgrades_gplay_already_owned_error">Služba Google Play hlásí, že již máte tento upgrade, ale nelze jej obnovit. Zkontrolujte, zda jste přihlášeni pomocí účtu Google, který jste použili pro původní nákup, a poté zkuste „Obnovit nákup“.</string>
     <string name="upgrade_screen_preamble">Permission Pilot je bez reklam a respektuje vaše soukromí. Upgrade podporuje další vývoj.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Služba Google Play není k dispozici</string>
+    <string name="upgrade_screen_offers_unavailable_message">Nelze načíst možnosti nákupu. Služba Google Play může být dočasně nedostupná — zkontrolujte vaše připojení a zkuste znovu.</string>
     <string name="upgrade_screen_subscription_trial_action">Spustit zkušební verzi</string>
     <string name="upgrade_screen_subscription_action">Předplatit</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/rok, zrušit kdykoliv</string>
-    <string name="upgrade_screen_iap_action">Koupit Pro</string>
+    <string name="upgrade_screen_iap_action">Jednorázový nákup</string>
     <string name="upgrade_screen_iap_action_hint">Jednorázový nákup za %s</string>
     <string name="upgrade_screen_restore_purchase_action">Obnovit nákup</string>
     <string name="upgrade_screen_restore_purchase_message">Žádné nákupy nenalezeny. Zkontrolujte, zda jste přihlášeni správným účtem Google.</string>
+    <string name="upgrade_screen_restore_banner_title">Už jste si Pro koupili?</string>
+    <string name="upgrade_screen_restore_banner_body">Vypadá to, že jste již dříve upgradovali na Pro na tomto zařízení. Obnovte svůj nákup a odemkněte jej znovu.</string>
     <string name="upgrade_screen_options_description">Předplatné se obnovuje automaticky. Můžete je kdykoliv zrušit.</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Jste Pro — děkujeme!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Váš jednorázový nákup Pro odemyká každou funkci Pro navždy.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Vaše předplatné odemyká každou funkci Pro.</string>
+    <string name="upgrade_screen_owned_sub_title">Vaše předplatné</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Vaše předplatné je aktivní a obnovuje se automaticky.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Vaše předplatné je nastaveno na vypršení a nebude se obnovovat. Budete mít Pro až do konce.</string>
+    <string name="upgrade_screen_owned_both_warning">Vlastníte jednorázový Pro upgrade a zároveň máte aktivní předplatné. Nepotřebujete obojí – zrušte předplatné v Google Play, abyste se vyhnuli dalším poplatkům.</string>
+    <string name="upgrade_screen_manage_subscription_action">Spravovat předplatné</string>
+    <string name="upgrade_screen_owned_iap_title">Celoživotní Pro</string>
+    <string name="upgrade_screen_owned_iap_body">Vlastníte jednorázový Pro upgrade. Žádné předplatné, žádné obnovení.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Přejít na jednorázový nákup</string>
+    <string name="upgrade_screen_switch_purchase_note">Vaše předplatné se nebude obnovovat, takže se nyní můžete přesunout na trvalý jednorázový Pro nákup.</string>
+    <string name="upgrade_screen_switch_locked_note">Chcete-li se přesunout na jednorázový nákup, nejdříve zrušte své předplatné v Google Play. Tato nabídka se odemkne, jakmile bude nastaveno tak, aby se neobnovovalo.</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play kontroluje pouze účet, ke kterému jste právě přihlášeni. Jednorázový nákup je oddělený od vašeho předplatného.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Vaše předplatné je stále aktivní a obnovuje se. Nejdřív jej zrušte v Google Play.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Nelze ověřit vaše předplatné v Google Play. Zkuste to prosím znovu.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">Potvrzování nákupu</string>
+    <string name="upgrade_screen_grace_body">Čekání na opětovné potvrzení nákupu Pro z Google Play. Obvykle se to vyřeší samo.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Stále nemůžeme opětovně potvrdit váš nákup Pro v Google Play. Pokud se to stále děje, zkuste obnovit nákup nebo kontaktujte podporu.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">Stav vypadá špatně?</string>
+    <string name="upgrade_screen_restore_status_body">Pokud jste si koupili Pro, ale nezobrazuje se vám, spusťte kontrolu v Google Play.</string>
+    <string name="upgrade_screen_restore_success_message">Nákup obnoven.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Ujistěte se, že jste přihlášeni pomocí Google účtu, který jste použili k nákupu. Právě byla spuštěna kontrola v Google Play.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Možnosti upgradu</string>
+    <string name="upgrade_screen_offers_body">Stejné funkce, jen různé cenové modely.</string>
+    <string name="upgrade_screen_offers_or">nebo</string>
+    <string name="upgrade_screen_subscription_offer_title">Roční předplatné</string>
+    <string name="upgrade_screen_subscription_offer_body">Obnovuje se ročně po bezplatné zkušební verzi. Zrušit lze kdykoliv v Obchodě Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Obnovuje se ročně. Zrušit lze kdykoliv v Obchodě Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Koupit jednou</string>
+    <string name="upgrade_screen_iap_offer_body">Jedna platba, žádné obnovení.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">Předplatné je stále aktivní</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Právě byla zkontrolována služba Google Play, ale pro účet používaný v této aplikaci nelze potvrdit nákup Pro verze.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Více účtů může zmást Google Play. Instalace aplikace přes webové stránky Google Play vynucuje její přidružení ke konkrétnímu účtu.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Synchronizace Obchodu Play může chvíli trvat. Zkuste restartovat, vymazat mezipaměť Google Play nebo prostě počkat.</string>
+    <string name="upgrade_screen_restore_contact_hint">Stále máte problém? Kontaktujte podporu z e-mailu, který provedl nákup, a připojte vaše číslo objednávky Google Play.</string>
 </resources>

--- a/app/src/gplay/res/values-da/strings.xml
+++ b/app/src/gplay/res/values-da/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play-tjenester er ikke tilgængelige.</string>
     <string name="upgrades_no_purchases_found_check_account">Ingen køb fundet. Bruger du den rigtige konto?</string>
+    <string name="upgrades_gplay_already_owned_title">Allerede købt</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play rapporterer, at du allerede ejer denne opgradering, men den kunne ikke gendannes. Kontroller, at du er logget ind med den Google-konto, der blev brugt til det oprindelige køb, og prøv derefter \"Gendan køb\".</string>
     <string name="upgrade_screen_preamble">Permission Pilot er reklamefri og respekterer dit privatliv. Opgradering støtter fortsat udvikling.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play er utilgængelig</string>
+    <string name="upgrade_screen_offers_unavailable_message">Kunne ikke indlæse købsindstillingerne. Google Play kan være midlertidigt utilgængelig – kontroller din forbindelse og prøv igen.</string>
     <string name="upgrade_screen_subscription_trial_action">Start gratis prøveperiode</string>
     <string name="upgrade_screen_subscription_action">Abonner</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/år, annuller når som helst</string>
-    <string name="upgrade_screen_iap_action">Køb Pro</string>
+    <string name="upgrade_screen_iap_action">Engangskøb</string>
     <string name="upgrade_screen_iap_action_hint">Engangsindkjøb af %s</string>
     <string name="upgrade_screen_restore_purchase_action">Gendan køb</string>
     <string name="upgrade_screen_restore_purchase_message">Ingen køb fundet. Tjek at du er logget ind med den korrekte Google-konto.</string>
+    <string name="upgrade_screen_restore_banner_title">Allerede købt Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Det ser ud til, at du allerede har opgraderet til Pro på denne enhed. Gendan dit køb for at låse det op igen.</string>
     <string name="upgrade_screen_options_description">Abonnementer fornyes automatisk. Du kan annullere når som helst.</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Du er Pro – tak!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Dit engangs Pro-køb låser op for alle Pro-funktioner, for evigt.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Dit abonnement låser alle Pro-funktioner op.</string>
+    <string name="upgrade_screen_owned_sub_title">Dit abonnement</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Dit abonnement er aktivt og fornyes automatisk.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Dit abonnement er indstillet til at udløbe og fornyes ikke. Du beholder Pro, indtil det slutter.</string>
+    <string name="upgrade_screen_owned_both_warning">Du ejer Pro-opgraderingen til engangsudgift og har også et aktivt abonnement. Du behøver ikke begge dele — annuller abonnementet i Google Play for at undgå yderligere gebyrer.</string>
+    <string name="upgrade_screen_manage_subscription_action">Administrer abonnement</string>
+    <string name="upgrade_screen_owned_iap_title">Livstids Pro</string>
+    <string name="upgrade_screen_owned_iap_body">Du ejer Pro-opgraderingen til engangsudgift. Intet abonnement, ingen fornyelser.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Skift til engangsudgift</string>
+    <string name="upgrade_screen_switch_purchase_note">Dit abonnement fornyes ikke, så du kan skifte til det permanente engangs-Pro-køb nu.</string>
+    <string name="upgrade_screen_switch_locked_note">Hvis du vil skifte til engangsbetalingen, skal du først annullere dit abonnement i Google Play. Dette tilbud bliver tilgængeligt, når det er indstillet til ikke at forny.</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play kontrollerer kun den konto, du er logget ind på. Engangsbetalingen er adskilt fra dit abonnement.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Dit abonnement er stadig aktivt og fornyes. Annuller det først i Google Play.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Kunne ikke bekræfte dit abonnement med Google Play. Prøv igen.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">Bekræfter dit køb</string>
+    <string name="upgrade_screen_grace_body">Venter på, at Google Play skal bekræfte dit Pro-køb igen. Dette løses normalt af sig selv.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Vi kan stadig ikke bekræfte dit Pro-køb med Google Play igen. Hvis dette fortsætter, skal du prøve at gendanne dit køb eller kontakte support.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">Ser status forkert ud?</string>
+    <string name="upgrade_screen_restore_status_body">Hvis du har købt Pro, men det vises ikke, skal du køre en livekontrol mod Google Play.</string>
+    <string name="upgrade_screen_restore_success_message">Køb gendannet.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Sørg for, at du er logget ind med den Google-konto, du brugte til at købe. En direkte kontrol mod Google Play blev netop udført.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Opgraderingsmuligheder</string>
+    <string name="upgrade_screen_offers_body">Samme funktioner, blot forskellige prismodeller.</string>
+    <string name="upgrade_screen_offers_or">eller</string>
+    <string name="upgrade_screen_subscription_offer_title">Årligt abonnement</string>
+    <string name="upgrade_screen_subscription_offer_body">Fornyes årligt efter den gratis prøveperiode. Annuller når som helst i Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Fornyes årligt. Annuller når som helst i Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Køb én gang</string>
+    <string name="upgrade_screen_iap_offer_body">En betaling, ingen fornyelser.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">Abonnement er stadig aktivt</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Google Play blev netop kontrolleret, men der kunne ikke bekræftes et Pro-køb for den konto, som denne app bruger.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Flere konti kan forvirre Google Play. Installation af appen via Google Play-hjemmesiden fremtvinger tilknytning til en bestemt konto.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Google Play-synkronisering kan tage tid. Prøv at genstarte, rydde Google Play Store-cachen eller bare vent.</string>
+    <string name="upgrade_screen_restore_contact_hint">Stadig fast? Kontakt support fra den e-mail, der foretog købet, og inkluder dit Google Play-ordrenummer.</string>
 </resources>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play-Dienste sind nicht verfügbar.</string>
     <string name="upgrades_no_purchases_found_check_account">Keine Käufe gefunden. Verwendest du das richtige Konto?</string>
+    <string name="upgrades_gplay_already_owned_title">Bereits gekauft</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play meldet, dass Sie dieses Upgrade bereits besitzen, es konnte jedoch nicht wiederhergestellt werden. Stellen Sie sicher, dass Sie mit dem Google-Konto angemeldet sind, das für den ursprünglichen Kauf verwendet wurde, und versuchen Sie dann, den Kauf wiederherzustellen.</string>
     <string name="upgrade_screen_preamble">Permission Pilot ist werbefrei und respektiert deine Privatsphäre. Ein Upgrade unterstützt die weitere Entwicklung.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play ist nicht verfügbar</string>
+    <string name="upgrade_screen_offers_unavailable_message">Die Kaufoptionen konnten nicht geladen werden. Google Play ist möglicherweise vorübergehend nicht verfügbar – überprüfen Sie Ihre Verbindung und versuchen Sie es erneut.</string>
     <string name="upgrade_screen_subscription_trial_action">Kostenlos testen</string>
     <string name="upgrade_screen_subscription_action">Abonnieren</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/Jahr, jederzeit kündbar</string>
-    <string name="upgrade_screen_iap_action">Pro kaufen</string>
+    <string name="upgrade_screen_iap_action">Einmalig kaufen</string>
     <string name="upgrade_screen_iap_action_hint">Einmalkauf für %s</string>
     <string name="upgrade_screen_restore_purchase_action">Kauf wiederherstellen</string>
     <string name="upgrade_screen_restore_purchase_message">Keine Käufe gefunden. Überprüfe, ob du mit dem richtigen Google-Konto angemeldet bist.</string>
+    <string name="upgrade_screen_restore_banner_title">Bereits Pro gekauft?</string>
+    <string name="upgrade_screen_restore_banner_body">Es sieht so aus, als hättest du auf diesem Gerät schon einmal ein Upgrade auf Pro durchgeführt. Stelle deinen Kauf wieder her, um es erneut freizuschalten.</string>
     <string name="upgrade_screen_options_description">Abonnements verlängern sich automatisch. Du kannst jederzeit kündigen.</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Sie haben Pro – vielen Dank!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Ihr einmaliger Pro-Kauf entsperrt alle Pro-Funktionen für immer.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Ihr Abonnement entsperrt alle Pro-Funktionen.</string>
+    <string name="upgrade_screen_owned_sub_title">Ihr Abonnement</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Ihr Abonnement ist aktiv und wird automatisch verlängert.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Ihr Abonnement läuft aus und wird nicht verlängert. Sie behalten Pro bis zum Ende.</string>
+    <string name="upgrade_screen_owned_both_warning">Sie besitzen das einmalige Pro-Upgrade und haben auch ein aktives Abonnement. Sie benötigen nicht beides – kündigen Sie das Abonnement in Google Play, um weitere Gebühren zu vermeiden.</string>
+    <string name="upgrade_screen_manage_subscription_action">Abo verwalten</string>
+    <string name="upgrade_screen_owned_iap_title">Pro für immer</string>
+    <string name="upgrade_screen_owned_iap_body">Sie besitzen das einmalige Pro-Upgrade. Kein Abonnement, keine Verlängerungen.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Zum einmaligen Kauf wechseln</string>
+    <string name="upgrade_screen_switch_purchase_note">Ihr Abonnement wird nicht verlängert, daher können Sie jetzt zum permanenten einmaligen Pro-Kauf wechseln.</string>
+    <string name="upgrade_screen_switch_locked_note">Um zum einmaligen Kauf zu wechseln, kündigen Sie zunächst Ihr Abonnement in Google Play. Dieses Angebot wird freigegeben, sobald es nicht mehr verlängert wird.</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play überprüft nur das Konto, mit dem Sie gerade angemeldet sind. Der Einmalkauf ist unabhängig von Ihrem Abonnement.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Ihr Abonnement ist noch aktiv und wird erneuert. Kündigen Sie es zuerst in Google Play.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Ihr Abonnement konnte nicht bei Google Play überprüft werden. Bitte versuchen Sie es noch einmal.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">Dein Kauf wird bestätigt</string>
+    <string name="upgrade_screen_grace_body">Warten auf erneute Bestätigung Ihres Pro-Kaufs durch Google Play. Dies löst sich normalerweise von selbst.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Wir können Ihren Pro-Kauf immer noch nicht bei Google Play erneut bestätigen. Wenn dies weiterhin geschieht, versuchen Sie, Ihren Kauf wiederherzustellen, oder kontaktieren Sie den Support.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">Status sieht falsch aus?</string>
+    <string name="upgrade_screen_restore_status_body">Wenn Sie Pro gekauft haben, es aber nicht angezeigt wird, führen Sie eine Live-Überprüfung bei Google Play durch.</string>
+    <string name="upgrade_screen_restore_success_message">Kauf wiederhergestellt.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Stellen Sie sicher, dass Sie mit dem Google-Konto angemeldet sind, mit dem Sie gekauft haben. Eine Live-Überprüfung bei Google Play wurde gerade durchgeführt.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Upgrade-Möglichkeiten</string>
+    <string name="upgrade_screen_offers_body">Gleiche Funktionen, nur unterschiedliche Preismodelle.</string>
+    <string name="upgrade_screen_offers_or">oder</string>
+    <string name="upgrade_screen_subscription_offer_title">Jährliches Abonnement</string>
+    <string name="upgrade_screen_subscription_offer_body">Verlängert sich nach dem kostenlosen Testzeitraum jährlich. Jederzeit über Google Play kündbar.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Verlängert sich jährlich. Jederzeit über Google Play kündbar.</string>
+    <string name="upgrade_screen_iap_offer_title">Einmalig kaufen</string>
+    <string name="upgrade_screen_iap_offer_body">Einmalige Zahlung, kein Abo.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">Abo noch aktiv</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Google Play wurde gerade überprüft, aber für das Konto, das es für diese App verwendet, konnte kein Pro-Kauf bestätigt werden.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Mehrere Konten können Google Play durcheinanderbringen. Die Installation der App über die Google Play-Website erzwingt die Zuordnung zu einem bestimmten Konto.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Die Google Play-Synchronisierung kann eine Weile dauern. Versuchen Sie, das Gerät neu zu starten, den Google Play Store-Cache zu löschen oder einfach zu warten.</string>
+    <string name="upgrade_screen_restore_contact_hint">Immer noch nicht weiter? Kontaktiere den Support von der E-Mail-Adresse aus, mit der der Kauf getätigt wurde, und gib deine Google-Play-Bestellnummer an.</string>
 </resources>

--- a/app/src/gplay/res/values-el/strings.xml
+++ b/app/src/gplay/res/values-el/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Οι υπηρεσίες Google Play δεν είναι διαθέσιμες.</string>
     <string name="upgrades_no_purchases_found_check_account">Δεν βρέθηκαν αγορές. Χρησιμοποιείτε τον σωστό λογαριασμό;</string>
+    <string name="upgrades_gplay_already_owned_title">Ήδη αγορασμένο</string>
+    <string name="upgrades_gplay_already_owned_error">Το Google Play αναφέρει ότι έχετε ήδη αυτήν την αναβάθμιση, αλλά δεν ήταν δυνατό να επαναφερθεί. Βεβαιωθείτε ότι είστε συνδεδεμένοι με τον λογαριασμό Google που χρησιμοποιήθηκε για την αρχική αγορά, στη συνέχεια δοκιμάστε «Επαναφορά αγοράς».</string>
     <string name="upgrade_screen_preamble">Το Permission Pilot είναι χωρίς διαφημίσεις και σέβεται την ιδιωτικότητά σας. Η αναβάθμιση υποστηρίζει τη συνεχή ανάπτυξη.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Το Google Play δεν είναι διαθέσιμο</string>
+    <string name="upgrade_screen_offers_unavailable_message">Δεν ήταν δυνατό να φορτωθούν οι επιλογές αγοράς. Το Google Play μπορεί να είναι προσωρινά μη διαθέσιμο — ελέγξτε τη σύνδεσή σας και δοκιμάστε ξανά.</string>
     <string name="upgrade_screen_subscription_trial_action">Έναρξη δωρεάν δοκιμής</string>
     <string name="upgrade_screen_subscription_action">Εγγραφή</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/χρόνο, ακύρωση ανά πάσα στιγμή</string>
-    <string name="upgrade_screen_iap_action">Αγορά Pro</string>
+    <string name="upgrade_screen_iap_action">Εφάπαξ αγορά</string>
     <string name="upgrade_screen_iap_action_hint">Εφάπαξ αγορά %s</string>
     <string name="upgrade_screen_restore_purchase_action">Επαναφορά αγοράς</string>
     <string name="upgrade_screen_restore_purchase_message">Δεν βρέθηκαν αγορές. Βεβαιωθείτε ότι είστε συνδεδεμένοι με τον σωστό λογαριασμό Google.</string>
+    <string name="upgrade_screen_restore_banner_title">Έχετε ήδη αγοράσει Pro;</string>
+    <string name="upgrade_screen_restore_banner_body">Φαίνεται ότι κάνατε αναβάθμιση σε Pro σε αυτήν τη συσκευή στο παρελθόν. Επαναφέρετε την αγορά σας για να το ξεκλειδώσετε ξανά.</string>
     <string name="upgrade_screen_options_description">Οι συνδρομές ανανεώνονται αυτόματα. Μπορείτε να ακυρώσετε ανά πάσα στιγμή.</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Είστε Pro — ευχαριστούμε!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Η ενιαία αγορά Pro ξεκλειδώνει κάθε λειτουργία Pro, για πάντα.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Η συνδρομή σας ξεκλειδώνει κάθε λειτουργία Pro.</string>
+    <string name="upgrade_screen_owned_sub_title">Η συνδρομή σας</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Η συνδρομή σας είναι ενεργή και ανανεώνεται αυτόματα.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Η συνδρομή σας έχει οριστεί να λήξει και δεν θα ανανεωθεί. Θα διατηρήσετε το Pro μέχρι να τελειώσει.</string>
+    <string name="upgrade_screen_owned_both_warning">Διαθέτετε την εφάπαξ αναβάθμιση Pro και έχετε επίσης ενεργή συνδρομή. Δεν χρειάζεστε και τα δύο — ακυρώστε τη συνδρομή στο Google Play για να αποφύγετε περαιτέρω χρεώσεις.</string>
+    <string name="upgrade_screen_manage_subscription_action">Διαχείριση συνδρομής</string>
+    <string name="upgrade_screen_owned_iap_title">Ισόβιο Pro</string>
+    <string name="upgrade_screen_owned_iap_body">Διαθέτετε την εφάπαξ αναβάθμιση Pro. Χωρίς συνδρομή, χωρίς ανανεώσεις.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Μετάβαση σε μια εφάπαξ αγορά</string>
+    <string name="upgrade_screen_switch_purchase_note">Η συνδρομή σας δεν θα ανανεωθεί, έτσι μπορείτε να μεταβείτε στη μόνιμη εφάπαξ αγορά Pro τώρα.</string>
+    <string name="upgrade_screen_switch_locked_note">Για να μεταβείτε στην εφάπαξ αγορά, ακυρώστε πρώτα τη συνδρομή σας στο Google Play. Αυτή η προσφορά ξεκλειδώνεται όταν οριστεί να μην ανανεωθεί.</string>
+    <string name="upgrade_screen_limitation_disclosure">Το Google Play ελέγχει μόνο το λογαριασμό στον οποίο είστε συνδεδεμένοι. Η εφάπαξ αγορά είναι ξεχωριστή από τη συνδρομή σας.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Η συνδρομή σας είναι ακόμα ενεργή και ανανεώνεται. Ακυρώστε την πρώτα στο Google Play.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Δεν ήταν δυνατή η επαλήθευση της συνδρομής σας με το Google Play. Δοκιμάστε ξανά.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">Επιβεβαίωση της αγοράς σας</string>
+    <string name="upgrade_screen_grace_body">Αναμονή για το Google Play να επιβεβαιώσει ξανά την αγορά Pro σας. Συνήθως επιλύεται αυτόματα.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Δεν μπορούμε ακόμα να επιβεβαιώσουμε ξανά την αγορά Pro σας με το Google Play. Εάν συνεχίσει να συμβαίνει, δοκιμάστε να επαναφέρετε την αγορά σας ή επικοινωνήστε με την υποστήριξη.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">Η κατάσταση φαίνεται λανθασμένη;</string>
+    <string name="upgrade_screen_restore_status_body">Εάν έχετε αγοράσει Pro αλλά δεν εμφανίζεται, εκτελέστε έναν έλεγχο σε πραγματικό χρόνο έναντι του Google Play.</string>
+    <string name="upgrade_screen_restore_success_message">Η αγορά επαναφέρθηκε.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Βεβαιωθείτε ότι είστε συνδεδεμένοι με τον λογαριασμό Google που χρησιμοποιήσατε για την αγορά. Ένας έλεγχος σε πραγματικό χρόνο έναντι του Google Play μόλις εκτελέστηκε.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Επιλογές αναβάθμισης</string>
+    <string name="upgrade_screen_offers_body">Ίδια χαρακτηριστικά, απλώς διαφορετικά μοντέλα τιμολόγησης.</string>
+    <string name="upgrade_screen_offers_or">ή</string>
+    <string name="upgrade_screen_subscription_offer_title">Ετήσια συνδρομή</string>
+    <string name="upgrade_screen_subscription_offer_body">Ανανεώνεται ετησίως μετά τη δωρεάν δοκιμή. Ακυρώστε ανά πάσα στιγμή στο Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Ανανεώνεται ετησίως. Ακυρώστε ανά πάσα στιγμή στο Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Αγοράστε μία φορά</string>
+    <string name="upgrade_screen_iap_offer_body">Μία πληρωμή, χωρίς ανανεώσεις.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">Η συνδρομή είναι ακόμη ενεργή</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Το Google Play μόλις ελέγχθηκε, αλλά δεν ήταν δυνατή η επιβεβαίωση μιας αγοράς Pro για τον λογαριασμό που χρησιμοποιεί η εφαρμογή.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Πολλοί λογαριασμοί μπορεί να μπερδέψουν το Google Play. Η εγκατάσταση της εφαρμογής μέσω του ιστοτόπου Google Play την αναγκάζει να συσχετίζεται με έναν συγκεκριμένο λογαριασμό.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Ο συγχρονισμός του Google Play ενδέχεται να πάρει χρόνο. Δοκιμάστε να κάνετε επανεκκίνηση, να καθαρίσετε την προσωρινή μνήμη του Google Play Store ή απλώς να περιμένετε.</string>
+    <string name="upgrade_screen_restore_contact_hint">Ακόμα κολλημένοι; Επικοινωνήστε με την υποστήριξη από το email που έκανε την αγορά και συμπεριλάβετε τον αριθμό παραγγελίας του Google Play.</string>
 </resources>

--- a/app/src/gplay/res/values-es/strings.xml
+++ b/app/src/gplay/res/values-es/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Los servicios de Google Play no están disponibles.</string>
     <string name="upgrades_no_purchases_found_check_account">No se encontraron compras. ¿Estás usando la cuenta correcta?</string>
+    <string name="upgrades_gplay_already_owned_title">Ya adquirido</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play reporta que ya tienes esta actualización, pero no se pudo restaurar. Verifica que hayas iniciado sesión con la cuenta de Google utilizada para la compra original y luego intenta «Restaurar compra».</string>
     <string name="upgrade_screen_preamble">Permission Pilot no tiene anuncios y respeta tu privacidad. Actualizar apoya el desarrollo continuo.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play no está disponible</string>
+    <string name="upgrade_screen_offers_unavailable_message">No se pudieron cargar las opciones de compra. Google Play podría estar temporalmente no disponible — verifica tu conexión e intenta de nuevo.</string>
     <string name="upgrade_screen_subscription_trial_action">Iniciar el período de prueba gratuita</string>
     <string name="upgrade_screen_subscription_action">Suscríbete</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/año, cancela en cualquier momento</string>
-    <string name="upgrade_screen_iap_action">Comprar Pro</string>
+    <string name="upgrade_screen_iap_action">Compra única</string>
     <string name="upgrade_screen_iap_action_hint">Compra única de %s</string>
     <string name="upgrade_screen_restore_purchase_action">Restaurar la compra</string>
     <string name="upgrade_screen_restore_purchase_message">No se encontraron compras. Comprueba que has iniciado sesión con la cuenta de Google correcta.</string>
+    <string name="upgrade_screen_restore_banner_title">¿Ya compraste Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Parece que ya actualizaste a Pro en este dispositivo antes. Restaura tu compra para desbloquearlo de nuevo.</string>
     <string name="upgrade_screen_options_description">Las suscripciones se renuevan automáticamente. Puedes cancelar en cualquier momento.</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">¡Eres Pro — gracias!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Tu compra única de Pro desbloquea todas las funciones Pro, para siempre.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Tu suscripción desbloquea todas las funciones Pro.</string>
+    <string name="upgrade_screen_owned_sub_title">Tu suscripción</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Tu suscripción está activa y se renueva automáticamente.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Tu suscripción está configurada para expirar y no se renovará. Mantendrás Pro hasta que finalice.</string>
+    <string name="upgrade_screen_owned_both_warning">Posees la actualización única de Pro y también tienes una suscripción activa. No necesitas ambas: cancela la suscripción en Google Play para evitar cargos adicionales.</string>
+    <string name="upgrade_screen_manage_subscription_action">Gestionar suscripción</string>
+    <string name="upgrade_screen_owned_iap_title">Pro de por vida</string>
+    <string name="upgrade_screen_owned_iap_body">Posees la actualización única de Pro. Sin suscripción, sin renovaciones.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Cambiar a una compra única</string>
+    <string name="upgrade_screen_switch_purchase_note">Tu suscripción no se renovará, por lo que ahora puedes cambiar a la compra Pro única y permanente.</string>
+    <string name="upgrade_screen_switch_locked_note">Para cambiar a la compra única, primero cancela tu suscripción en Google Play. Esta oferta se desbloquea una vez que esté configurada para no renovarse.</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play solo verifica la cuenta en la que actualmente has iniciado sesión. La compra única es independiente de tu suscripción.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Tu suscripción sigue activa y se está renovando. Cancélala en Google Play primero.</string>
+    <string name="upgrade_screen_sub_check_failed_message">No se pudo verificar tu suscripción con Google Play. Por favor, intenta de nuevo.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">Confirmando tu compra</string>
+    <string name="upgrade_screen_grace_body">Esperando que Google Play reconfirme tu compra Pro. Esto generalmente se resuelve por sí solo.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Aún no podemos reconfirmar tu compra Pro con Google Play. Si esto sigue ocurriendo, intenta restaurar tu compra o contacta con soporte.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">¿El estado se ve incorrecto?</string>
+    <string name="upgrade_screen_restore_status_body">Si has comprado Pro pero no aparece, ejecuta una verificación en tiempo real con Google Play.</string>
+    <string name="upgrade_screen_restore_success_message">Compra restaurada.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Asegúrate de que hayas iniciado sesión con la cuenta de Google que utilizaste para comprar. Se acaba de ejecutar una verificación en tiempo real con Google Play.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Opciones de actualización</string>
+    <string name="upgrade_screen_offers_body">Las mismas funciones, solo con modelos de precios diferentes.</string>
+    <string name="upgrade_screen_offers_or">o</string>
+    <string name="upgrade_screen_subscription_offer_title">Suscripción anual</string>
+    <string name="upgrade_screen_subscription_offer_body">Se renueva anualmente después del período de prueba gratuita. Cancela en cualquier momento en Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Se renueva anualmente. Cancela en cualquier momento en Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Comprar una vez</string>
+    <string name="upgrade_screen_iap_offer_body">Un solo pago, sin renovaciones.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">Suscripción aún activa</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Google Play se acaba de verificar, pero no se pudo confirmar ninguna compra de Pro para la cuenta que utiliza esta aplicación.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Múltiples cuentas pueden confundir a Google Play. Instalar la aplicación a través del sitio web de Google Play la obliga a asociarse con una cuenta específica.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">La sincronización con Google Play puede tardar un tiempo. Intenta reiniciar, borrar la caché de Google Play Store o simplemente esperar.</string>
+    <string name="upgrade_screen_restore_contact_hint">¿Aún atascado? Contacta con soporte desde el correo electrónico que realizó la compra e incluye tu número de pedido de Google Play.</string>
 </resources>

--- a/app/src/gplay/res/values-fi/strings.xml
+++ b/app/src/gplay/res/values-fi/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play -palvelut eivät ole käytettävissä.</string>
     <string name="upgrades_no_purchases_found_check_account">Ostoja ei löytynyt. Käytätkö oikeaa tiliä?</string>
+    <string name="upgrades_gplay_already_owned_title">Jo ostettu</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play ilmoittaa, että omistit jo tämän päivityksen, mutta sitä ei voitu palauttaa. Varmista, että olet kirjautunut Google-tilillä, jolla teit alkuperäisen ostoksen, ja yritä sitten \"Palauta osto\".</string>
     <string name="upgrade_screen_preamble">Permission Pilot on mainokseton ja kunnioittaa yksityisyyttäsi. Päivittäminen tukee jatkuvaa kehitystä.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play ei ole käytettävissä</string>
+    <string name="upgrade_screen_offers_unavailable_message">Ostovaihtoehtoja ei voitu ladata. Google Play saattaa olla tilapäisesti poissa käytöstä – tarkista yhteytesi ja yritä uudelleen.</string>
     <string name="upgrade_screen_subscription_trial_action">Aloita ilmainen kokeilu</string>
     <string name="upgrade_screen_subscription_action">Tilaa</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/vuosi, voit peruuttaa milloin tahansa</string>
-    <string name="upgrade_screen_iap_action">Osta Pro</string>
+    <string name="upgrade_screen_iap_action">Kertaostos</string>
     <string name="upgrade_screen_iap_action_hint">Kertaostos hintaan %s</string>
     <string name="upgrade_screen_restore_purchase_action">Palauta ostos</string>
     <string name="upgrade_screen_restore_purchase_message">Ostoksia ei löydy. Tarkista, että olet kirjautunut oikealla Google-tilillä.</string>
+    <string name="upgrade_screen_restore_banner_title">Ostettu Pro jo?</string>
+    <string name="upgrade_screen_restore_banner_body">Näyttää siltä, että olet päivittänyt Pro-versioon tällä laitteella aiemmin. Palauta ostoksesi avataksesi sen uudelleen.</string>
     <string name="upgrade_screen_options_description">Tilaukset uusiutuvat automaattisesti. Voit peruuttaa milloin tahansa.</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Olet Pro – kiitos!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Kertaluonteinen Pro-ostos avaa kaikki Pro-ominaisuudet ikuisesti.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Tilauksesi avaa kaikki Pro-ominaisuudet.</string>
+    <string name="upgrade_screen_owned_sub_title">Tilauksesi</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Tilauksesi on aktiivinen ja uusiutuu automaattisesti.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Tilauksesi on asetettu vanhentumaan eikä se uusiudu. Säilytät Pro-ominaisuudet sen loppuun asti.</string>
+    <string name="upgrade_screen_owned_both_warning">Omistat kertamaksullisen Pro-päivityksen ja sinulla on myös aktiivinen tilaus. Et tarvitse molempia – peruuta tilaus Google Playssa, jotta vältyt lisäkustannuksilta.</string>
+    <string name="upgrade_screen_manage_subscription_action">Hallitse tilausta</string>
+    <string name="upgrade_screen_owned_iap_title">Elinikäinen Pro</string>
+    <string name="upgrade_screen_owned_iap_body">Omistat kertamaksullisen Pro-päivityksen. Ei tilausta, ei uusintoja.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Siirry kertamaksuun</string>
+    <string name="upgrade_screen_switch_purchase_note">Tilauksesi ei uusiudu, joten voit siirtyä pysyvään kertamaksulliseen Pro-ostoon nyt.</string>
+    <string name="upgrade_screen_switch_locked_note">Vaihda kertamaksun ostoon peruuttamalla ensin tilauspalvelusi Google Playsta. Tämä tarjous vapautuu, kun se on asetettu pois uusiutumasta.</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play tarkistaa vain tilin, johon olet tällä hetkellä kirjautunut. Kertaosto on erillinen tilauspalvelustasi.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Tilauspalvelusi on vielä aktiivinen ja uusiutuu. Peruuta se ensin Google Playsta.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Tilauspalvelusi tarkistaminen Google Playsta epäonnistui. Yritä uudelleen.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">Vahvistetaan ostoasi</string>
+    <string name="upgrade_screen_grace_body">Odotetaan Google Playta vahvistamaan uudelleen Pro-ostoasi. Tämä yleensä ratkeaa itsestään.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Emme silti pysty vahvistamaan Pro-ostoasi uudelleen Google Playssa. Jos tämä jatkuu, yritä palauttaa ostosi tai ota yhteyttä tukeen.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">Tilanne näyttää väärältä?</string>
+    <string name="upgrade_screen_restore_status_body">Jos olet ostanut Pro:n mutta sitä ei näy, suorita reaaliaikainen tarkistus Google Playssa.</string>
+    <string name="upgrade_screen_restore_success_message">Osto palautettu.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Varmista, että olet kirjautunut Google-tilillä, jolla ostit. Google Play suoritti juuri tuoreen tarkistuksen.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Päivitysvaihtoehdot</string>
+    <string name="upgrade_screen_offers_body">Samat ominaisuudet, vain eri hinnoittelumallit.</string>
+    <string name="upgrade_screen_offers_or">tai</string>
+    <string name="upgrade_screen_subscription_offer_title">Vuosittainen tilaus</string>
+    <string name="upgrade_screen_subscription_offer_body">Uusiutuu vuosittain ilmaisen kokeilujakson jälkeen. Voit peruuttaa milloin tahansa Google Playssa.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Uusiutuu vuosittain. Voit peruuttaa milloin tahansa Google Playssa.</string>
+    <string name="upgrade_screen_iap_offer_title">Osta kerran</string>
+    <string name="upgrade_screen_iap_offer_body">Yksi maksu, ei uusintoja.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">Tilaus on edelleen aktiivinen</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Google Playta tarkistettiin juuri, mutta Pro-ostoa ei voitu vahvistaa tilissä, jota tämä sovellus käyttää.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Useat tilit voivat hämmentää Google Playta. Sovelluksen asentaminen Google Play -verkkosivuston kautta pakottaa sen liittymään tiettyyn tiliin.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Google Play -synkronointi voi kestää. Kokeile uudelleenkäynnistystä, Google Play -välimuistin tyhjentämistä tai vain odottamista.</string>
+    <string name="upgrade_screen_restore_contact_hint">Oletko vielä jumissa? Ota yhteyttä tukeen sähköpostista, jolla ostoksesi tehtiin, ja sisällytä Google Play -tilausnumerosi.</string>
 </resources>

--- a/app/src/gplay/res/values-fr/strings.xml
+++ b/app/src/gplay/res/values-fr/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Les services Google Play sont inaccessibles.</string>
     <string name="upgrades_no_purchases_found_check_account">Aucun achat n’a été trouvé. Utilisez-vous le bon compte ?</string>
+    <string name="upgrades_gplay_already_owned_title">Déjà acheté</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play indique que vous possédez déjà cette mise à niveau, mais elle n’a pas pu être restaurée. Vérifiez que vous êtes connecté au compte Google utilisé pour l’achat initial, puis essayez « Restaurer l’achat ».</string>
     <string name="upgrade_screen_preamble">Permission Pilot est sans publicité et respecte votre vie privée. La mise à niveau soutient le développement continu.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play indisponible</string>
+    <string name="upgrade_screen_offers_unavailable_message">Impossible de charger les options d’achat. Google Play est peut-être temporairement indisponible — vérifiez votre connexion et réessayez.</string>
     <string name="upgrade_screen_subscription_trial_action">Commencer l’essai gratuit</string>
     <string name="upgrade_screen_subscription_action">M’abonner</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/an, annulation à tout moment</string>
-    <string name="upgrade_screen_iap_action">Acheter Pro</string>
+    <string name="upgrade_screen_iap_action">Achat unique</string>
     <string name="upgrade_screen_iap_action_hint">Achat unique de %s</string>
     <string name="upgrade_screen_restore_purchase_action">Rétablir l’achat</string>
     <string name="upgrade_screen_restore_purchase_message">Aucun achat trouvé. Vérifiez que vous êtes connecté avec le bon compte Google.</string>
+    <string name="upgrade_screen_restore_banner_title">Vous avez déjà acheté Pro ?</string>
+    <string name="upgrade_screen_restore_banner_body">Il semble que vous ayez déjà fait la mise à niveau vers Pro sur cet appareil. Restaurez votre achat pour le déverrouiller à nouveau.</string>
     <string name="upgrade_screen_options_description">Les abonnements se renouvellent automatiquement. Vous pouvez annuler à tout moment.</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Vous êtes Pro — merci !</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Votre achat Pro unique déverrouille toutes les fonctionnalités Pro, pour toujours.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Votre abonnement déverrouille toutes les fonctionnalités Pro.</string>
+    <string name="upgrade_screen_owned_sub_title">Votre abonnement</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Votre abonnement est actif et se renouvelle automatiquement.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Votre abonnement est configuré pour expirer et ne se renouvellera pas. Vous conserverez Pro jusqu’à sa fin.</string>
+    <string name="upgrade_screen_owned_both_warning">Vous possédez l’achat unique Pro et vous avez également un abonnement actif. Vous n’avez pas besoin des deux — annulez l’abonnement dans Google Play pour éviter des frais supplémentaires.</string>
+    <string name="upgrade_screen_manage_subscription_action">Gérer l’abonnement</string>
+    <string name="upgrade_screen_owned_iap_title">Pro à vie</string>
+    <string name="upgrade_screen_owned_iap_body">Vous possédez l’achat unique Pro. Pas d’abonnement, pas de renouvellements.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Passer à un achat unique</string>
+    <string name="upgrade_screen_switch_purchase_note">Votre abonnement ne se renouvellera pas, vous pouvez donc passer à l’achat Pro permanent et unique dès maintenant.</string>
+    <string name="upgrade_screen_switch_locked_note">Pour passer à l’achat unique, annulez d’abord votre abonnement dans Google Play. Cette offre se déverrouille une fois l’abonnement défini pour ne pas se renouveler.</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play vérifie uniquement le compte auquel vous êtes actuellement connecté. L’achat unique est distinct de votre abonnement.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Votre abonnement est toujours actif et se renouvelle. Annulez-le d’abord dans Google Play.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Impossible de vérifier votre abonnement auprès de Google Play. Veuillez réessayer.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">Confirmation de votre achat</string>
+    <string name="upgrade_screen_grace_body">En attente que Google Play confirme à nouveau votre achat Pro. Cela se résout généralement automatiquement.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Nous ne pouvons toujours pas confirmer à nouveau votre achat Pro auprès de Google Play. Si cela continue, essayez de restaurer votre achat ou contactez le support.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">Le statut semble incorrect ?</string>
+    <string name="upgrade_screen_restore_status_body">Si vous avez acheté Pro mais cela ne s’affiche pas, exécutez une vérification en direct auprès de Google Play.</string>
+    <string name="upgrade_screen_restore_success_message">Achat restauré.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Assurez-vous d’être connecté avec le compte Google que vous avez utilisé pour votre achat. Une vérification en direct auprès de Google Play vient d’être effectuée.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Options de mise à niveau</string>
+    <string name="upgrade_screen_offers_body">Les mêmes fonctionnalités, simplement des modèles de tarification différents.</string>
+    <string name="upgrade_screen_offers_or">ou</string>
+    <string name="upgrade_screen_subscription_offer_title">Abonnement annuel</string>
+    <string name="upgrade_screen_subscription_offer_body">Se renouvelle annuellement après l’essai gratuit. Annulez à tout moment dans Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Se renouvelle annuellement. Annulez à tout moment dans Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Acheter une fois</string>
+    <string name="upgrade_screen_iap_offer_body">Un seul paiement, pas de renouvellement.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">Abonnement toujours actif</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Google Play a été consulté, mais aucun achat Pro n’a pu être confirmé pour le compte utilisé par cette appli.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Plusieurs comptes peuvent perturber Google Play. Installer l’appli via le site Web de Google Play force son association avec un compte spécifique.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">La synchronisation Google Play peut prendre du temps. Essayez de redémarrer votre appareil, de vider le cache de Google Play Store ou simplement d’attendre.</string>
+    <string name="upgrade_screen_restore_contact_hint">Toujours bloqué ? Contactez le support depuis l’adresse e-mail qui a effectué l’achat et incluez votre numéro de commande Google Play.</string>
 </resources>

--- a/app/src/gplay/res/values-hi-rIN/strings.xml
+++ b/app/src/gplay/res/values-hi-rIN/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play सेवाएं उपलब्ध नहीं हैं।</string>
     <string name="upgrades_no_purchases_found_check_account">कोई खरीदारी नहीं मिली। क्या आप सही खाते का उपयोग कर रहे हैं?</string>
+    <string name="upgrades_gplay_already_owned_title">पहले से खरीदा गया</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play की रिपोर्ट है कि आप पहले से इस अपग्रेड के मालिक हैं, लेकिन इसे पुनः स्थापित नहीं किया जा सका। जांचें कि आप मूल खरीद के लिए उपयोग किए गए Google खाते से साइन इन हैं, फिर \"खरीद को पुनः स्थापित करें\" की कोशिश करें।</string>
     <string name="upgrade_screen_preamble">Permission Pilot विज्ञापन-मुक्त है और आपकी गोपनीयता का सम्मान करता है। अपग्रेड करना निरंतर विकास का समर्थन करता है।</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play अनुपलब्ध है</string>
+    <string name="upgrade_screen_offers_unavailable_message">खरीद विकल्पों को लोड नहीं किया जा सका। Google Play अस्थायी रूप से अनुपलब्ध हो सकता है — अपने कनेक्शन की जांच करें और फिर से कोशिश करें।</string>
     <string name="upgrade_screen_subscription_trial_action">निशुल्क प्रयोग प्रारंभ करें</string>
     <string name="upgrade_screen_subscription_action">सदस्यता लें</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/वर्ष, कभी भी रद्द करें</string>
-    <string name="upgrade_screen_iap_action">Pro खरीदें</string>
+    <string name="upgrade_screen_iap_action">एक-बार खरीदे</string>
     <string name="upgrade_screen_iap_action_hint">%s की एकमुश्त खरीद</string>
     <string name="upgrade_screen_restore_purchase_action">खरीदारी पुनर्स्थापित करें</string>
     <string name="upgrade_screen_restore_purchase_message">कोई खरीदारी नहीं मिली। जांचें कि आप सही Google खाते से साइन इन हैं।</string>
+    <string name="upgrade_screen_restore_banner_title">पहले से Pro खरीदा?</string>
+    <string name="upgrade_screen_restore_banner_body">ऐसा लगता है कि आप इस डिवाइस पर पहले Pro पर अपग्रेड कर चुके हैं। इसे फिर से अनलॉक करने के लिए अपनी खरीद को पुनः स्थापित करें।</string>
     <string name="upgrade_screen_options_description">सदस्यता स्वचालित रूप से नवीनीकृत होती है। आप कभी भी रद्द कर सकते हैं।</string>
     <string name="upgrade_title_suffix">प्रो</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">आप Pro हैं — धन्यवाद!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">आपकी एक बार की Pro खरीद हमेशा के लिए हर Pro सुविधा को अनलॉक करती है।</string>
+    <string name="upgrade_screen_owned_hero_sub_body">आपकी सदस्यता हर Pro सुविधा को अनलॉक करती है।</string>
+    <string name="upgrade_screen_owned_sub_title">आपकी सदस्यता</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">आपकी सदस्यता सक्रिय है और स्वचालित रूप से नवीनीकृत होती है।</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">आपकी सदस्यता समाप्त होने के लिए सेट है और नवीनीकृत नहीं होगी। आप इसके समाप्त होने तक Pro को रखेंगे।</string>
+    <string name="upgrade_screen_owned_both_warning">आप एक बार की Pro अपग्रेड के मालिक हैं और एक सक्रिय सदस्यता भी रखते हैं। आपको दोनों की आवश्यकता नहीं है — आगे के शुल्क से बचने के लिए Google Play में सदस्यता को रद्द करें।</string>
+    <string name="upgrade_screen_manage_subscription_action">सदस्यता प्रबंधित करें</string>
+    <string name="upgrade_screen_owned_iap_title">आजीवन Pro</string>
+    <string name="upgrade_screen_owned_iap_body">आप एक बार की Pro अपग्रेड के मालिक हैं। कोई सदस्यता नहीं, कोई नवीनीकरण नहीं।</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">एक बार की खरीदारी पर स्विच करें</string>
+    <string name="upgrade_screen_switch_purchase_note">आपकी सदस्यता नवीनीकृत नहीं होगी, इसलिए आप अब स्थायी एक बार की Pro खरीदारी पर जा सकते हैं।</string>
+    <string name="upgrade_screen_switch_locked_note">एक बार की खरीदारी पर स्विच करने के लिए, पहले Google Play में अपनी सदस्यता को रद्द करें। यह ऑफर तब अनलॉक हो जाता है जब इसे नवीनीकृत न करने के लिए सेट किया जाता है।</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play केवल उस खाते की जांच करता है जिसमें आप वर्तमान में साइन इन हैं। एक बार की खरीदारी आपकी सदस्यता से अलग है।</string>
+    <string name="upgrade_screen_sub_still_renewing_message">आपकी सदस्यता अभी भी सक्रिय है और नवीनीकृत हो रही है। पहले इसे Google Play में रद्द करें।</string>
+    <string name="upgrade_screen_sub_check_failed_message">Google Play के साथ आपकी सदस्यता को सत्यापित नहीं किया जा सका। कृपया पुनः प्रयास करें।</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">आपकी खरीदारी की पुष्टि की जा रही है</string>
+    <string name="upgrade_screen_grace_body">Google Play को आपकी Pro खरीदारी को फिर से पुष्टि करने की प्रतीक्षा है। यह आमतौर पर अपने आप ठीक हो जाता है।</string>
+    <string name="upgrade_screen_grace_diagnostics_body">हम अभी भी Google Play के साथ आपकी Pro खरीदारी को फिर से पुष्टि नहीं कर सकते। यदि यह बार-बार होता रहे, तो अपनी खरीदारी को पुनः स्थापित करने का प्रयास करें या सहायता से संपर्क करें।</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">स्थिति गलत लग रही है?</string>
+    <string name="upgrade_screen_restore_status_body">अगर आपने Pro खरीदा है लेकिन वह दिख नहीं रहा है, तो Google Play के साथ एक लाइव जांच चलाएं।</string>
+    <string name="upgrade_screen_restore_success_message">क्रय बहाल किया गया।</string>
+    <string name="upgrade_screen_restore_webinstall_hint">सुनिश्चित करें कि आप उस Google खाते से साइन इन हैं जिसका उपयोग आपने खरीदारी के लिए किया था। Google Play के साथ एक लाइव जांच अभी चली।</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">अपग्रेड विकल्प</string>
+    <string name="upgrade_screen_offers_body">समान विशेषताएं, बस विभिन्न मूल्य निर्धारण मॉडल।</string>
+    <string name="upgrade_screen_offers_or">या</string>
+    <string name="upgrade_screen_subscription_offer_title">वार्षिक सदस्यता</string>
+    <string name="upgrade_screen_subscription_offer_body">मुफ्त परीक्षण के बाद वार्षिक नवीकरण करता है। किसी भी समय Google Play में रद्द करें।</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">हर साल नवीनीकृत होता है। Google Play में कभी भी रद्द करें।</string>
+    <string name="upgrade_screen_iap_offer_title">एक बार खरीदें</string>
+    <string name="upgrade_screen_iap_offer_body">एक भुगतान, कोई नवीनीकरण नहीं।</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">सदस्यता अभी भी सक्रिय है</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Google Play की अभी जांच की गई, लेकिन इस ऐप के लिए उपयोग किए जा रहे खाते के लिए कोई Pro खरीद की पुष्टि नहीं की जा सकी।</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">कई खाते Google Play को भ्रमित कर सकते हैं। Google Play वेबसाइट के माध्यम से ऐप इंस्टॉल करने से यह एक विशिष्ट खाते के साथ जुड़ने के लिए बाध्य होता है।</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Google Play सिंक्रोनाइजेशन में समय लग सकता है। रीबूट करने, Google Play Store कैश साफ़ करने, या बस प्रतीक्षा करने का प्रयास करें।</string>
+    <string name="upgrade_screen_restore_contact_hint">अभी भी फंसे हुए हैं? खरीद करने वाले ईमेल से समर्थन से संपर्क करें और अपनी Google Play ऑर्डर संख्या शामिल करें।</string>
 </resources>

--- a/app/src/gplay/res/values-hr/strings.xml
+++ b/app/src/gplay/res/values-hr/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Usluge Google Playa nisu dostupne.</string>
     <string name="upgrades_no_purchases_found_check_account">Nisu pronađene kupnje. Koristite li pravi račun?</string>
+    <string name="upgrades_gplay_already_owned_title">Već kupljeno</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play izvještava da već posjedujete ovu nadogradnju, ali nije mogla biti vraćena. Provjerite jeste li prijavljeni sa Google računom korištenim za izvornu kupnju, pa pokušajte s opcijom \"Vrati kupnju\".</string>
     <string name="upgrade_screen_preamble">Permission Pilot je bez oglasa i poštuje vašu privatnost. Nadogradnjom podržavate daljnji razvoj.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play nije dostupan</string>
+    <string name="upgrade_screen_offers_unavailable_message">Nije bilo moguće učitati opcije kupnje. Google Play možda je privremeno nedostupan — provjerite vašu vezu i pokušajte ponovno.</string>
     <string name="upgrade_screen_subscription_trial_action">Započnite besplatnu probu</string>
     <string name="upgrade_screen_subscription_action">Pretplatite se</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/godinu, otkaži bilo kada</string>
-    <string name="upgrade_screen_iap_action">Kupi Pro</string>
+    <string name="upgrade_screen_iap_action">Jednokratna kupnja</string>
     <string name="upgrade_screen_iap_action_hint">Jednokratna kupnja od %s</string>
     <string name="upgrade_screen_restore_purchase_action">Obnovi kupnju</string>
     <string name="upgrade_screen_restore_purchase_message">Nisu pronađene kupnje. Provjerite jeste li prijavljeni ispravnim Google računom.</string>
+    <string name="upgrade_screen_restore_banner_title">Već ste kupili Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Čini se da ste se prije na ovom uređaju nadogradili na Pro. Vratite vašu kupnju da je ponovno otključate.</string>
     <string name="upgrade_screen_options_description">Pretplate se automatski obnavljaju. Možete otkazati u bilo koje vrijeme.</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Sada ste Pro — hvala!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Vaša jednokratna Pro kupnja otključava sve Pro značajke zauvijek.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Vaša pretplata otključava sve Pro značajke.</string>
+    <string name="upgrade_screen_owned_sub_title">Vaša pretplata</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Vaša pretplata je aktivna i obnavlja se automatski.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Vaša pretplata je postavljena da ističe i neće se obnoviti. Zadržat ćete Pro dok ne istekne.</string>
+    <string name="upgrade_screen_owned_both_warning">Posjedujete jednokratnu Pro nadogradnju i također imate aktivnu pretplatu. Ne trebate oboje — otkažite pretplatu u Google Playu kako biste izbjegli daljnje naknade.</string>
+    <string name="upgrade_screen_manage_subscription_action">Upravljajte pretplatom</string>
+    <string name="upgrade_screen_owned_iap_title">Doživotni Pro</string>
+    <string name="upgrade_screen_owned_iap_body">Posjedujete jednokratnu Pro nadogradnju. Bez pretplate, bez obnove.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Prebacite se na jednokratnu kupnju</string>
+    <string name="upgrade_screen_switch_purchase_note">Vaša pretplata se neće obnoviti, pa sada možete prijeći na trajnu jednokratnu Pro kupnju.</string>
+    <string name="upgrade_screen_switch_locked_note">Za prebacivanje na jednokratnu kupnju, prvo trebate otkazati pretplatu na Google Playu. Ova ponuda se otključava nakon što je postavljena da se ne obnovi.</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play provjerava samo račun na koji ste trenutno prijavljeni. Jednokratna kupnja je odvojena od vaše pretplate.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Vaša pretplata je i dalje aktivna i obnavlja se. Trebate je prvo otkazati na Google Playu.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Nije moguće provjeriti vašu pretplatu s Google Playom. Pokušajte ponovno.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">Potvrda vaše kupnje</string>
+    <string name="upgrade_screen_grace_body">Čeka se da Google Play ponovno potvrdi vašu Pro kupnju. Obično se to razriješi samo od sebe.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Još uvijek ne možemo ponovno potvrditi vašu Pro kupnju s Google Playom. Ako se to nastavlja, pokušajte vratiti vašu kupnju ili se obratite podršci.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">Stanje izgleda krivo?</string>
+    <string name="upgrade_screen_restore_status_body">Ako ste kupili Pro, ali se ne prikazuje, pokrenite živu provjeru s Google Playom.</string>
+    <string name="upgrade_screen_restore_success_message">Kupnja je vraćena.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Provjerite da ste prijavljeni s Google računom koji ste koristili za kupnju. Živa provjera s Google Playom upravo je pokrenuta.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Opcije nadogradnje</string>
+    <string name="upgrade_screen_offers_body">Iste mogućnosti, samo različiti modeli cijena.</string>
+    <string name="upgrade_screen_offers_or">ili</string>
+    <string name="upgrade_screen_subscription_offer_title">Godišnja pretplata</string>
+    <string name="upgrade_screen_subscription_offer_body">Obnavlja se godišnje nakon besplatnog probnog razdoblja. Otkažite bilo kada u Google Playu.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Obnavlja se godišnje. Otkažite bilo kada u Google Playu.</string>
+    <string name="upgrade_screen_iap_offer_title">Kupi jednom</string>
+    <string name="upgrade_screen_iap_offer_body">Jedna uplata, bez obnova.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">Pretplata je još uvijek aktivna</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Google Play je upravo provjeren, ali nijedna Pro kupnja nije mogla biti potvrđena za račun koji koristi ova aplikacija.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Više računa može zbuniti Google Play. Instaliranje aplikacije putem web-mjesta Google Playa prisiljava je da se poveže s određenim računom.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Sinkronizacija Google Playa može potrajati. Pokušajte ponovno pokrenuti, obrisati predmemoriju Google Play Storea ili samo pričekati.</string>
+    <string name="upgrade_screen_restore_contact_hint">Još uvijek zapeli? Kontaktirajte podršku s e-pošte koja je izvršila kupnju i uključite broj narudžbe s Google Playa.</string>
 </resources>

--- a/app/src/gplay/res/values-hu/strings.xml
+++ b/app/src/gplay/res/values-hu/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">A Google Play szolgáltatások nem érhetők el.</string>
     <string name="upgrades_no_purchases_found_check_account">Nem találhatók vásárlások. A megfelelő fiókot használod?</string>
+    <string name="upgrades_gplay_already_owned_title">Már megvásárolt</string>
+    <string name="upgrades_gplay_already_owned_error">A Google Play azt jelenti, hogy már rendelkezel ezzel a frissítéssel, de nem sikerült helyreállítani. Ellenőrizd, hogy bejelentkeztél-e azzal a Google-fiókkal, amelyet az eredeti vásárláshoz használtál, majd próbáld meg a \"Vásárlás helyreállítása\" lehetőséget.</string>
     <string name="upgrade_screen_preamble">A Permission Pilot reklámmentes és tiszteletben tartja az adatvédelmed. A frissítés támogatja a további fejlesztést.</string>
+    <string name="upgrade_screen_offers_unavailable_title">A Google Play nem elérhető</string>
+    <string name="upgrade_screen_offers_unavailable_message">Nem sikerült betölteni a vásárlási lehetőségeket. A Google Play ideiglenesen nem érhető el – ellenőrizd az internetkapcsolatod, és próbáld újra.</string>
     <string name="upgrade_screen_subscription_trial_action">Ingyenes próba indítása</string>
     <string name="upgrade_screen_subscription_action">Iratkozz fel</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/év, bármikor lemondható</string>
-    <string name="upgrade_screen_iap_action">Pro megvásárlása</string>
+    <string name="upgrade_screen_iap_action">Egyszeri vásárlás</string>
     <string name="upgrade_screen_iap_action_hint">Egyszeri vásárlás: %s</string>
     <string name="upgrade_screen_restore_purchase_action">Vásárlás visszaállítása</string>
     <string name="upgrade_screen_restore_purchase_message">Nem található vásárlás. Ellenőrizd, hogy a megfelelő Google-fiókkal vagy vagy bejelentkezve.</string>
+    <string name="upgrade_screen_restore_banner_title">Már megvásároltad a Pro-t?</string>
+    <string name="upgrade_screen_restore_banner_body">Úgy tűnik, korábban már Pro-ra frissítettél ezen az eszközön. Állítsd vissza a vásárlást, hogy újra feloldhasd.</string>
     <string name="upgrade_screen_options_description">Az előfizetések automatikusan megújulnak. Bármikor lemondhatod.</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Pro vagy – köszönjük!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Az egyszeri Pro vásárlásod minden Pro funkciót feloldja, örökre.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Az előfizetésed minden Pro funkciót feloldja.</string>
+    <string name="upgrade_screen_owned_sub_title">Az előfizetésed</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Az előfizetésed aktív és automatikusan megújul.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Az előfizetésed nem fog megújulni. Pro marad, amíg le nem jár.</string>
+    <string name="upgrade_screen_owned_both_warning">Megvásároltad az egyszeri Pro verzióját, és van egy aktív előfizetésed is. Nincs szükséged mindkettőre — szüntesd meg az előfizetésed a Google Play-ben a további díjak elkerüléséhez.</string>
+    <string name="upgrade_screen_manage_subscription_action">Előfizetés kezelése</string>
+    <string name="upgrade_screen_owned_iap_title">Élettartam Pro</string>
+    <string name="upgrade_screen_owned_iap_body">Megvásároltad az egyszeri Pro verzióját. Nincs előfizetés, nincs megújítás.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Váltás egyszeri vásárlásra</string>
+    <string name="upgrade_screen_switch_purchase_note">Az előfizetésed nem újul meg, így most már áttérhetsz az egyszeri Pro vásárlásra.</string>
+    <string name="upgrade_screen_switch_locked_note">Az egyszeri vásárlásra való váltáshoz először szüntesd meg az előfizetésed a Google Play-ben. Ez az ajánlat akkor lesz elérhető, ha beállítod, hogy ne újuljon meg.</string>
+    <string name="upgrade_screen_limitation_disclosure">A Google Play csak az aktuálisan bejelentkeztetett fiókot ellenőrzi. Az egyszeri vásárlás és az előfizetésed egymástól függetlenek.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Az előfizetésed továbbra is aktív és megújul. Előbb szüntesd meg azt a Google Play-ben.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Nem sikerült ellenőrizni az előfizetésed a Google Play-ben. Kérjük, próbáld újra.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">Vásárlás megerősítése</string>
+    <string name="upgrade_screen_grace_body">Arra várakozunk, hogy a Google Play újra megerősítse a Pro vásárlásod. Ez általában magától megoldódik.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Még mindig nem tudjuk újra megerősíteni a Pro vásárlásod a Google Play-ben. Ha ez továbbra is megtörténik, próbáld meg helyreállítani a vásárlásod, vagy vedd fel a kapcsolatot az ügyfélszolgálattal.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">Nem megfelelőnek tűnik az állapot?</string>
+    <string name="upgrade_screen_restore_status_body">Ha megvásároltad a Pro verziót, de nem jelenik meg, futtass élő ellenőrzést a Google Play ellen.</string>
+    <string name="upgrade_screen_restore_success_message">Vásárlás helyreállítva.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Győződj meg arról, hogy a vásárláshoz használt Google-fiókkal vagy bejelentkezve. Az élő Google Play ellenőrzés éppen most futott le.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Frissítési lehetőségek</string>
+    <string name="upgrade_screen_offers_body">Ugyanazok a funkciók, csak más árképzési modellek.</string>
+    <string name="upgrade_screen_offers_or">vagy</string>
+    <string name="upgrade_screen_subscription_offer_title">Éves előfizetés</string>
+    <string name="upgrade_screen_subscription_offer_body">Évente megújul az ingyenes próbaidőszak után. Bármikor lemondható a Google Play-ben.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Évente megújul. Bármikor lemondható a Google Play-ben.</string>
+    <string name="upgrade_screen_iap_offer_title">Egyszeri vásárlás</string>
+    <string name="upgrade_screen_iap_offer_body">Egy fizetés, nincs megújítás.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">Előfizetés még aktív</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">A Google Play-t éppen most ellenőrizték, de a Pro vásárlást nem sikerült megerősíteni az alkalmazásban használt fiók számára.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Több fiók összezavarhatja a Google Play-t. Az alkalmazás Google Play webhelyről történő telepítése azt kényszeríti, hogy egy adott fiókkal társuljon.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">A Google Play szinkronizálása eltarthat egy ideig. Próbálj meg újraindítani, töröld a Google Play Store gyorsítótárát, vagy egyszerűen csak várakozz.</string>
+    <string name="upgrade_screen_restore_contact_hint">Még mindig elakadt? Lépj kapcsolatba a támogatással a vásárlást végzett e-mail címről, és add meg a Google Play megrendelési számot.</string>
 </resources>

--- a/app/src/gplay/res/values-it/strings.xml
+++ b/app/src/gplay/res/values-it/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">I servizi di Google Play non sono disponibili.</string>
     <string name="upgrades_no_purchases_found_check_account">Nessun acquisto trovato. Stai utilizzando l\'account corretto?</string>
+    <string name="upgrades_gplay_already_owned_title">Già acquistato</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play segnala che possiedi già questo acquisto, ma non è stato possibile ripristinarlo. Verifica che tu sia acceduto con l’account Google utilizzato per l’acquisto originale, quindi prova a «Ripristina acquisto».</string>
     <string name="upgrade_screen_preamble">Permission Pilot è senza pubblicità e rispetta la tua privacy. Aggiornare supporta lo sviluppo continuo.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play non è disponibile</string>
+    <string name="upgrade_screen_offers_unavailable_message">Impossibile caricare le opzioni di acquisto. Google Play potrebbe essere temporaneamente non disponibile — controlla la connessione e riprova.</string>
     <string name="upgrade_screen_subscription_trial_action">Inizia la prova gratuita</string>
     <string name="upgrade_screen_subscription_action">Abbonati</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/anno, annulla in qualsiasi momento</string>
-    <string name="upgrade_screen_iap_action">Acquista Pro</string>
+    <string name="upgrade_screen_iap_action">Acquisto una tantum</string>
     <string name="upgrade_screen_iap_action_hint">Acquisto una tantum di %s</string>
     <string name="upgrade_screen_restore_purchase_action">Ripristina acquisto</string>
     <string name="upgrade_screen_restore_purchase_message">Nessun acquisto trovato. Verifica di aver effettuato l’accesso con l’account Google corretto.</string>
+    <string name="upgrade_screen_restore_banner_title">Hai già acquistato Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Sembra che tu abbia già acquistato Pro su questo dispositivo. Ripristina il tuo acquisto per sbloccarlo di nuovo.</string>
     <string name="upgrade_screen_options_description">Gli abbonamenti si rinnovano automaticamente. Puoi annullare in qualsiasi momento.</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Sei Pro — grazie!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Il tuo acquisto unico di Pro sblocca ogni funzione Pro, per sempre.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Il tuo abbonamento sblocca ogni funzione Pro.</string>
+    <string name="upgrade_screen_owned_sub_title">Il tuo abbonamento</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Il tuo abbonamento è attivo e si rinnova automaticamente.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Il tuo abbonamento è impostato per scadere e non si rinnoverà. Manterrai Pro fino al termine.</string>
+    <string name="upgrade_screen_owned_both_warning">Possiedi l’acquisto unico di Pro e hai anche un abbonamento attivo. Non hai bisogno di entrambi — annulla l’abbonamento in Google Play per evitare ulteriori addebiti.</string>
+    <string name="upgrade_screen_manage_subscription_action">Gestisci abbonamento</string>
+    <string name="upgrade_screen_owned_iap_title">Pro a vita</string>
+    <string name="upgrade_screen_owned_iap_body">Possiedi l’acquisto unico di Pro. Nessun abbonamento, nessun rinnovo.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Passa a un acquisto unico</string>
+    <string name="upgrade_screen_switch_purchase_note">Il tuo abbonamento non si rinnoverà, quindi ora puoi passare all’acquisto unico permanente di Pro.</string>
+    <string name="upgrade_screen_switch_locked_note">Per passare all’acquisto unico, annulla prima il tuo abbonamento in Google Play. Questa offerta si sblocca una volta impostato per non rinnovarsi.</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play controlla solo l’account con cui sei attualmente connesso. L’acquisto unico è separato dal tuo abbonamento.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Il tuo abbonamento è ancora attivo e si sta rinnovando. Annullalo prima in Google Play.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Impossibile verificare il tuo abbonamento con Google Play. Riprova.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">Conferma in corso</string>
+    <string name="upgrade_screen_grace_body">In attesa che Google Play confermi di nuovo il tuo acquisto Pro. Di solito si risolve da solo.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Non riusciamo ancora a riconfermare il tuo acquisto Pro con Google Play. Se continua a succedere, prova a ripristinare l’acquisto o contatta il supporto.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">Lo stato sembra sbagliato?</string>
+    <string name="upgrade_screen_restore_status_body">Se hai acquistato Pro ma non viene visualizzato, esegui un controllo in tempo reale su Google Play.</string>
+    <string name="upgrade_screen_restore_success_message">Acquisto ripristinato.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Assicurati di essere connesso con l’account Google che hai utilizzato per l’acquisto. È appena stato eseguito un controllo in tempo reale su Google Play.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Opzioni di aggiornamento</string>
+    <string name="upgrade_screen_offers_body">Stesse funzioni, solo diversi modelli di prezzo.</string>
+    <string name="upgrade_screen_offers_or">oppure</string>
+    <string name="upgrade_screen_subscription_offer_title">Abbonamento annuale</string>
+    <string name="upgrade_screen_subscription_offer_body">Si rinnova ogni anno dopo il periodo di prova gratuito. Annulla in qualsiasi momento in Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Si rinnova ogni anno. Annulla in qualsiasi momento su Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Acquista una volta</string>
+    <string name="upgrade_screen_iap_offer_body">Un pagamento, senza rinnovi.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">Abbonamento ancora attivo</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Google Play è stato appena controllato, ma non è stato possibile confermare nessun acquisto Pro per l’account utilizzato da questa app.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Account multipli possono confondere Google Play. Installare l’app dal sito di Google Play la costringe ad associarsi a un account specifico.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">La sincronizzazione di Google Play può richiedere un po’. Prova a riavviare, svuota la cache di Google Play Store o aspetta semplicemente.</string>
+    <string name="upgrade_screen_restore_contact_hint">Ancora bloccato? Contatta il supporto dall’email che ha effettuato l’acquisto e includi il tuo numero d’ordine di Google Play.</string>
 </resources>

--- a/app/src/gplay/res/values-iw/strings.xml
+++ b/app/src/gplay/res/values-iw/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">שירותי Google Play אינם זמינים.</string>
     <string name="upgrades_no_purchases_found_check_account">לא נמצאו רכישות. האם את/ה משתמש/ת בחשבון הנכון?</string>
+    <string name="upgrades_gplay_already_owned_title">כבר נקנה</string>
+    <string name="upgrades_gplay_already_owned_error">גוגל פליי דיווח שכבר קנית את השדרוג הזה, אך לא ניתן היה להשחזרו. בדוק שאתה מחובר עם חשבון גוגל שנשמש לרכישה המקורית, ולאחר מכן נסה \"השחזר רכישה\".</string>
     <string name="upgrade_screen_preamble">Permission Pilot היא בללי פרסומות ומכבדת את פרטיותך. שדרוג תומך בפיתוח המשך.</string>
+    <string name="upgrade_screen_offers_unavailable_title">גוגל פליי לא זמין</string>
+    <string name="upgrade_screen_offers_unavailable_message">לא ניתן היה לטעון את אפשרויות הרכישה. גוגל פליי עשוי להיות לא זמין זמנית — בדוק את החיבור שלך ונסה שוב.</string>
     <string name="upgrade_screen_subscription_trial_action">התחל ניסיון חינם</string>
     <string name="upgrade_screen_subscription_action">הירשם כמנוי</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/שנה, בטל בכל עת</string>
-    <string name="upgrade_screen_iap_action">קנה פרו</string>
+    <string name="upgrade_screen_iap_action">רכישה חד-פעמית</string>
     <string name="upgrade_screen_iap_action_hint">רכישה חד פעמית של %s</string>
     <string name="upgrade_screen_restore_purchase_action">שחזור רכישה</string>
     <string name="upgrade_screen_restore_purchase_message">לא נמצאו רכישות. ודא שאתה מחובר באמצעות חשבון גוגל הנכון.</string>
+    <string name="upgrade_screen_restore_banner_title">כבר קנית Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">נראה שהשדרגת ל-Pro בעבר בהתקן זה. השחזר את הרכישה שלך כדי לפתוח אותה שוב.</string>
     <string name="upgrade_screen_options_description">מנויים מתחדשים אוטומטית. ניתן לבטל בכל עת.</string>
     <string name="upgrade_title_suffix">פרו</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">אתה Pro — תודה!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">הרכישה החד-פעמית של Pro שלך פותחת את כל תכונות Pro, לנצח.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">המנוי שלך פותח את כל תכונות Pro.</string>
+    <string name="upgrade_screen_owned_sub_title">המנוי שלך</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">המנוי שלך פעיל ומתחדש באופן אוטומטי.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">המנוי שלך מוגדר לפוג ולא יתחדש. תוכל להשתמש ב-Pro עד שיסתיים.</string>
+    <string name="upgrade_screen_owned_both_warning">יש לך שדרוג Pro חד-פעמי ויש לך גם מנוי פעיל. אתה לא צריך את שניהם — בטל את המנוי בגוגל פליי כדי להימנע מחיובים נוספים.</string>
+    <string name="upgrade_screen_manage_subscription_action">ניהול המנוי</string>
+    <string name="upgrade_screen_owned_iap_title">Pro לכל החיים</string>
+    <string name="upgrade_screen_owned_iap_body">יש לך שדרוג Pro חד-פעמי. אין מנוי, אין התחדשויות.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">עבור לרכישה חד-פעמית</string>
+    <string name="upgrade_screen_switch_purchase_note">המנוי שלך לא יתחדש, כך שתוכל לעבור לרכישה קבועה של Pro עכשיו.</string>
+    <string name="upgrade_screen_switch_locked_note">כדי לעבור לרכישה חד-פעמית, ראשית בטל את המנוי שלך בגוגל פליי. ההצעה הזו נפתחת ברגע שהוגדרה לא להתחדש.</string>
+    <string name="upgrade_screen_limitation_disclosure">גוגל פליי בודקת רק את החשבון שאתה כרגע מחובר אליו. הרכישה החד-פעמית נפרדת מהמנוי שלך.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">המנוי שלך עדיין פעיל ומתחדש. בטל אותו בגוגל פליי קודם.</string>
+    <string name="upgrade_screen_sub_check_failed_message">לא הצלחנו לאמת את המנוי שלך עם גוגל פליי. אנא נסה שוב.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">מאשרים את הרכישה שלך</string>
+    <string name="upgrade_screen_grace_body">ממתינים לאישור חוזר מגוגל פליי לרכישת ה-Pro שלך. זה בדרך כלל נפתר מעצמו.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">עדיין לא הצלחנו לאשר מחדש את רכישת ה-Pro שלך עם גוגל פליי. אם זה ממשיך לקרות, נסה לשחזר את הרכישה שלך או פנה לתמיכה.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">הסטטוס נראה לא נכון?</string>
+    <string name="upgrade_screen_restore_status_body">אם קנית את Pro אבל זה לא מופיע, הפעל בדיקה חיה מול גוגל פליי.</string>
+    <string name="upgrade_screen_restore_success_message">הרכישה שוחזרה.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">וודא שאתה מחובר בחשבון הגוגל שבו השתמשת לרכישה. בדיקה חיה מול גוגל פליי זה עתה בוצעה.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">אפשרויות שדרוג</string>
+    <string name="upgrade_screen_offers_body">אותן תכונות, רק דגמי תמחור שונים.</string>
+    <string name="upgrade_screen_offers_or">או</string>
+    <string name="upgrade_screen_subscription_offer_title">מנוי שנתי</string>
+    <string name="upgrade_screen_subscription_offer_body">מתחדש כל שנה לאחר הניסיון החינם. בטל בכל עת בגוגל פליי.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">מתחדש כל שנה. בטל בכל עת בגוגל פליי.</string>
+    <string name="upgrade_screen_iap_offer_title">קנה פעם אחת</string>
+    <string name="upgrade_screen_iap_offer_body">תשלום אחד, ללא התחדשויות.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">המנוי עדיין פעיל</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">בדקנו את גוגל פליי, אך לא הצלחנו לאשר רכישת Pro עבור החשבון המשמש את האפליקציה הזו.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">מספר חשבונות יכול לגרום לבעיות בגוגל פליי. התקנת האפליקציה דרך אתר גוגל פליי מחייבת אותה להשתייך לחשבון מסוים.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">סנכרון גוגל פליי יכול לקחת זמן. נסה להפעיל מחדש, לנקות את המטמון של חנות גוגל פליי, או פשוט להמתין.</string>
+    <string name="upgrade_screen_restore_contact_hint">עדיין תקוע? צור קשר עם התמיכה מהכתובת דוא\"ל שבה בוצעה הרכישה וכלול את מספר ההזמנה של גוגל פליי שלך.</string>
 </resources>

--- a/app/src/gplay/res/values-ja/strings.xml
+++ b/app/src/gplay/res/values-ja/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play サービスを利用できません。</string>
     <string name="upgrades_no_purchases_found_check_account">購入履歴が見つかりません。正しいアカウントを使用していますか？</string>
+    <string name="upgrades_gplay_already_owned_title">既に購入済み</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play ではこのアップグレードを所有していると報告されていますが、復元できませんでした。元の購入に使用した Google アカウントでサインインしていることを確認してから、「購入を復元」をお試しください。</string>
     <string name="upgrade_screen_preamble">Permission Pilotは広告なしでプライバシーを尊重しています。アップグレードは継続的な開発をサポートします。</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play は利用できません</string>
+    <string name="upgrade_screen_offers_unavailable_message">購入オプションを読み込めませんでした。Google Play が一時的に利用できない可能性があります。接続を確認してもう一度お試しください。</string>
     <string name="upgrade_screen_subscription_trial_action">試用を開始する</string>
     <string name="upgrade_screen_subscription_action">登録</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/年、いつでもキャンセルできます</string>
-    <string name="upgrade_screen_iap_action">Proを購入</string>
+    <string name="upgrade_screen_iap_action">1 回限りの購入</string>
     <string name="upgrade_screen_iap_action_hint">%sの一回購入</string>
     <string name="upgrade_screen_restore_purchase_action">購入を復元</string>
     <string name="upgrade_screen_restore_purchase_message">購入履歴が見つかりません。正しいGoogleアカウントでサインインしているか確認してください。</string>
+    <string name="upgrade_screen_restore_banner_title">Pro をすでに購入しましたか？</string>
+    <string name="upgrade_screen_restore_banner_body">以前このデバイスで Pro にアップグレードしたようです。購入を復元して Pro をもう一度ロック解除してください。</string>
     <string name="upgrade_screen_options_description">サブスクリプションは自動更新されます。いつでもキャンセルできます。</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Pro のご利用ありがとうございます！</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Pro のワンタイム購入により、すべての Pro 機能が永久にロック解除されます。</string>
+    <string name="upgrade_screen_owned_hero_sub_body">ご契約により、すべての Pro 機能がロック解除されます。</string>
+    <string name="upgrade_screen_owned_sub_title">ご契約</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">ご契約は有効で、自動更新されます。</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">ご契約は更新しないように設定されており、終了予定です。Pro は終了までご利用いただけます。</string>
+    <string name="upgrade_screen_owned_both_warning">一度限りの Pro アップグレードとアクティブなサブスクリプションの両方をお持ちです。両方は必要ありません。さらなる料金を避けるため、Google Play でご契約をキャンセルしてください。</string>
+    <string name="upgrade_screen_manage_subscription_action">ご契約を管理</string>
+    <string name="upgrade_screen_owned_iap_title">生涯 Pro</string>
+    <string name="upgrade_screen_owned_iap_body">一度限りの Pro アップグレードをお持ちです。サブスクリプションはなく、更新もありません。</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">ワンタイム購入に切り替える</string>
+    <string name="upgrade_screen_switch_purchase_note">ご契約は更新されないため、今すぐ永続的なワンタイム Pro 購入に切り替えることができます。</string>
+    <string name="upgrade_screen_switch_locked_note">ワンタイム購入に切り替えるには、まず Google Play でご契約をキャンセルしてください。このオファーは、更新しないように設定されるとロック解除されます。</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play は、現在サインインしているアカウントのみをチェックします。一度限りの購入はサブスクリプションとは別です。</string>
+    <string name="upgrade_screen_sub_still_renewing_message">ご契約はまだ有効で更新されています。まず Google Play でキャンセルしてください。</string>
+    <string name="upgrade_screen_sub_check_failed_message">Google Play でご契約を確認できませんでした。もう一度お試しください。</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">購入を確認中</string>
+    <string name="upgrade_screen_grace_body">Google Play が Pro 購入を再確認するのを待っています。これは通常自動的に解決します。</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Google Play で Pro 購入を再確認できません。この問題が続く場合は、購入を復元するか、サポートにお問い合わせください。</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">ステータスが間違っていますか？</string>
+    <string name="upgrade_screen_restore_status_body">Pro を購入しているのに表示されない場合は、Google Play に対してライブチェックを実行してください。</string>
+    <string name="upgrade_screen_restore_success_message">購入が復元されました。</string>
+    <string name="upgrade_screen_restore_webinstall_hint">購入に使用した Google アカウントでサインインしていることを確認してください。Google Play に対するライブチェックが実行されました。</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">アップグレードオプション</string>
+    <string name="upgrade_screen_offers_body">同じ機能ですが、価格設定モデルが異なります。</string>
+    <string name="upgrade_screen_offers_or">または</string>
+    <string name="upgrade_screen_subscription_offer_title">年間サブスクリプション</string>
+    <string name="upgrade_screen_subscription_offer_body">無料体験後、毎年更新されます。Google Play でいつでもキャンセルできます。</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">毎年更新されます。Google Play でいつでもキャンセルできます。</string>
+    <string name="upgrade_screen_iap_offer_title">1 回購入</string>
+    <string name="upgrade_screen_iap_offer_body">1 回の支払い、更新なし。</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">サブスクリプションはまだ有効です</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Google Play を確認しましたが、このアプリが使用しているアカウントで Pro 購入を確認できませんでした。</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">複数のアカウントは Google Play を混乱させる可能性があります。Google Play ウェブサイトからアプリをインストールすれば、特定のアカウントに関連付けられます。</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Google Play の同期には時間がかかる場合があります。再起動するか、Google Play ストアのキャッシュをクリアするか、しばらく待ってみてください。</string>
+    <string name="upgrade_screen_restore_contact_hint">まだお困りですか？購入に使用したメールアドレスからサポートに連絡し、Google Play の注文番号を含めてください。</string>
 </resources>

--- a/app/src/gplay/res/values-ko/strings.xml
+++ b/app/src/gplay/res/values-ko/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play 서비스를 사용할 수 없습니다.</string>
     <string name="upgrades_no_purchases_found_check_account">구매 내역을 찾을 수 없습니다. 올바른 계정을 사용하고 있습니까?</string>
+    <string name="upgrades_gplay_already_owned_title">이미 구매됨</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play에서 이미 이 업그레이드를 소유하고 있다고 표시되지만 복구할 수 없습니다. 원래 구매에 사용한 Google 계정으로 로그인했는지 확인한 후 \'구매 복구\'를 시도하세요.</string>
     <string name="upgrade_screen_preamble">Permission Pilot은 광고가 없고 개인 정보를 존중합니다. 업그레이드는 지속적인 개발을 지원합니다.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play를 사용할 수 없음</string>
+    <string name="upgrade_screen_offers_unavailable_message">구매 옵션을 로드할 수 없습니다. Google Play가 일시적으로 사용 불가능할 수 있습니다. 연결을 확인하고 다시 시도하세요.</string>
     <string name="upgrade_screen_subscription_trial_action">무료 체험 시작</string>
     <string name="upgrade_screen_subscription_action">구독하기</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/년, 언제든 취소 가능</string>
-    <string name="upgrade_screen_iap_action">Pro 구매</string>
+    <string name="upgrade_screen_iap_action">영구적 구매</string>
     <string name="upgrade_screen_iap_action_hint">%s 일회성 구매</string>
     <string name="upgrade_screen_restore_purchase_action">구매 복원</string>
     <string name="upgrade_screen_restore_purchase_message">구매 내역이 없습니다. 올바른 Google 계정으로 로그인되어 있는지 확인하세요.</string>
+    <string name="upgrade_screen_restore_banner_title">이미 Pro를 구매했나요?</string>
+    <string name="upgrade_screen_restore_banner_body">이 기기에서 이전에 Pro로 업그레이드했던 것 같습니다. 구매를 복구하여 Pro를 다시 사용하세요.</string>
     <string name="upgrade_screen_options_description">구독은 자동으로 갱신됩니다. 언제든지 취소할 수 있습니다.</string>
     <string name="upgrade_title_suffix">프로</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Pro 이용 중이시네요 — 감사합니다!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">일회성 Pro 구매로 모든 Pro 기능을 영원히 사용할 수 있습니다.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">구독하면 모든 Pro 기능을 사용할 수 있습니다.</string>
+    <string name="upgrade_screen_owned_sub_title">구독</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">구독이 활성화되어 있으며 자동으로 갱신됩니다.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">구독이 만료되도록 설정되어 있으며 갱신되지 않습니다. 만료될 때까지 Pro를 계속 사용할 수 있습니다.</string>
+    <string name="upgrade_screen_owned_both_warning">일회성 Pro 업그레이드를 소유했으면서 동시에 활성 구독도 있습니다. 둘 다 필요하지 않습니다 — 추가 요금을 피하려면 Google Play에서 구독을 취소하세요.</string>
+    <string name="upgrade_screen_manage_subscription_action">구독 관리</string>
+    <string name="upgrade_screen_owned_iap_title">평생 Pro</string>
+    <string name="upgrade_screen_owned_iap_body">일회성 Pro 업그레이드를 소유했습니다. 구독 없음, 갱신 없음.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">일회성 구매로 전환</string>
+    <string name="upgrade_screen_switch_purchase_note">구독이 갱신되지 않으므로 이제 영구적인 일회성 Pro 구매로 이동할 수 있습니다.</string>
+    <string name="upgrade_screen_switch_locked_note">일회 구매로 전환하려면 먼저 Google Play에서 구독을 취소하세요. 자동 갱신하지 않도록 설정하면 이 오퍼가 활성화됩니다.</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play는 현재 로그인한 계정만 확인합니다. 일회 구매는 구독과 별개입니다.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">구독이 아직 활성 상태이며 갱신 중입니다. 먼저 Google Play에서 취소하세요.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Google Play에서 구독을 확인할 수 없습니다. 다시 시도하세요.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">구매 확인 중</string>
+    <string name="upgrade_screen_grace_body">Google Play에서 Pro 구매를 다시 확인할 때까지 기다리는 중입니다. 일반적으로 자동으로 해결됩니다.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Google Play에서 Pro 구매를 여전히 다시 확인할 수 없습니다. 계속 발생하면 구매 복구를 시도하거나 지원팀에 문의하세요.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">상태가 잘못된 것 같나요?</string>
+    <string name="upgrade_screen_restore_status_body">Pro를 구매했지만 표시되지 않는다면 Google Play에 대해 실시간 확인을 실행하세요.</string>
+    <string name="upgrade_screen_restore_success_message">구매가 복구되었습니다.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">구매에 사용한 Google 계정으로 로그인했는지 확인하세요. Google Play에 대한 실시간 확인이 방금 완료되었습니다.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">업그레이드 옵션</string>
+    <string name="upgrade_screen_offers_body">동일한 기능, 다른 가격 모델만 있습니다.</string>
+    <string name="upgrade_screen_offers_or">또는</string>
+    <string name="upgrade_screen_subscription_offer_title">연간 구독</string>
+    <string name="upgrade_screen_subscription_offer_body">무료 평가판 후 매년 갱신됩니다. Google Play에서 언제든지 취소할 수 있습니다.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">매년 갱신됩니다. Google Play에서 언제든지 취소할 수 있습니다.</string>
+    <string name="upgrade_screen_iap_offer_title">한 번 구매</string>
+    <string name="upgrade_screen_iap_offer_body">일회 결제, 갱신 없음.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">구독이 여전히 활성 상태입니다</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Google Play를 방금 확인했지만, 이 앱에서 사용 중인 계정의 Pro 구매를 확인할 수 없습니다.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">여러 계정이 Google Play를 혼동시킬 수 있습니다. Google Play 웹사이트를 통해 앱을 설치하면 특정 계정과 연결됩니다.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Google Play 동기화는 시간이 걸릴 수 있습니다. 기기를 다시 시작하거나 Google Play 스토어 캐시를 지우거나 잠시 기다려보세요.</string>
+    <string name="upgrade_screen_restore_contact_hint">여전히 해결되지 않나요? 구매한 이메일로 지원팀에 문의하고 Google Play 주문 번호를 함께 알려주세요.</string>
 </resources>

--- a/app/src/gplay/res/values-ku-rTR/strings.xml
+++ b/app/src/gplay/res/values-ku-rTR/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Xizmetên Google Play berdest nînin.</string>
     <string name="upgrades_no_purchases_found_check_account">Kirîn nehate dîtin. Ma tu hesabê rast bi kar tînî?</string>
+    <string name="upgrades_gplay_already_owned_title">Jixwe Kirî</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play raportê dike ku tu vê bulaşê jixwe di xwe de heye, lê nikare were gerandin. Kontrol bike ku tu bê nava ketî bi hesabê Google ya ku ji bo kirina yekem hatiye bikaranîn, û paşê \"Beşdarkirina Venîştin\" biceribîne.</string>
     <string name="upgrade_screen_preamble">Permission Pilot بێ رێکلامەیە و نھێنیتکەت پھابوو دەکات. بەرزترکردن پشتگیریکردنی گەشەپێکردنی دەوامەیە.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play ne berdest e</string>
+    <string name="upgrade_screen_offers_unavailable_message">Vebijarkên beşdarkirinê nikare werin barkirîn. Google Play dibe ku demek ne berdest be — peywendiya xwe kontrol bike û dî carî biceribîne.</string>
     <string name="upgrade_screen_subscription_trial_action">دەستپێککردنی تەستی بەژیوانی</string>
     <string name="upgrade_screen_subscription_action">بوونهەڵبەست</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/sal, hûndirim bê gerd</string>
-    <string name="upgrade_screen_iap_action">كڕینی Pro</string>
+    <string name="upgrade_screen_iap_action">Beşdarkirina Yek-Carek</string>
     <string name="upgrade_screen_iap_action_hint">کڕینی یەکجارەی %s</string>
     <string name="upgrade_screen_restore_purchase_action">گەڕاندنەوەکردنی کڕین</string>
     <string name="upgrade_screen_restore_purchase_message">ھیچ کڕینیک نەدێت. چەکبکەرە كە بە ھەسابی ئیگووڵی گوگڵ دەست کەوتیی.</string>
+    <string name="upgrade_screen_restore_banner_title">Jixwe Pro kirî?</string>
+    <string name="upgrade_screen_restore_banner_body">Xuya dike ku tu berê li vî amûrî veguhastî Pro. Beşdarkirina xwe venîştin da ku cara dî vê vekin.</string>
     <string name="upgrade_screen_options_description">بوونهەڵبەستەکان بە خۆدیکەوە نوێكردرەوەن. دەتوانیت ھەر کاتیک لاببکەیت.</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Tu Pro yî — spas!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Kirîna Pro-ya yek-car hemû taybetmendiyên Pro derxîne, sedemzî.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Aboneya te hemû taybetmendiyên Pro derxîne.</string>
+    <string name="upgrade_screen_owned_sub_title">Aboneya te</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Aboneya te çalak e û bi otomatîk nû dibe.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Aboneya te sazkirî ye da ku qede bibe û nû nabibe. Tu Pro-yî heta qedandîna wê bihûnîne.</string>
+    <string name="upgrade_screen_owned_both_warning">Tu pêbazirandina Pro-ya yek-car heye û tu jî aboneyeke çalak heye. Tu hewce nikare her du — aboneya di Google Play de betal bike da ku xercên zêde nabe.</string>
+    <string name="upgrade_screen_manage_subscription_action">Aboneya birêve bike</string>
+    <string name="upgrade_screen_owned_iap_title">Pro-ya sedemzî</string>
+    <string name="upgrade_screen_owned_iap_body">Tu pêbazirandina Pro-ya yek-car heye. Aboneya tune, nû kirin tune.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Veguherîn bo kirîna yek-car</string>
+    <string name="upgrade_screen_switch_purchase_note">Peymanê we nabe nûkirî, lewra we niha dikarin biçin beşdareya Pro ya demdemî ya yekcarî.</string>
+    <string name="upgrade_screen_switch_locked_note">Ji bo ku biçin beşdareya yekcarî, pêşî peymanê we di Google Play da betal bikin. Ev pêşkêş açilî dibe dema peymanê we nabe nûkirî.</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play tenê hesaba we ya niha kontrol dike. Beşdareya yekcarî ji peymanê we cuda ye.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Peymanê we hîn jî çalak e û nabe nûkirî. Pêşî ew di Google Play da betal bikin.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Peymanê we bi Google Play piştrast nekirî. Ji kerema xwe dîsa hewl bide.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">Beşdareya we tê piştraskirin</string>
+    <string name="upgrade_screen_grace_body">Em li bendî ne ku Google Play beşdareya Pro ya we dîsa piştrast bike. Ev bi awayekî xweser çareserî dibe.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Em hîn nikarin beşdareya Pro ya we bi Google Play dîsa piştrast bikin. Ger ev dewam bike, beşdareya we vegerînin an jî ji piştgiriyê alîkarî xwastin.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">Rewş xelet xuya dike?</string>
+    <string name="upgrade_screen_restore_status_body">Ger we Pro kiriye lê nayê nîşandan, li Google Play kontrollê zindî bike.</string>
+    <string name="upgrade_screen_restore_success_message">Kirrê vegerand.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Ewle bin ku tu bi hesabê Google-ê ya ji bo kirrê bikarî anî tê vekirin. Kontrolek zindî li dijiî Google Play tenê hat kirin.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Vebijarkên nûvekirinê</string>
+    <string name="upgrade_screen_offers_body">Taybetmendiyên wekhev, tenê modela berçavkandinê cuda ye.</string>
+    <string name="upgrade_screen_offers_or">an</string>
+    <string name="upgrade_screen_subscription_offer_title">Aboneya salî</string>
+    <string name="upgrade_screen_subscription_offer_body">Piştî demê bê bayê salî nûkirin dike. Di her demî de di Google Play de betal bike.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Salî nûkirin dike. Di her demî de di Google Play de betal bike.</string>
+    <string name="upgrade_screen_iap_offer_title">Carek bikire</string>
+    <string name="upgrade_screen_iap_offer_body">Yek peymê, nûkirin tune.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">Aboneya Hê Aktîf e</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Google Play tenê nû hat kontrolkirin, lê kirîya Pro-yê ya ji hesaba ku vê sepê bikar tîne nehat pejirandin.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Gelek hesab dikarin Google Play-ê têkev bikin. Stkirina sepê ji rûpela malê ya Google Play bê bicih dike ku ew bi hesabeke diyarkirî re têkilî bibe.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Hemdamîya Google Play dikare demek bigire. Biceribînin ku sîstema nû bikiriş, dîskerê Google Play Store paqij bikiriş, an jî bê derewî sekinê.</string>
+    <string name="upgrade_screen_restore_contact_hint">Hîn jî tê êşkirtin? Piştiranê ji e-nameyê ya ku kirînê kiribe bikişîne û jimara fermangeha Google Play-ê ya te cih bikiriş.</string>
 </resources>

--- a/app/src/gplay/res/values-nb/strings.xml
+++ b/app/src/gplay/res/values-nb/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play-tjenester er ikke tilgjengelige.</string>
     <string name="upgrades_no_purchases_found_check_account">Ingen kjøp funnet. Bruker du riktig konto?</string>
+    <string name="upgrades_gplay_already_owned_title">Allerede kjøpt</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play rapporterer at du allerede eier denne oppgraderingen, men den kunne ikke gjenopprettes. Sjekk at du er logget inn med Google-kontoen som ble brukt for det opprinnelige kjøpet, og prøv deretter \"Gjenopprett kjøp\".</string>
     <string name="upgrade_screen_preamble">Permission Pilot er uten annonser og respekterer ditt personvern. Oppgradering støtter fortsatt utvikling.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play er utilgjengelig</string>
+    <string name="upgrade_screen_offers_unavailable_message">Kunne ikke laste kjøpsalternativene. Google Play kan være midlertidig utilgjengelig – kontroller tilkoblingen din og prøv igjen.</string>
     <string name="upgrade_screen_subscription_trial_action">Start gratis prøveperiode</string>
     <string name="upgrade_screen_subscription_action">Abonner</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/år, avbryt når som helst</string>
-    <string name="upgrade_screen_iap_action">Kjøp Pro</string>
+    <string name="upgrade_screen_iap_action">Engangskjøp</string>
     <string name="upgrade_screen_iap_action_hint">Engangsinnkjøp av %s</string>
     <string name="upgrade_screen_restore_purchase_action">Gjenopprett kjøp</string>
     <string name="upgrade_screen_restore_purchase_message">Ingen kjøp funnet. Sjekk at du er logget inn med riktig Google-konto.</string>
+    <string name="upgrade_screen_restore_banner_title">Allerede kjøpt Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Det ser ut til at du oppgraderte til Pro på denne enheten før. Gjenopprett kjøpet ditt for å låse det opp igjen.</string>
     <string name="upgrade_screen_options_description">Abonnementer fornyes automatisk. Du kan avbryte når som helst.</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Du er Pro – takk!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Ditt engangs Pro-kjøp låser opp hver Pro-funksjon, for alltid.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Abonnementet ditt låser opp alle Pro-funksjoner.</string>
+    <string name="upgrade_screen_owned_sub_title">Abonnementet ditt</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Abonnementet ditt er aktivt og fornyes automatisk.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Abonnementet ditt er satt til å utløpe og vil ikke fornyes. Du beholder Pro til det utløper.</string>
+    <string name="upgrade_screen_owned_both_warning">Du eier engangs Pro-oppgraderingen og har også et aktivt abonnement. Du trenger ikke begge deler – avbryt abonnementet i Google Play for å unngå ytterligere kostnader.</string>
+    <string name="upgrade_screen_manage_subscription_action">Administrer abonnement</string>
+    <string name="upgrade_screen_owned_iap_title">Livstids Pro</string>
+    <string name="upgrade_screen_owned_iap_body">Du eier engangs Pro-oppgraderingen. Ingen abonnement, ingen fornyelser.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Bytt til engangskjøp</string>
+    <string name="upgrade_screen_switch_purchase_note">Abonnementet ditt vil ikke fornyes, så du kan gå over til det permanente engangs Pro-kjøpet nå.</string>
+    <string name="upgrade_screen_switch_locked_note">For å bytte til engangskjøp, må du først avbryte abonnementet ditt i Google Play. Dette tilbudet låses opp når det er satt til ikke å fornyes.</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play sjekker bare kontoen du er logget inn på. Engangskjøpet er atskilt fra abonnementet ditt.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Abonnementet ditt er fortsatt aktivt og fornyes. Avbryt det i Google Play først.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Kunne ikke bekrefte abonnementet ditt med Google Play. Vennligst prøv igjen.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">Bekrefter kjøpet ditt</string>
+    <string name="upgrade_screen_grace_body">Venter på at Google Play skal bekrefte Pro-kjøpet ditt på nytt. Dette løser seg vanligvis av seg selv.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Vi kan fortsatt ikke bekrefte Pro-kjøpet ditt på nytt med Google Play. Hvis dette fortsetter å skje, prøv å gjenopprette kjøpet ditt eller kontakt support.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">Ser statusen feil ut?</string>
+    <string name="upgrade_screen_restore_status_body">Hvis du har kjøpt Pro, men det vises ikke, kjør en live-kontroll mot Google Play.</string>
+    <string name="upgrade_screen_restore_success_message">Kjøp gjenopprettet.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Kontroller at du er logget inn med Google-kontoen du brukte til å kjøpe. En direktekontroll mot Google Play ble nettopp kjørt.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Oppgraderingsalternativer</string>
+    <string name="upgrade_screen_offers_body">De samme funksjonene, bare ulike prismodeller.</string>
+    <string name="upgrade_screen_offers_or">eller</string>
+    <string name="upgrade_screen_subscription_offer_title">Årlig abonnement</string>
+    <string name="upgrade_screen_subscription_offer_body">Fornyes årlig etter gratis prøveperiode. Avbryt når som helst i Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Fornyes årlig. Avbryt når som helst i Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Kjøp en gang</string>
+    <string name="upgrade_screen_iap_offer_body">En betaling, ingen fornyelser.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">Abonnement er fortsatt aktivt</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Google Play ble nettopp sjekket, men ingen Pro-kjøp kunne bekreftes for kontoen som brukes for denne appen.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Flere kontoer kan forvirre Google Play. Installering av appen gjennom Google Play-nettstedet tvinger appen til å knyttes til en bestemt konto.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Google Play-synkronisering kan ta en stund. Prøv å starte på nytt, tøm Google Play Store-cachen, eller bare vent.</string>
+    <string name="upgrade_screen_restore_contact_hint">Fortsatt fast? Kontakt kundestøtte fra e-posten som gjorde kjøpet og ta med ditt Google Play-ordrenummer.</string>
 </resources>

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play-services zijn niet beschikbaar.</string>
     <string name="upgrades_no_purchases_found_check_account">Geen aankopen gevonden. Gebruik je het juiste account?</string>
+    <string name="upgrades_gplay_already_owned_title">Reeds gekocht</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play meldt dat je deze upgrade al bezit, maar deze kon niet worden hersteld. Controleer of je bent aangemeld met het Google-account dat voor de oorspronkelijke aankoop werd gebruikt, en probeer vervolgens \'Aankoop herstellen\'.</string>
     <string name="upgrade_screen_preamble">Permission Pilot is advertentievrij en respecteert je privacy. Upgraden ondersteunt verdere ontwikkeling.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play is niet beschikbaar</string>
+    <string name="upgrade_screen_offers_unavailable_message">Kon de aankoopopties niet laden. Google Play is mogelijk tijdelijk niet beschikbaar — controleer je verbinding en probeer het opnieuw.</string>
     <string name="upgrade_screen_subscription_trial_action">Start gratis proefperiode</string>
     <string name="upgrade_screen_subscription_action">Abonneren</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/jaar, annuleer op elk moment</string>
-    <string name="upgrade_screen_iap_action">Pro kopen</string>
+    <string name="upgrade_screen_iap_action">Eenmalige aankoop</string>
     <string name="upgrade_screen_iap_action_hint">Eenmalige aankoop van %s</string>
     <string name="upgrade_screen_restore_purchase_action">Herstel aankoop</string>
     <string name="upgrade_screen_restore_purchase_message">Geen aankopen gevonden. Controleer of je bent aangemeld met het juiste Google-account.</string>
+    <string name="upgrade_screen_restore_banner_title">Al Pro gekocht?</string>
+    <string name="upgrade_screen_restore_banner_body">Het lijkt erop dat je op dit apparaat eerder naar Pro bent geüpgraded. Herstel je aankoop om het opnieuw in te schakelen.</string>
     <string name="upgrade_screen_options_description">Abonnementen verlengen automatisch. Je kunt op elk moment opzeggen.</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Je bent Pro — dank je wel!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Je eenmalige Pro-aankoop ontgrendelt elk Pro-onderdeel voor altijd.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Je abonnement ontgrendelt elk Pro-onderdeel.</string>
+    <string name="upgrade_screen_owned_sub_title">Je abonnement</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Je abonnement is actief en vernieuwt zich automatisch.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Je abonnement verloopt binnenkort en wordt niet vernieuwd. Je behoudt Pro totdat het afloopt.</string>
+    <string name="upgrade_screen_owned_both_warning">Je bezit de eenmalige Pro-upgrade en hebt ook een actief abonnement. Je hebt niet beide nodig — annuleer het abonnement in Google Play om verdere kosten te voorkomen.</string>
+    <string name="upgrade_screen_manage_subscription_action">Abonnement beheren</string>
+    <string name="upgrade_screen_owned_iap_title">Pro voor altijd</string>
+    <string name="upgrade_screen_owned_iap_body">Je bezit de eenmalige Pro-upgrade. Geen abonnement, geen verlengingen.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Schakel over naar eenmalige aankoop</string>
+    <string name="upgrade_screen_switch_purchase_note">Je abonnement wordt niet vernieuwd, dus je kunt nu overstappen naar de permanente eenmalige Pro-aankoop.</string>
+    <string name="upgrade_screen_switch_locked_note">Om over te schakelen naar de eenmalige aankoop, annuleer je abonnement eerst in Google Play. Deze aanbieding wordt beschikbaar zodra het is ingesteld om niet te verlengen.</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play controleert alleen het account waarbij je momenteel bent aangemeld. De eenmalige aankoop is gescheiden van je abonnement.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Je abonnement is nog steeds actief en vernieuwt. Annuleer het eerst in Google Play.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Je abonnement kon niet met Google Play worden geverifieerd. Probeer het opnieuw.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">Je aankoop bevestigen</string>
+    <string name="upgrade_screen_grace_body">Wachten tot Google Play je Pro-aankoop opnieuw bevestigt. Dit lost meestal vanzelf op.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">We kunnen je Pro-aankoop nog steeds niet opnieuw bevestigen met Google Play. Als dit blijft gebeuren, probeer je aankoop te herstellen of neem contact op met ondersteuning.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">Ziet de status er fout uit?</string>
+    <string name="upgrade_screen_restore_status_body">Als je Pro hebt gekocht maar het wordt niet weergegeven, voer een live controle uit tegen Google Play.</string>
+    <string name="upgrade_screen_restore_success_message">Aankoop hersteld.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Zorg ervoor dat je bent aangemeld met het Google-account dat je voor de aankoop hebt gebruikt. Een live controle tegen Google Play is zojuist uitgevoerd.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Upgrade-opties</string>
+    <string name="upgrade_screen_offers_body">Dezelfde functies, alleen verschillende prijsmodellen.</string>
+    <string name="upgrade_screen_offers_or">of</string>
+    <string name="upgrade_screen_subscription_offer_title">Jaarabonnement</string>
+    <string name="upgrade_screen_subscription_offer_body">Wordt jaarlijks verlengd na de gratis proefperiode. Annuleer op elk moment in Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Wordt jaarlijks verlengd. Annuleer op elk moment in Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Eenmalig kopen</string>
+    <string name="upgrade_screen_iap_offer_body">Eenmalige betaling, geen verlengingen.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">Abonnement nog actief</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Google Play is zojuist gecontroleerd, maar kon geen Pro-aankoop bevestigen voor het account dat deze app gebruikt.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Meerdere accounts kunnen Google Play verwarren. Het installeren van de app via de Google Play-website zorgt ervoor dat deze aan een specifiek account wordt gekoppeld.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Google Play-synchronisatie kan even duren. Probeer opnieuw op te starten, de Google Play Store-cache te wissen of gewoon te wachten.</string>
+    <string name="upgrade_screen_restore_contact_hint">Nog steeds vast? Neem contact op met ondersteuning vanuit het e-mailadres waarmee je de aankoop hebt gedaan en voeg je Google Play-ordernummer toe.</string>
 </resources>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Usługi Google Play są niedostępne.</string>
     <string name="upgrades_no_purchases_found_check_account">Nie znaleziono zakupów. Czy używasz właściwego konta?</string>
+    <string name="upgrades_gplay_already_owned_title">Już zakupiono</string>
+    <string name="upgrades_gplay_already_owned_error">Sklep Google Play informuje, że posiadasz już tę aktualizację, ale nie można jej przywrócić. Sprawdź, czy jesteś zalogowany na koncie Google użytym do pierwotnego zakupu, a następnie spróbuj Przywróć zakup.</string>
     <string name="upgrade_screen_preamble">Pilot Uprawnień jest wolny od reklam i szanuje twoją prywatność. Aktualizacja wspiera dalszy rozwój.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Sklep Google Play jest niedostępny</string>
+    <string name="upgrade_screen_offers_unavailable_message">Nie udało się załadować opcji zakupu. Sklep Google Play może być tymczasowo niedostępny — sprawdź połączenie i spróbuj ponownie.</string>
     <string name="upgrade_screen_subscription_trial_action">Rozpocznij wersję próbną</string>
     <string name="upgrade_screen_subscription_action">Subskrybuj</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/rok, anuluj w dowolnym momencie</string>
-    <string name="upgrade_screen_iap_action">Kup Pro</string>
+    <string name="upgrade_screen_iap_action">Jednorazowy zakup</string>
     <string name="upgrade_screen_iap_action_hint">Jednorazowy zakup za %s</string>
     <string name="upgrade_screen_restore_purchase_action">Przywróć zakup</string>
     <string name="upgrade_screen_restore_purchase_message">Nie znaleziono zakupów. Upewnij się, że jesteś zalogowany na właściwym koncie Google.</string>
+    <string name="upgrade_screen_restore_banner_title">Już kupiłeś Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Wygląda na to, że na tym urządzeniu dokonałeś już wcześniej aktualizacji do wersji Pro. Przywróć zakup, aby ją ponownie odblokować.</string>
     <string name="upgrade_screen_options_description">Subskrypcje odnawiają się automatycznie. Możesz anulować w dowolnym momencie.</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Pilot Uprawnień Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Jesteś Pro - dziękuję!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Twój jednorazowy zakup Pro odblokowuje każdą funkcję Pro na zawsze.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Twoja subskrypcja odblokowuje każdą funkcję Pro.</string>
+    <string name="upgrade_screen_owned_sub_title">Twoja subskrypcja</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Twoja subskrypcja jest aktywna i odnawia się automatycznie.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Twoja subskrypcja wygasa i nie będzie odnawiana. Pro będzie przechowywany do czasu jej zakończenia.</string>
+    <string name="upgrade_screen_owned_both_warning">Posiadasz jednorazową aktualizację Pro, a także aktywną subskrypcję. Nie potrzebujesz obu opcji — anuluj subskrypcję w Sklepie Google Play, aby uniknąć dodatkowych opłat.</string>
+    <string name="upgrade_screen_manage_subscription_action">Zarządzaj subskrypcją</string>
+    <string name="upgrade_screen_owned_iap_title">Dożywotni Pro</string>
+    <string name="upgrade_screen_owned_iap_body">Jesteś właścicielem jednorazowej aktualizacji do wersji Pro. Bez subskrypcji i odnawiania.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Przełącz na jednorazowy zakup</string>
+    <string name="upgrade_screen_switch_purchase_note">Twoja subskrypcja nie zostanie odnowiona, więc możesz już teraz dokonać jednorazowego zakupu wersji Pro.</string>
+    <string name="upgrade_screen_switch_locked_note">Aby przejść na zakup jednorazowy, najpierw anuluj subskrypcję w Sklepie Google Play. Oferta zostanie odblokowana po ustawieniu opcji nie odnawiaj.</string>
+    <string name="upgrade_screen_limitation_disclosure">Sklep Google Play sprawdza tylko konto, na którym jesteś aktualnie zalogowany. Jednorazowy zakup jest niezależny od subskrypcji.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Twoja subskrypcja jest nadal aktywna i odnawia się. Anuluj ją najpierw w Sklepie Google Play.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Nie udało się zweryfikować twojej subskrypcji w Sklepie Google Play. Spróbuj ponownie.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">Potwierdzanie twojego zakupu</string>
+    <string name="upgrade_screen_grace_body">Oczekiwanie na ponowne potwierdzenie zakupu wersji Pro przez Sklepie Google Play. Zazwyczaj problem rozwiązuje się samoistnie.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Nadal nie możemy ponownie potwierdzić zakupu wersji Pro w Sklepie Google Play. Jeśli problem się powtarza, spróbuj przywrócić zakup lub skontaktuj się z pomocą techniczną.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">Status wygląda źle?</string>
+    <string name="upgrade_screen_restore_status_body">Jeśli kupiłeś wersję Pro, ale aplikacja nie jest wyświetlana, przeprowadź kontrolę na żywo w Sklepie Google Play.</string>
+    <string name="upgrade_screen_restore_success_message">Zakup przywrócony.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Upewnij się, że jesteś zalogowany na koncie Google, którego użyłeś do zakupu. Właśnie uruchomiono weryfikację na żywo w Sklepie Google Play.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Opcje aktualizacji</string>
+    <string name="upgrade_screen_offers_body">Te same funkcje, tylko różne modele cenowe.</string>
+    <string name="upgrade_screen_offers_or">lub</string>
+    <string name="upgrade_screen_subscription_offer_title">Roczna subskrypcja</string>
+    <string name="upgrade_screen_subscription_offer_body">Odnawiane co roku po zakończeniu bezpłatnego okresu próbnego. Anuluj w dowolnym momencie w Sklepie Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Odnawiane co roku. Anuluj w dowolnym momencie w Sklepie Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Kup raz</string>
+    <string name="upgrade_screen_iap_offer_body">Jedna płatność, bez odnawiania.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">Subskrypcja nadal aktywna</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Właśnie sprawdzono Sklep Google Play, ale nie udało się potwierdzić zakupu wersji Pro dla konta używanego z tą aplikacją.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Wiele kont może powodować problemy w Sklepie Google Play. Instalacja aplikacji za pośrednictwem witryny Sklepie Google Play wymusza powiązanie jej z konkretnym kontem.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Synchronizacja Sklepu Google Play może chwilę potrwać. Spróbuj uruchomić ponownie komputer, wyczyścić pamięć podręczną Sklepu Google Play lub po prostu poczekać.</string>
+    <string name="upgrade_screen_restore_contact_hint">Nadal masz problem? Skontaktuj się z pomocą techniczną z adresu e-mail, z którego dokonano zakupu, podając numer zamówienia Google Play.</string>
 </resources>

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Os serviços do Google Play não estão disponíveis.</string>
     <string name="upgrades_no_purchases_found_check_account">Nenhuma compra encontrada. Você está usando a conta correta?</string>
+    <string name="upgrades_gplay_already_owned_title">Já comprado</string>
+    <string name="upgrades_gplay_already_owned_error">O Google Play informa que você já possui esta atualização, mas ela não pôde ser restaurada. Verifique se você está conectado à conta do Google usada para a compra original e tente \"Restaurar compra\".</string>
     <string name="upgrade_screen_preamble">O Permission Pilot é livre de anúncios e respeita sua privacidade. Fazer um upgrade apoia o desenvolvimento contínuo.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play indisponível</string>
+    <string name="upgrade_screen_offers_unavailable_message">Não foi possível carregar as opções de compra. O Google Play pode estar temporariamente indisponível — verifique sua conexão e tente novamente.</string>
     <string name="upgrade_screen_subscription_trial_action">Iniciar teste gratuito</string>
     <string name="upgrade_screen_subscription_action">Se inscrever</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/ano, cancele a qualquer momento</string>
-    <string name="upgrade_screen_iap_action">Comprar Pro</string>
+    <string name="upgrade_screen_iap_action">Compra de uma só vez</string>
     <string name="upgrade_screen_iap_action_hint">Compra única de %s</string>
     <string name="upgrade_screen_restore_purchase_action">Restaurar a compra</string>
     <string name="upgrade_screen_restore_purchase_message">Nenhuma compra encontrada. Verifique se você está conectado com a conta Google correta.</string>
+    <string name="upgrade_screen_restore_banner_title">Já comprou Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Parece que você atualizou para Pro neste dispositivo antes. Restaure sua compra para desbloqueá-lo novamente.</string>
     <string name="upgrade_screen_options_description">As assinaturas são renovadas automaticamente. Você pode cancelar a qualquer momento.</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Você é Pro — obrigado!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Sua compra única do Pro desbloqueia todos os recursos Pro, para sempre.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Sua assinatura desbloqueia todos os recursos Pro.</string>
+    <string name="upgrade_screen_owned_sub_title">Sua assinatura</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Sua assinatura está ativa e renova automaticamente.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Sua assinatura está marcada para expirar e não será renovada. Você manterá o Pro até que expire.</string>
+    <string name="upgrade_screen_owned_both_warning">Você possui a atualização Pro única e também tem uma assinatura ativa. Você não precisa de ambas — cancele a assinatura no Google Play para evitar cobranças futuras.</string>
+    <string name="upgrade_screen_manage_subscription_action">Gerenciar assinatura</string>
+    <string name="upgrade_screen_owned_iap_title">Pro Vitalício</string>
+    <string name="upgrade_screen_owned_iap_body">Você possui a atualização Pro única. Sem assinatura, sem renovações.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Mudar para uma compra única</string>
+    <string name="upgrade_screen_switch_purchase_note">Sua assinatura não será renovada, então você pode mudar para a compra Pro única permanente agora.</string>
+    <string name="upgrade_screen_switch_locked_note">Para mudar para a compra única, primeiro cancele sua assinatura no Google Play. Esta oferta será desbloqueada quando estiver definida para não renovar.</string>
+    <string name="upgrade_screen_limitation_disclosure">O Google Play verifica apenas a conta com a qual você está conectado. A compra única é separada de sua assinatura.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Sua assinatura ainda está ativa e se renovando. Cancele-a no Google Play primeiro.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Não foi possível verificar sua assinatura no Google Play. Tente novamente.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">Confirmando sua compra</string>
+    <string name="upgrade_screen_grace_body">Aguardando o Google Play reconfirmar sua compra Pro. Isso geralmente se resolve sozinho.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Ainda não conseguimos reconfirmar sua compra Pro no Google Play. Se isso continuar acontecendo, tente restaurar sua compra ou entre em contato com o suporte.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">O status parece errado?</string>
+    <string name="upgrade_screen_restore_status_body">Se você comprou Pro mas ele não está aparecendo, faça uma verificação em tempo real no Google Play.</string>
+    <string name="upgrade_screen_restore_success_message">Compra restaurada.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Certifique-se de que você está conectado com a conta do Google que usou para fazer a compra. Uma verificação em tempo real com o Google Play foi realizada.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Opções de atualização</string>
+    <string name="upgrade_screen_offers_body">Mesmos recursos, apenas modelos de preço diferentes.</string>
+    <string name="upgrade_screen_offers_or">ou</string>
+    <string name="upgrade_screen_subscription_offer_title">Assinatura anual</string>
+    <string name="upgrade_screen_subscription_offer_body">Renova anualmente após o período de avaliação gratuita. Cancele a qualquer momento no Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Renova anualmente. Cancele a qualquer momento no Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Comprar uma vez</string>
+    <string name="upgrade_screen_iap_offer_body">Um pagamento, sem renovações.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">Assinatura ainda ativa</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Google Play foi verificado recentemente, mas nenhuma compra de Pro pôde ser confirmada para a conta que está usando para este aplicativo.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Múltiplas contas podem confundir o Google Play. Instalar o aplicativo através do site do Google Play força sua vinculação a uma conta específica.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">A sincronização do Google Play pode levar um tempo. Tente reiniciar, limpar o cache do Google Play Store ou simplesmente aguardar.</string>
+    <string name="upgrade_screen_restore_contact_hint">Ainda com problemas? Entre em contato com o suporte usando o e-mail que realizou a compra e inclua seu número de pedido do Google Play.</string>
 </resources>

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Os serviços do Google Play não estão disponíveis.</string>
     <string name="upgrades_no_purchases_found_check_account">Nenhuma compra encontrada. Está a utilizar a conta correta?</string>
+    <string name="upgrades_gplay_already_owned_title">Já comprado</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play reporta que já possui esta atualização, mas não conseguiu ser restaurada. Verifique se tem sessão iniciada com a conta Google utilizada para a compra original e tente \'Restaurar compra\'.</string>
     <string name="upgrade_screen_preamble">O Permission Pilot é sem anúncios e respeita a sua privacidade. Atualizar apoia o desenvolvimento contínuo.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play indisponível</string>
+    <string name="upgrade_screen_offers_unavailable_message">Não foi possível carregar as opções de compra. Google Play pode estar temporariamente indisponível — verifique a sua ligação e tente novamente.</string>
     <string name="upgrade_screen_subscription_trial_action">Iniciar teste gratuito</string>
     <string name="upgrade_screen_subscription_action">Subscrever</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/ano, cancelar em qualquer altura</string>
-    <string name="upgrade_screen_iap_action">Comprar Pro</string>
+    <string name="upgrade_screen_iap_action">Compra única</string>
     <string name="upgrade_screen_iap_action_hint">Compra única de %s</string>
     <string name="upgrade_screen_restore_purchase_action">Restaurar compra</string>
     <string name="upgrade_screen_restore_purchase_message">Nenhuma compra encontrada. Verifique se está com a conta Google correta.</string>
+    <string name="upgrade_screen_restore_banner_title">Já comprou o Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Parece que já atualizou para Pro neste dispositivo. Restaure a compra para o desbloquear novamente.</string>
     <string name="upgrade_screen_options_description">As subscrições renovam automaticamente. Pode cancelar a qualquer momento.</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Tem o Pro — obrigado!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">A sua compra única do Pro desbloqueia todas as funcionalidades Pro, para sempre.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">A sua subscrição desbloqueia todas as funcionalidades Pro.</string>
+    <string name="upgrade_screen_owned_sub_title">A sua subscrição</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">A sua subscrição está ativa e renova-se automaticamente.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">A sua subscrição está definida para expirar e não será renovada. Pode manter o Pro até ao fim.</string>
+    <string name="upgrade_screen_owned_both_warning">Possui a compra Pro única e também tem uma subscrição ativa. Não precisa de ambas — cancele a subscrição no Google Play para evitar cobranças futuras.</string>
+    <string name="upgrade_screen_manage_subscription_action">Gerir subscrição</string>
+    <string name="upgrade_screen_owned_iap_title">Pro Permanente</string>
+    <string name="upgrade_screen_owned_iap_body">Possui a compra Pro única. Sem subscrição, sem renovações.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Mudar para uma compra única</string>
+    <string name="upgrade_screen_switch_purchase_note">A sua subscrição não será renovada, portanto pode agora mudar para a compra Pro única e permanente.</string>
+    <string name="upgrade_screen_switch_locked_note">Para mudar para a compra única, primeiro cancele a sua subscrição no Google Play. Esta oferta desbloqueia-se depois de ser definida para não renovar.</string>
+    <string name="upgrade_screen_limitation_disclosure">O Google Play apenas verifica a conta em que está atualmente ligado. A compra única é separada da sua subscrição.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">A sua subscrição ainda está ativa e em renovação. Cancele-a primeiro no Google Play.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Não foi possível verificar a sua subscrição no Google Play. Tente novamente.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">A confirmar a compra</string>
+    <string name="upgrade_screen_grace_body">A aguardar que o Google Play confirme novamente a sua compra Pro. Normalmente resolve-se automaticamente.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Ainda não conseguimos confirmar novamente a sua compra Pro no Google Play. Se isto continuar a acontecer, tente restaurar a sua compra ou contacte o suporte.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">O estado parece incorreto?</string>
+    <string name="upgrade_screen_restore_status_body">Se comprou Pro mas não está a aparecer, execute uma verificação em direto no Google Play.</string>
+    <string name="upgrade_screen_restore_success_message">Compra restaurada.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Certifique-se de que está a iniciar sessão com a conta Google que utilizou para comprar. Uma verificação em direto no Google Play foi executada agora.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Opções de atualização</string>
+    <string name="upgrade_screen_offers_body">As mesmas funcionalidades, apenas com modelos de preço diferentes.</string>
+    <string name="upgrade_screen_offers_or">ou</string>
+    <string name="upgrade_screen_subscription_offer_title">Subscrição anual</string>
+    <string name="upgrade_screen_subscription_offer_body">Renova anualmente após o período experimental gratuito. Cancele a qualquer momento no Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Renova anualmente. Cancele a qualquer momento no Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Compra única</string>
+    <string name="upgrade_screen_iap_offer_body">Um pagamento, sem renovações.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">Subscrição ainda ativa</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">O Google Play foi verificado agora, mas nenhuma compra Pro foi confirmada para a conta que está a ser utilizada nesta aplicação.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Várias contas podem confundir o Google Play. Instalar a aplicação através do site do Google Play força a associação a uma conta específica.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">A sincronização do Google Play pode demorar. Tente reiniciar o dispositivo, limpar a cache do Google Play ou simplesmente aguarde.</string>
+    <string name="upgrade_screen_restore_contact_hint">Continua sem solução? Contacte o apoio através do endereço de e-mail usado na compra e inclua o número da encomenda do Google Play.</string>
 </resources>

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Serviciile Google Play nu sunt disponibile.</string>
     <string name="upgrades_no_purchases_found_check_account">Nu s-au găsit achiziții. Folosești contul corect?</string>
+    <string name="upgrades_gplay_already_owned_title">Deja cumpărat</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play raportează că deja deții acest upgrade, dar nu a putut fi restaurat. Verifică că ești conectat cu contul Google folosit pentru achiziția originală, apoi încearcă „Restaurează achiziția”.</string>
     <string name="upgrade_screen_preamble">Permission Pilot este fără reclame şi îți respectă confidențialitatea. Actualizarea sprijină dezvoltarea continuă.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play indisponibil</string>
+    <string name="upgrade_screen_offers_unavailable_message">Nu s-au putut încărca opțiunile de achiziție. Google Play ar putea fi temporar indisponibil — verifică conexiunea și încearcă din nou.</string>
     <string name="upgrade_screen_subscription_trial_action">Începe încercarea gratuită</string>
     <string name="upgrade_screen_subscription_action">Abonează-te</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/an, anulează oricând</string>
-    <string name="upgrade_screen_iap_action">Cumpără Pro</string>
+    <string name="upgrade_screen_iap_action">Achiziție unică</string>
     <string name="upgrade_screen_iap_action_hint">Achiziție unică de %s</string>
     <string name="upgrade_screen_restore_purchase_action">Restabiliți achiziția</string>
     <string name="upgrade_screen_restore_purchase_message">Nicio achiziție găsită. Verifică că eşti autentificat cu contul Google corect.</string>
+    <string name="upgrade_screen_restore_banner_title">Deja ai cumpărat Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Se pare că ai cumpărat versiunea Pro pe acest dispozitiv anterior. Restaurează achiziția pentru a o debloca din nou.</string>
     <string name="upgrade_screen_options_description">Abonamentele se reînnoiesc automat. Poți anula oricând.</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Ești Pro — mulțumim!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Achiziția ta Pro de o singură dată deblochează fiecare caracteristică Pro, pentru totdeauna.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Abonamentul tău deblochează fiecare caracteristică Pro.</string>
+    <string name="upgrade_screen_owned_sub_title">Abonamentul tău</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Abonamentul tău este activ și se reînoiește automat.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Abonamentul tău este setat să expire și nu se va reînnoi. Vei continua să ai acces la Pro până la expirare.</string>
+    <string name="upgrade_screen_owned_both_warning">Deții achiziția Pro de o singură dată și de asemenea ai un abonament activ. Nu ai nevoie de ambele — anulează abonamentul din Google Play pentru a evita cheltuielile suplimentare.</string>
+    <string name="upgrade_screen_manage_subscription_action">Gestionează abonamentul</string>
+    <string name="upgrade_screen_owned_iap_title">Pro pe viață</string>
+    <string name="upgrade_screen_owned_iap_body">Deții achiziția Pro de o singură dată. Fără abonament, fără reînnouiri.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Treci la o achiziție unică</string>
+    <string name="upgrade_screen_switch_purchase_note">Abonamentul tău nu se va reînnoi, deci poți trece acum la achiziția Pro unică și permanentă.</string>
+    <string name="upgrade_screen_switch_locked_note">Pentru a trece la achiziția unică, anulează mai întâi abonamentul tău în Google Play. Această ofertă se deblochează odată ce este setată să nu se reînnoiască.</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play verifică doar contul cu care ești conectat în acest moment. Achiziția unică este separată de abonamentul tău.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Abonamentul tău este încă activ și se reînnoiește. Anulează-l mai întâi în Google Play.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Nu am putut verifica abonamentul tău cu Google Play. Te rog să încerci din nou.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">Se confirmă achiziția ta</string>
+    <string name="upgrade_screen_grace_body">Se așteaptă ca Google Play să reconfirme achiziția Pro. De obicei se rezolvă de la sine.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Nu putem încă reconfirma achiziția Pro cu Google Play. Dacă continuă să se întâmple, încearcă să restabilești achiziția sau contactează suportul.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">Starea arată greșit?</string>
+    <string name="upgrade_screen_restore_status_body">Dacă ai achiziționat Pro dar nu se afișează, efectuează o verificare în direct cu Google Play.</string>
+    <string name="upgrade_screen_restore_success_message">Achiziția a fost restabilită.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Asigură-te că ești conectat cu contul Google pe care l-ai folosit pentru achiziție. O verificare în direct cu Google Play a fost efectuată tocmai acum.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Opțiuni de upgrade</string>
+    <string name="upgrade_screen_offers_body">Aceleași funcții, doar modele de prețuri diferite.</string>
+    <string name="upgrade_screen_offers_or">sau</string>
+    <string name="upgrade_screen_subscription_offer_title">Abonament anual</string>
+    <string name="upgrade_screen_subscription_offer_body">Se reînnoiește anual după perioada de probă gratuită. Anulează oricând în Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Se reînnoiește anual. Anulează oricând în Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Cumpără o dată</string>
+    <string name="upgrade_screen_iap_offer_body">O plată, fără reînnoiri.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">Abonament încă activ</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Google Play a fost tocmai verificat, dar nu s-a putut confirma nicio achiziție Pro pentru contul pe care îl folosește aplicația.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Conturi multiple pot confunda Google Play. Instalarea aplicației prin site-ul Google Play o forțează să se asocieze cu un cont specific.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Sincronizarea Google Play poate dura ceva timp. Încearcă să repornești, să ștergi memoria cache a Google Play Store sau pur și simplu să aștepți.</string>
+    <string name="upgrade_screen_restore_contact_hint">Încă blocat? Contactează asistența din e-mailul care a realizat achiziția și include numărul comenzii Google Play.</string>
 </resources>

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Сервисы Google Play недоступны.</string>
     <string name="upgrades_no_purchases_found_check_account">Покупки не найдены. Вы используете правильный аккаунт?</string>
+    <string name="upgrades_gplay_already_owned_title">Уже приобретено</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play сообщает, что вы уже владеете этим обновлением, но оно не удалось восстановить. Убедитесь, что вы вошли с помощью учетной записи Google, используемой для первоначальной покупки, затем попробуйте «Восстановить покупку».</string>
     <string name="upgrade_screen_preamble">Permission Pilot не содержит рекламы и уважает вашу конфиденциальность. Обновление поддерживает дальнейшую разработку.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play недоступен</string>
+    <string name="upgrade_screen_offers_unavailable_message">Не удалось загрузить параметры покупки. Google Play может быть временно недоступен — проверьте подключение и попробуйте еще раз.</string>
     <string name="upgrade_screen_subscription_trial_action">Начать бесплатный пробный период</string>
     <string name="upgrade_screen_subscription_action">Подписаться</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/год, отменить в любое время</string>
-    <string name="upgrade_screen_iap_action">Купить Pro</string>
+    <string name="upgrade_screen_iap_action">Разовая покупка</string>
     <string name="upgrade_screen_iap_action_hint">Единовременная покупка %s</string>
     <string name="upgrade_screen_restore_purchase_action">Восстановить покупку</string>
     <string name="upgrade_screen_restore_purchase_message">Покупки не найдены. Убедитесь, что вы вошли с правильным аккаунтом Google.</string>
+    <string name="upgrade_screen_restore_banner_title">Уже купили Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Похоже, что Вы уже обновились до Pro на этом устройстве. Восстановите свою покупку, чтобы разблокировать его снова.</string>
     <string name="upgrade_screen_options_description">Подписки обновляются автоматически. Вы можете отменить в любое время.</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Вы Pro — спасибо!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Ваша единоразовая покупка Pro разблокирует все функции Pro навсегда.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Ваша подписка разблокирует все функции Pro.</string>
+    <string name="upgrade_screen_owned_sub_title">Ваша подписка</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Ваша подписка активна и автоматически продлевается.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Ваша подписка истечет и не будет продлеваться. Вы сохраняете Pro до конца.</string>
+    <string name="upgrade_screen_owned_both_warning">Вы имеете единоразовое обновление Pro и активную подписку. Вам не нужны обе — отмените подписку в Google Play, чтобы избежать дополнительных платежей.</string>
+    <string name="upgrade_screen_manage_subscription_action">Управлять подпиской</string>
+    <string name="upgrade_screen_owned_iap_title">Pro на всю жизнь</string>
+    <string name="upgrade_screen_owned_iap_body">У вас есть единоразовое обновление Pro. Без подписки, без продлений.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Переключиться на единоразовую покупку</string>
+    <string name="upgrade_screen_switch_purchase_note">Ваша подписка не будет продлеваться, поэтому вы можете перейти на постоянное единоразовое обновление Pro.</string>
+    <string name="upgrade_screen_switch_locked_note">Чтобы переключиться на единоразовую покупку, сначала отмените подписку в Google Play. Это предложение станет доступным, когда вы отключите автоматическое продление.</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play проверяет только аккаунт, в который вы сейчас вошли. Единоразовая покупка отделена от вашей подписки.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Ваша подписка по-прежнему активна и продлевается. Сначала отмените ее в Google Play.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Не удалось проверить вашу подписку в Google Play. Пожалуйста, попробуйте еще раз.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">Подтверждение покупки</string>
+    <string name="upgrade_screen_grace_body">Ожидание подтверждения вашей покупки Pro в Google Play. Обычно это разрешается автоматически.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Нам по-прежнему не удается подтвердить вашу покупку Pro в Google Play. Если это продолжает происходить, попробуйте восстановить покупку или обратитесь в службу поддержки.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">Статус выглядит неправильно?</string>
+    <string name="upgrade_screen_restore_status_body">Если вы приобрели Pro, но это не отображается, запустите проверку в Google Play.</string>
+    <string name="upgrade_screen_restore_success_message">Покупка восстановлена.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Убедитесь, что вы вошли с помощью аккаунта Google, который использовали для покупки. Проверка в Google Play только что выполнена.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Варианты обновления</string>
+    <string name="upgrade_screen_offers_body">Те же функции, просто разные модели ценообразования.</string>
+    <string name="upgrade_screen_offers_or">или</string>
+    <string name="upgrade_screen_subscription_offer_title">Годовая подписка</string>
+    <string name="upgrade_screen_subscription_offer_body">Возобновляется ежегодно после пробного периода. Отменить можно в любой момент в Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Возобновляется ежегодно. Отменить можно в любой момент в Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Одноразовая покупка</string>
+    <string name="upgrade_screen_iap_offer_body">Одноразовый платеж без возобновлений.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">Подписка всё ещё активна</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Google Play был только что проверен, но для аккаунта, используемого этим приложением, не удалось подтвердить покупку Pro.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Несколько аккаунтов могут запутать Google Play. Установка приложения через сайт Google Play заставляет его привязаться к определенному аккаунту.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Синхронизация Google Play может занять время. Попробуйте перезагрузить устройство, очистить кэш Google Play Store или просто подождать.</string>
+    <string name="upgrade_screen_restore_contact_hint">Всё ещё не получается? Свяжитесь с поддержкой с адреса электронной почты, который произвёл покупку, и укажите номер заказа Google Play.</string>
 </resources>

--- a/app/src/gplay/res/values-sk/strings.xml
+++ b/app/src/gplay/res/values-sk/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Služby Google Play nie sú dostupné.</string>
     <string name="upgrades_no_purchases_found_check_account">Nenašli sa žiadne nákupy. Používate správny účet?</string>
+    <string name="upgrades_gplay_already_owned_title">Už zakúpené</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play hlási, že už vlastníte tento upgrade, ale nepodarilo sa ho obnoviť. Skontrolujte, že ste prihlásení s účtom Google, ktorý ste používali pri pôvodnom nákupe, a potom skúste „Obnoviť nákup“.</string>
     <string name="upgrade_screen_preamble">Permission Pilot je bez reklam a rešpektuje vaše súkromie. Upgrade podporuje ďalejší vyvoj.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play nie je k dispozícii</string>
+    <string name="upgrade_screen_offers_unavailable_message">Nepodarilo sa načítať možnosti nákupu. Google Play môže byť dočasne nedostupný — skontrolujte vaše pripojenie a skúste znova.</string>
     <string name="upgrade_screen_subscription_trial_action">Vyskúšajte zadarmo</string>
     <string name="upgrade_screen_subscription_action">Predplatiť</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/rok, kedykoľvek zrušiť</string>
-    <string name="upgrade_screen_iap_action">Kupí Pro</string>
+    <string name="upgrade_screen_iap_action">Jednorazový nákup</string>
     <string name="upgrade_screen_iap_action_hint">Jednorazový nákup za %s</string>
     <string name="upgrade_screen_restore_purchase_action">Obnoviť nákup</string>
     <string name="upgrade_screen_restore_purchase_message">Žiadne nákupy neboli nájdené. Skontrolujte, či ste prihlásení so správnym účtom Google.</string>
+    <string name="upgrade_screen_restore_banner_title">Už ste kúpili Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Vyzerá to, že ste na tomto zariadení predtým upgradovali na Pro. Obnovte si nákup a odomknite ho znova.</string>
     <string name="upgrade_screen_options_description">Predplatné sa obnovia automaticky. Môžete ich kedykoľvek zrušiť.</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Ste Pro — ďakujeme!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Váš jednorazový nákup Pro odomyká všetky funkcie Pro. Navždy.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Vaše predplatné odomyká všetky funkcie Pro.</string>
+    <string name="upgrade_screen_owned_sub_title">Vaše predplatné</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Vaše predplatné je aktívne a automaticky sa obnovuje.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Vaše predplatné vypršia a nebude sa obnovovať. Budete mať Pro až do jeho konca.</string>
+    <string name="upgrade_screen_owned_both_warning">Vlastníte jednorazový upgrade Pro a máte aj aktívne predplatné. Nepotrebujete oboje – zrušte predplatné v Google Play, aby ste sa vyhli ďalším poplatkom.</string>
+    <string name="upgrade_screen_manage_subscription_action">Spravovať predplatné</string>
+    <string name="upgrade_screen_owned_iap_title">Doživotný Pro</string>
+    <string name="upgrade_screen_owned_iap_body">Vlastníte jednorazový upgrade Pro. Žiadne predplatné, žiadne obnovy.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Prejsť na jednorazový nákup</string>
+    <string name="upgrade_screen_switch_purchase_note">Vaše predplatné sa neobnoví, takže teraz môžete prejsť na trvalý jednorazový nákup Pro.</string>
+    <string name="upgrade_screen_switch_locked_note">Ak chcete prejsť na jednorazový nákup, najskôr zrušte svoje predplatné v Google Play. Táto ponuka sa odomkne, keď nastavíte predplatné, aby sa neobnovalo.</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play kontroluje iba účet, s ktorým ste momentálne prihlásení. Jednorazový nákup je nezávislý od vášho predplatného.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Vaše predplatné je stále aktívne a obnovuje sa. Zrušte ho najskôr v Google Play.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Nepodarilo sa overiť vaše predplatné v Google Play. Skúste znova prosím.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">Potvrdzovanie vášho nákupu</string>
+    <string name="upgrade_screen_grace_body">Čakáme, kým Google Play znovu potvrdí váš nákup Pro. Zvyčajne sa to vyrieši automaticky.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Stále nemôžeme znovu potvrdiť váš nákup Pro v Google Play. Ak sa to stále deje, skúste obnoviť svoj nákup alebo kontaktujte podporu.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">Stav vyzerá zle?</string>
+    <string name="upgrade_screen_restore_status_body">Ak ste si kúpili Pro, ale nie je to viditeľné, spustite živú kontrolu voči Google Play.</string>
+    <string name="upgrade_screen_restore_success_message">Nákup obnovený.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Uistite sa, že ste prihlásení pomocou účtu Google, ktorý ste použili na nákup. Práve sa spustila živá kontrola voči Google Play.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Možnosti aktualizácie</string>
+    <string name="upgrade_screen_offers_body">Rovnaké funkcie, len iné cenové modely.</string>
+    <string name="upgrade_screen_offers_or">alebo</string>
+    <string name="upgrade_screen_subscription_offer_title">Ročné predplatné</string>
+    <string name="upgrade_screen_subscription_offer_body">Obnovuje sa ročne po bezplatnej skúšobnej dobe. Kedykoľvek ho môžete zrušiť v Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Obnovuje sa ročne. Kedykoľvek ho môžete zrušiť v Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Kúpiť raz</string>
+    <string name="upgrade_screen_iap_offer_body">Jedna platba, bez obnovenia.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">Predplatné je stále aktívne</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Google Play bolo práve skontrolované, ale nákup Pro sa nedal potvrdiť pre účet, ktorý aplikácia používa.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Viaceré účty môžu zmiasť Google Play. Inštalácia aplikácie prostredníctvom webovej stránky Google Play si vynúti priradenie ku konkrétnemu účtu.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Synchronizácia Google Play môže chvíľu trvať. Skúste reštartovať, vymazať vyrovnávaciu pamäť Google Play Store alebo jednoducho počkať.</string>
+    <string name="upgrade_screen_restore_contact_hint">Stále v problémoch? Kontaktujte podporu z e-mailu, ktorý bol použitý na nákup, a uveďte číslo svojej objednávky Google Play.</string>
 </resources>

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play услуге нису доступне.</string>
     <string name="upgrades_no_purchases_found_check_account">Није пронађена ниједна куповина. Да ли користите исправан налог?</string>
+    <string name="upgrades_gplay_already_owned_title">Већ куплено</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play извештава да већ поседујете ово унапређење, али га није могуће вратити. Проверите да ли сте пријављени са Google налогом који је коришћен за оригиналну куповину, а затим покушајте „Враћање куповине”.</string>
     <string name="upgrade_screen_preamble">Permission Pilot нема реклама и поштује вашу приватност. Надоградњом подржавате даљи развој.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play није доступан</string>
+    <string name="upgrade_screen_offers_unavailable_message">Није могуће учитати опције куповине. Google Play може бити привремено недоступан — проверите вашу везу и покушајте поново.</string>
     <string name="upgrade_screen_subscription_trial_action">Покрените бесплатно испробавање</string>
     <string name="upgrade_screen_subscription_action">Претплати се</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/година, отказ било када</string>
-    <string name="upgrade_screen_iap_action">Купи Pro</string>
+    <string name="upgrade_screen_iap_action">Једнократна куповина</string>
     <string name="upgrade_screen_iap_action_hint">Једнократна куповина %s</string>
     <string name="upgrade_screen_restore_purchase_action">Врати куповину</string>
     <string name="upgrade_screen_restore_purchase_message">Ниједна куповина није понађена. Проверите да сте пријављени исправним Google налогом.</string>
+    <string name="upgrade_screen_restore_banner_title">Већ сте купили Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Изгледа да сте раније купили Pro на овом уређају. Вратите куповину да откључате Pro.</string>
     <string name="upgrade_screen_options_description">Претплате се аутоматски обнављају. Можете отказати када хоћете.</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Ви сте Pro — хвала!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Ваша једнократна куповина Pro откључава све Pro функције заувек.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Ваша претплата откључава сваку Pro функцију.</string>
+    <string name="upgrade_screen_owned_sub_title">Ваша претплата</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Ваша претплата је активна и аутоматски се обнавља.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Ваша претплата је подешена да истекне и неће се обновити. Задржаћете Pro док се не заврши.</string>
+    <string name="upgrade_screen_owned_both_warning">Поседујете једнократно Pro ажурирање и такође имате активну претплату. Не требају вам обе — откажите претплату у Google Play како бисте избегли даље трошкове.</string>
+    <string name="upgrade_screen_manage_subscription_action">Управљај претплатом</string>
+    <string name="upgrade_screen_owned_iap_title">Доживотни Pro</string>
+    <string name="upgrade_screen_owned_iap_body">Поседујете једнократно Pro ажурирање. Без претплате, без обнављања.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Пређите на једнократну куповину</string>
+    <string name="upgrade_screen_switch_purchase_note">Ваша претплата се неће обновити, па сада можете прећи на трајно једнократно Pro куповање.</string>
+    <string name="upgrade_screen_switch_locked_note">Да бисте прешли на једнократну куповину, прво откажите своју претплату у Google Play. Та понуда ће бити доступна када је претплата подешена да се не обнови.</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play проверава само налог са којим сте пријављени. Једнократна куповина је одвојена од ваше претплате.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Ваша претплата је још активна и обнавља се. Прво је откажите у Google Play.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Провера ваше претплате са Google Play није успела. Покушајте поново.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">Потврђивање ваше куповине</string>
+    <string name="upgrade_screen_grace_body">Чека се да Google Play поново потврди вашу Pro куповину. Ово се обично решава аутоматски.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Још увек не можемо поново потврдити вашу Pro куповину са Google Play. Ако се ово настави, покушајте да вратите куповину или контактирајте подршку.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">Статус изгледа неисправно?</string>
+    <string name="upgrade_screen_restore_status_body">Ако сте купили Pro али се не приказује, покрените проверу уживо насупрот Google Play.</string>
+    <string name="upgrade_screen_restore_success_message">Куповина је обновљена.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Уверите се да сте пријављени са Google налогом који сте користили за куповину. Управо је извршена провера са Google Play.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Опције унапређења</string>
+    <string name="upgrade_screen_offers_body">Исте функције, само различити модели цена.</string>
+    <string name="upgrade_screen_offers_or">или</string>
+    <string name="upgrade_screen_subscription_offer_title">Годишња претплата</string>
+    <string name="upgrade_screen_subscription_offer_body">Обнавља се годишње по истеку бесплатног периода. Отказати можете било када у Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Обнавља се годишње. Отказати можете било када у Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Купи једном</string>
+    <string name="upgrade_screen_iap_offer_body">Једнократна уплата, без обнављања.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">Претплата је још увек активна</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Google Play је управо проверен, али Pro куповина није могла да буде потврђена за налог који користи ова апликација.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Више налога може збунити Google Play. Инсталирање апликације преко Google Play веб сајта приморава асоцијацију са одређеним налогом.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Синхронизација Google Play може потрајати. Покушајте поново покретање, брисање Google Play Store кеша или једноставно сачекајте.</string>
+    <string name="upgrade_screen_restore_contact_hint">И даље имате проблем? Контактирајте подршку са имејла који је направио куповину и укључите ваш Google Play број наруџбине.</string>
 </resources>

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play-tjänster är inte tillgängliga.</string>
     <string name="upgrades_no_purchases_found_check_account">Inga köp hittades. Använder du rätt konto?</string>
+    <string name="upgrades_gplay_already_owned_title">Redan köpt</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play rapporterar att du redan äger denna uppgradering, men den kunde inte återställas. Kontrollera att du är inloggad med Google-kontot som användes för det ursprungliga köpet och försök sedan med \"Återställ köp\".</string>
     <string name="upgrade_screen_preamble">Permission Pilot är reklamfri och respekterar din integritet. Att uppgradera stödjer fortsatt utveckling.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play är inte tillgängligt</string>
+    <string name="upgrade_screen_offers_unavailable_message">Kunde inte läsa in köpalternativen. Google Play kanske är temporärt otillgängligt – kontrollera din anslutning och försök igen.</string>
     <string name="upgrade_screen_subscription_trial_action">Starta gratis prov</string>
     <string name="upgrade_screen_subscription_action">Prenumerera</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/år, avbryt när som helst</string>
-    <string name="upgrade_screen_iap_action">Köp Pro</string>
+    <string name="upgrade_screen_iap_action">Engångsköp</string>
     <string name="upgrade_screen_iap_action_hint">Engångsingång av %s</string>
     <string name="upgrade_screen_restore_purchase_action">Återställ köp</string>
     <string name="upgrade_screen_restore_purchase_message">Inga köp hittades. Kontrollera att du är inloggad med rätt Google-konto.</string>
+    <string name="upgrade_screen_restore_banner_title">Redan köpt Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Det verkar som om du redan uppgraderade till Pro på den här enheten tidigare. Återställ ditt köp för att låsa upp det igen.</string>
     <string name="upgrade_screen_options_description">Prenumerationer förnyas automatiskt. Du kan avsluta när som helst.</string>
     <string name="upgrade_title_suffix">Expert</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Du är Pro – tack!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Ditt engångköp av Pro låser upp alla Pro-funktioner för alltid.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Din prenumeration låser upp alla Pro-funktioner.</string>
+    <string name="upgrade_screen_owned_sub_title">Din prenumeration</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Din prenumeration är aktiv och förnyas automatiskt.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Din prenumeration är inställd på att upphöra och kommer inte att förnyas. Du behåller Pro tills den slutar.</string>
+    <string name="upgrade_screen_owned_both_warning">Du äger engångsuppgraderingen till Pro och har också en aktiv prenumeration. Du behöver inte båda – avsluta prenumerationen i Google Play för att undvika ytterligare debiteringar.</string>
+    <string name="upgrade_screen_manage_subscription_action">Hantera prenumeration</string>
+    <string name="upgrade_screen_owned_iap_title">Pro på livstid</string>
+    <string name="upgrade_screen_owned_iap_body">Du äger engångsuppgraderingen till Pro. Ingen prenumeration, inga förnyelser.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Växla till ett engångsköp</string>
+    <string name="upgrade_screen_switch_purchase_note">Din prenumeration kommer inte att förnyas, så du kan byta till det permanenta engångsköpet av Pro nu.</string>
+    <string name="upgrade_screen_switch_locked_note">För att byta till engångsköpet måste du först avbryta din prenumeration i Google Play. Det här erbjudandet aktiveras när det är inställt på att inte förnyas.</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play kontrollerar bara kontot du är inloggad på. Engångsköpet är separat från din prenumeration.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Din prenumeration är fortfarande aktiv och förnyas. Avbryt den i Google Play först.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Kunde inte verifiera din prenumeration med Google Play. Försök igen.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">Bekräftar ditt köp</string>
+    <string name="upgrade_screen_grace_body">Väntar på att Google Play ska ombekräfta ditt Pro-köp. Det löser sig vanligtvis själv.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Vi kan fortfarande inte ombekräfta ditt Pro-köp med Google Play. Om detta fortsätter att hända kan du försöka återställa ditt köp eller kontakta support.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">Status ser fel ut?</string>
+    <string name="upgrade_screen_restore_status_body">Om du har köpt Pro men det inte visas kan du köra en direktkontroll mot Google Play.</string>
+    <string name="upgrade_screen_restore_success_message">Köp återställt.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Kontrollera att du är inloggad med Google-kontot du använt för köp. En direktkontroll mot Google Play har just körts.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Uppgraderingsalternativ</string>
+    <string name="upgrade_screen_offers_body">Samma funktioner, bara olika prismodeller.</string>
+    <string name="upgrade_screen_offers_or">eller</string>
+    <string name="upgrade_screen_subscription_offer_title">Årlig prenumeration</string>
+    <string name="upgrade_screen_subscription_offer_body">Förnyas årligen efter den kostnadsfria provperioden. Avsluta när som helst i Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Förnyas årligen. Avsluta när som helst i Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Köp en gång</string>
+    <string name="upgrade_screen_iap_offer_body">En betalning, ingen förnyelse.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">Prenumerationen är fortfarande aktiv</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Google Play kontrollerades precis, men inget Pro-köp kunde bekräftas för det konto som används för denna app.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Flera konton kan förvirra Google Play. Om du installerar appen via Google Play-webbplatsen tvingas den associeras med ett specifikt konto.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Google Play-synkronisering kan ta en stund. Försök starta om, rensa Google Play Store-cachen eller vänta bara.</string>
+    <string name="upgrade_screen_restore_contact_hint">Fortfarande fastnad? Kontakta supporten från den e-postadress som gjorde köpet och inkludera ditt Google Play-ordernummer.</string>
 </resources>

--- a/app/src/gplay/res/values-th/strings.xml
+++ b/app/src/gplay/res/values-th/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">บริการ Google Play ไม่พร้อมใช้งาน</string>
     <string name="upgrades_no_purchases_found_check_account">ไม่พบรายการซื้อ คุณใช้บัญชีที่ถูกต้องหรือไม่?</string>
+    <string name="upgrades_gplay_already_owned_title">ซื้อแล้ว</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play รายงานว่าคุณเป็นเจ้าของการอัปเกรดนี้แล้ว แต่ไม่สามารถคืนค่าได้ ตรวจสอบว่าคุณลงชื่อเข้าใช้ด้วยบัญชี Google ที่ใช้สำหรับการซื้อครั้งแรก จากนั้นลองใช้ \"คืนค่าการซื้อ\"</string>
     <string name="upgrade_screen_preamble">Permission Pilot ไม่มีโฆษณาและเคารพความเป็นส่วนตัวของคุณ การอัปเกรดช่วยสนับสนุนการพัฒนาอย่างต่อเนื่อง</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play ไม่พร้อมใช้งาน</string>
+    <string name="upgrade_screen_offers_unavailable_message">ไม่สามารถโหลดตัวเลือกการซื้อได้ Google Play อาจไม่พร้อมใช้งานชั่วคราว — ตรวจสอบการเชื่อมต่อของคุณและลองอีกครั้ง</string>
     <string name="upgrade_screen_subscription_trial_action">เริ่มทดลองใช้องค์ฟรี</string>
     <string name="upgrade_screen_subscription_action">สมัครสมาชิก</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/ปี ยกเลิกได้ตลอดเวลา</string>
-    <string name="upgrade_screen_iap_action">ซื้อ Pro</string>
+    <string name="upgrade_screen_iap_action">ซื้อครั้งเดียว</string>
     <string name="upgrade_screen_iap_action_hint">ซื้อครั้งเดียวในราคา %s</string>
     <string name="upgrade_screen_restore_purchase_action">กู้คืนการซื้อ</string>
     <string name="upgrade_screen_restore_purchase_message">ไม่พบการซื้อ ตรวจสอบว่าคุณล็อกเข้าด้วยบัญชี Google ที่ถูกต้อง</string>
+    <string name="upgrade_screen_restore_banner_title">ซื้อ Pro ไปแล้วหรือ?</string>
+    <string name="upgrade_screen_restore_banner_body">ดูเหมือนว่าคุณได้อัปเกรดเป็น Pro บนอุปกรณ์นี้มาแล้ว คืนค่าการซื้อของคุณเพื่อปลดล็อคอีกครั้ง</string>
     <string name="upgrade_screen_options_description">สมาชิกภาพจะต่ออายุโดยอัตโนมัติ คุณยกเลิกได้เมื่อใดก็ได้</string>
     <string name="upgrade_title_suffix">โปร</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">คุณเป็น Pro — ขอบคุณ!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">การซื้อ Pro ครั้งเดียวของคุณปลดล็อคฟีเจอร์ Pro ทั้งหมดเป็นการถาวร</string>
+    <string name="upgrade_screen_owned_hero_sub_body">การสมัครสมาชิกของคุณปลดล็อคฟีเจอร์ Pro ทั้งหมด</string>
+    <string name="upgrade_screen_owned_sub_title">การสมัครสมาชิกของคุณ</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">การสมัครสมาชิกของคุณยังใช้งานอยู่ และต่ออายุโดยอัตโนมัติ</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">การสมัครสมาชิกของคุณจะหมดอายุและจะไม่ต่ออายุ คุณจะยังคงใช้ Pro จนกว่าจะสิ้นสุด</string>
+    <string name="upgrade_screen_owned_both_warning">คุณมี Pro upgrade แบบครั้งเดียว และมีการสมัครสมาชิกที่ยังใช้งานอยู่ คุณไม่ต้องใช้ทั้งสอง — ยกเลิกการสมัครสมาชิกใน Google Play เพื่อหลีกเลี่ยงค่าใช้จ่ายเพิ่มเติม</string>
+    <string name="upgrade_screen_manage_subscription_action">จัดการการสมัครสมาชิก</string>
+    <string name="upgrade_screen_owned_iap_title">Lifetime Pro</string>
+    <string name="upgrade_screen_owned_iap_body">คุณมี Pro upgrade แบบครั้งเดียว ไม่มีการสมัครสมาชิก ไม่มีการต่ออายุ</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">เปลี่ยนไปซื้อแบบครั้งเดียว</string>
+    <string name="upgrade_screen_switch_purchase_note">การสมัครสมาชิกของคุณจะไม่ต่ออายุ ดังนั้นตอนนี้คุณสามารถเปลี่ยนไปซื้อ Pro แบบครั้งเดียวได้</string>
+    <string name="upgrade_screen_switch_locked_note">หากต้องการสลับไปใช้การซื้อแบบครั้งเดียว ให้ยกเลิกการสมัครสมาชิกของคุณใน Google Play ก่อน ข้อเสนอนี้จะปลดล็อกเมื่อคุณตั้งค่าให้ไม่ต่ออายุ</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play จะตรวจสอบเฉพาะบัญชีที่คุณลงชื่อเข้าสู่ระบบอยู่เท่านั้น การซื้อแบบครั้งเดียวจะแยกต่างหากจากการสมัครสมาชิกของคุณ</string>
+    <string name="upgrade_screen_sub_still_renewing_message">การสมัครสมาชิกของคุณยังคงใช้งานและต่ออายุอยู่ ให้ยกเลิกใน Google Play ก่อน</string>
+    <string name="upgrade_screen_sub_check_failed_message">ไม่สามารถยืนยันการสมัครสมาชิกของคุณกับ Google Play ได้ โปรดลองอีกครั้ง</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">กำลังยืนยันการซื้อของคุณ</string>
+    <string name="upgrade_screen_grace_body">กำลังรอให้ Google Play ยืนยันการซื้อ Pro ของคุณอีกครั้ง ปกติจะแก้ไขได้เอง</string>
+    <string name="upgrade_screen_grace_diagnostics_body">เรายังไม่สามารถยืนยันการซื้อ Pro ของคุณกับ Google Play ได้ หากปัญหานี้ยังคงเกิดขึ้น ให้ลองกู้คืนการซื้อของคุณหรือติดต่อฝ่ายสนับสนุน</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">สถานะดูผิดปกติหรือ</string>
+    <string name="upgrade_screen_restore_status_body">หากคุณซื้อ Pro แล้วแต่ยังไม่ปรากฏ ให้ตรวจสอบแบบสดกับ Google Play</string>
+    <string name="upgrade_screen_restore_success_message">การซื้อได้รับการกู้คืนแล้ว</string>
+    <string name="upgrade_screen_restore_webinstall_hint">ตรวจสอบว่าคุณลงชื่อเข้าใช้ด้วยบัญชี Google ที่ใช้ในการซื้อแล้ว การตรวจสอบแบบสดกับ Google Play เพิ่งดำเนินการเสร็จสิ้น</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">ตัวเลือกอัปเกรด</string>
+    <string name="upgrade_screen_offers_body">คุณสมบัติเดียวกัน เพียงแค่แบบจ่ายเงินต่างกัน</string>
+    <string name="upgrade_screen_offers_or">หรือ</string>
+    <string name="upgrade_screen_subscription_offer_title">สมาชิกรายปี</string>
+    <string name="upgrade_screen_subscription_offer_body">ต่ออายุทุกปีหลังจากรอบทดลองใช้ฟรี คุณสามารถยกเลิกได้ตลอดเวลาใน Google Play</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">ต่ออายุทุกปี คุณสามารถยกเลิกได้ตลอดเวลาใน Google Play</string>
+    <string name="upgrade_screen_iap_offer_title">ซื้อครั้งเดียว</string>
+    <string name="upgrade_screen_iap_offer_body">ชำระเงินครั้งเดียว ไม่มีการต่ออายุ</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">การสมัครสมาชิกยังคงใช้งานอยู่</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Google Play เพิ่งได้รับการตรวจสอบ แต่ไม่สามารถยืนยันการซื้อ Pro สำหรับบัญชีที่แอปนี้ใช้</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">บัญชีหลายบัญชีอาจทำให้ Google Play สับสน การติดตั้งแอปผ่านเว็บไซต์ Google Play จะทำให้มันเชื่อมโยงกับบัญชีเฉพาะเจาะจง</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">การซิงค์ Google Play อาจใช้เวลาสักครู่ ลองรีบูต ล้างแคชของ Google Play Store หรือเพียงแค่รอสักครู่</string>
+    <string name="upgrade_screen_restore_contact_hint">ยังติดอยู่หรือ? ติดต่อฝ่ายสนับสนุนจากอีเมลที่ใช้ซื้อ พร้อมแนบหมายเลขคำสั่งซื้อ Google Play ของคุณ</string>
 </resources>

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play hizmetleri kullanılamıyor.</string>
     <string name="upgrades_no_purchases_found_check_account">Satın alma bulunamadı. Doğru hesabı mı kullanıyorsunuz?</string>
+    <string name="upgrades_gplay_already_owned_title">Zaten satın alındı</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play, bu yükseltmeye zaten sahip olduğunuzu belirtiyor, ancak geri yüklenemedi. Orijinal satın alma işlemi için kullanılan Google hesabıyla oturum açmış olduğunuzdan emin olun, ardından \"Satın almayı geri yükle\" seçeneğini deneyin.</string>
     <string name="upgrade_screen_preamble">Permission Pilot reklamsız ve gizliliğinize saygı gösteriyor. Yükseltme yapılması, sürekli geliştirmeyi destekler.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play kullanılamıyor</string>
+    <string name="upgrade_screen_offers_unavailable_message">Satın alma seçenekleri yüklenemedi. Google Play geçici olarak kullanılamıyor olabilir — bağlantınızı kontrol edin ve tekrar deneyin.</string>
     <string name="upgrade_screen_subscription_trial_action">Ücretsiz deneme süresini başlatın</string>
     <string name="upgrade_screen_subscription_action">Abone ol</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/yıl, istediğiniz zaman iptal edebilirsiniz</string>
-    <string name="upgrade_screen_iap_action">Pro Sürümü Satın Al</string>
+    <string name="upgrade_screen_iap_action">Tek seferlik satın alma</string>
     <string name="upgrade_screen_iap_action_hint">%s tek seferlik satın alma</string>
     <string name="upgrade_screen_restore_purchase_action">Satın almayı geri yükle</string>
     <string name="upgrade_screen_restore_purchase_message">Satın alma bulunamadı. Doğru Google hesabıyla giriş yaptığınızdan emin olun.</string>
+    <string name="upgrade_screen_restore_banner_title">Zaten Pro satın aldınız mı?</string>
+    <string name="upgrade_screen_restore_banner_body">Bu cihazda daha önce Pro\'ya yükseltme yaptığınız görülüyor. Satın almayı geri yükleyin ve kilidi açın.</string>
     <string name="upgrade_screen_options_description">Abonelikler otomatik olarak yenilenir. İstediğiniz zaman iptal edebilirsiniz.</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Pro\'sunuz — teşekkür ederiz!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Bir defaya mahsus Pro satın alımınız tüm Pro özelliklerini sonsuza kadar açar.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Aboneliğiniz tüm Pro özelliklerini açar.</string>
+    <string name="upgrade_screen_owned_sub_title">Aboneliğiniz</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Aboneliğiniz etkin ve otomatik olarak yenileniyor.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Aboneliğiniz süresi dolmak üzere ve yenilenmeyecektir. Pro\'yu süresi bitene kadar kullanabileceksiniz.</string>
+    <string name="upgrade_screen_owned_both_warning">Hem bir defaya mahsus Pro yükseltmesine hem de etkin bir aboneliğe sahipsiniz. İkisine de ihtiyacınız yok — daha fazla ücretlerden kaçınmak için Google Play\'den aboneliği iptal edin.</string>
+    <string name="upgrade_screen_manage_subscription_action">Aboneliği yönet</string>
+    <string name="upgrade_screen_owned_iap_title">Ömür Boyu Pro</string>
+    <string name="upgrade_screen_owned_iap_body">Bir defaya mahsus Pro yükseltmesine sahipsiniz. Abonelik yok, yenileme yok.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Tek seferlik satın almaya geç</string>
+    <string name="upgrade_screen_switch_purchase_note">Aboneliğiniz yenilenmiyor, bu nedenle artık kalıcı tek seferlik Pro satın almaya geçebilirsiniz.</string>
+    <string name="upgrade_screen_switch_locked_note">Tek seferlik satın almaya geçmek için önce Google Play\'de aboneliğinizi iptal edin. Bu teklif yenilenmeyecek şekilde ayarlandığında açılır.</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play yalnızca şu anda oturum açtığınız hesabı kontrol eder. Tek seferlik satın alma, aboneliğinizden ayrıdır.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Aboneliğiniz hala aktif ve yenileniyor. Önce Google Play\'de iptal edin.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Aboneliğiniz Google Play ile doğrulanamadı. Lütfen tekrar deneyin.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">Satın alımınız doğrulanıyor</string>
+    <string name="upgrade_screen_grace_body">Google Play\'in Pro satın alımınızı yeniden doğrulaması bekleniyor. Bu genellikle kendi başına çözülür.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Pro satın alımınızı Google Play ile yeniden doğrulayamıyoruz. Bu sorun devam ederse, satın alımınızı geri yüklemeyi deneyin veya destek ekibi ile iletişime geçin.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">Durum yanlış mı görünüyor?</string>
+    <string name="upgrade_screen_restore_status_body">Eğer Pro satın aldıysanız ancak gösterilmiyorsa, Google Play\'de canlı bir kontrol çalıştırın.</string>
+    <string name="upgrade_screen_restore_success_message">Satın alma geri yüklendi.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Satın almak için kullandığınız Google hesabıyla oturum açtığınızdan emin olun. Google Play\'de canlı bir kontrol yeni yapıldı.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Yükseltme seçenekleri</string>
+    <string name="upgrade_screen_offers_body">Aynı özellikler, farklı fiyatlandırma modelleri.</string>
+    <string name="upgrade_screen_offers_or">veya</string>
+    <string name="upgrade_screen_subscription_offer_title">Yıllık abonelik</string>
+    <string name="upgrade_screen_subscription_offer_body">Ücretsiz deneme döneminden sonra her yıl yenilenir. Google Play\'den istediğiniz zaman iptal edebilirsiniz.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Yılda bir kez yenilenir. Google Play\'de istediğiniz zaman iptal edin.</string>
+    <string name="upgrade_screen_iap_offer_title">Bir kez satın al</string>
+    <string name="upgrade_screen_iap_offer_body">Tek ödeme, yenileme yok.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">Abonelik hâlâ aktif</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Google Play az önce kontrol edildi, ancak bu uygulama tarafından kullanılan hesap için Pro satın alımı doğrulanamadı.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Birden fazla hesap Google Play\'i karıştırabilir. Belirli bir hesapla ilişkilendirmeye zorlayan Google Play web sitesi üzerinden uygulamayı yükleyin.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Google Play senkronizasyonu zaman alabilir. Yeniden başlatmayı, Google Play Store önbelleğini temizlemeyi veya sadece beklemeyi deneyin.</string>
+    <string name="upgrade_screen_restore_contact_hint">Hâlâ takılı kaldınız mı? Satın almayı yapan e-posta hesabından destek birimiyle iletişime geçin ve Google Play sipariş numaranızı ekleyin.</string>
 </resources>

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Сервіси Google Play недоступні.</string>
     <string name="upgrades_no_purchases_found_check_account">Покупки не знайдено. Ви використовуєте правильний обліковий запис?</string>
+    <string name="upgrades_gplay_already_owned_title">Вже придбано</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play повідомляє, що ви вже володієте цим оновленням, але його не вдалося відновити. Переконайтесь, що ви увійшли з обліковим записом Google, який використовувався для початкової покупки, а потім спробуйте «Відновити покупку».</string>
     <string name="upgrade_screen_preamble">Permission Pilot без реклами і поважає вашу приватність. Оновлення підтримує подальшу розробку.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play недоступний</string>
+    <string name="upgrade_screen_offers_unavailable_message">Не вдалося завантажити параметри покупки. Google Play тимчасово може бути недоступний — перевірте з\'єднання та спробуйте ще раз.</string>
     <string name="upgrade_screen_subscription_trial_action">Випробувати пробний період</string>
     <string name="upgrade_screen_subscription_action">Підписатися</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/рік, скасуйте у будь-який час</string>
-    <string name="upgrade_screen_iap_action">Придбати Pro</string>
+    <string name="upgrade_screen_iap_action">Одноразова покупка</string>
     <string name="upgrade_screen_iap_action_hint">Одноразова покупка %s</string>
     <string name="upgrade_screen_restore_purchase_action">Відновити покупку</string>
     <string name="upgrade_screen_restore_purchase_message">Покупок не знайдено. Перевірте, що ви ввійшли з правильним обліковим записом Google.</string>
+    <string name="upgrade_screen_restore_banner_title">Вже купили Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Схоже, раніше ви оновили цей пристрій до Pro. Відновіть вашу покупку, щоб розблокувати його ще раз.</string>
     <string name="upgrade_screen_options_description">Підписки поновлюються автоматично. Скасувати можна будь-коли.</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Ви маєте Pro — дякуємо!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Ваша одноразова покупка Pro розблокує всі функції Pro навічно.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Ваша підписка розблокує всі функції Pro.</string>
+    <string name="upgrade_screen_owned_sub_title">Ваша підписка</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Ваша підписка активна і автоматично поновлюється.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Ваша підписка припиниться й не поновиться. Ви матимете Pro до її закінчення.</string>
+    <string name="upgrade_screen_owned_both_warning">Ви маєте одноразове оновлення Pro і також активну підписку. Вам не потрібні обидва — скасуйте підписку в Google Play, щоб уникнути подальших платежів.</string>
+    <string name="upgrade_screen_manage_subscription_action">Керування підпискою</string>
+    <string name="upgrade_screen_owned_iap_title">Безстрокове Pro</string>
+    <string name="upgrade_screen_owned_iap_body">Ви маєте одноразове оновлення Pro. Без підписки, без поновлень.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Перейти на одноразову покупку</string>
+    <string name="upgrade_screen_switch_purchase_note">Ваша підписка не поновиться, тому зараз ви можете перейти на постійну одноразову покупку Pro.</string>
+    <string name="upgrade_screen_switch_locked_note">Щоб перейти на одноразову покупку, спочатку скасуйте підписку в Google Play. Пропозиція розблокується, коли буде припинено поновлення.</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play перевіряє лише обліковий запис, в якому ви зараз увійшли. Разова покупка відокремлена від вашої підписки.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Ваша підписка все ще активна і поновлюється. Спочатку скасуйте її в Google Play.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Не вдалося перевірити вашу підписку в Google Play. Будь ласка, спробуйте ще раз.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">Підтвердження вашої покупки</string>
+    <string name="upgrade_screen_grace_body">Очікування повторного підтвердження вашої Pro покупки в Google Play. Зазвичай це розв\'язується само собою.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Ми все ще не можемо повторно підтвердити вашу Pro покупку в Google Play. Якщо це продовжує відбуватися, спробуйте відновити покупку або зв\'яжіться з підтримкою.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">Статус виглядає невірним?</string>
+    <string name="upgrade_screen_restore_status_body">Якщо ви придбали Pro, але це не показується, виконайте пряму перевірку в Google Play.</string>
+    <string name="upgrade_screen_restore_success_message">Покупку відновлено.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Переконайтеся, що ви увійшли за допомогою облікового запису Google, який використовували для покупки. Пряма перевірка в Google Play щойно була виконана.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Варіанти оновлення</string>
+    <string name="upgrade_screen_offers_body">Ті ж функції, просто різні моделі ціноутворення.</string>
+    <string name="upgrade_screen_offers_or">або</string>
+    <string name="upgrade_screen_subscription_offer_title">Щорічна підписка</string>
+    <string name="upgrade_screen_subscription_offer_body">Поновлюється щороку після безплатного періоду. Скасуйте будь-коли в Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Поновлюється щороку. Скасуйте будь-коли в Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Купити один раз</string>
+    <string name="upgrade_screen_iap_offer_body">Один платіж, без поновлень.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">Підписка все ще активна</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Google Play щойно перевірено, але не вдалося підтвердити покупку Pro для облікового запису, який використовує ця програма.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Кілька акаунтів можуть спричинити проблеми в Google Play. Встановлення програми через веб-сайт Google Play примушує її асоціюватися з конкретним акаунтом.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Синхронізація Google Play може зайняти деякий час. Спробуйте перезавантажити пристрій, очистити кеш Google Play Store або просто почекайте.</string>
+    <string name="upgrade_screen_restore_contact_hint">Все ще застрягли? Зв\'яжіться з підтримкою, використовуючи електронну пошту, яка здійснила покупку, та вкажіть номер замовлення Google Play.</string>
 </resources>

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Dịch vụ Google Play không khả dụng.</string>
     <string name="upgrades_no_purchases_found_check_account">Không tìm thấy giao dịch mua nào. Bạn có đang sử dụng đúng tài khoản không?</string>
+    <string name="upgrades_gplay_already_owned_title">Đã mua</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play báo cáo rằng bạn đã sở hữu nâng cấp này, nhưng không thể khôi phục được. Kiểm tra rằng bạn đã đăng nhập bằng tài khoản Google được sử dụng để mua hàng ban đầu, sau đó hãy thử \"Khôi phục mua hàng\".</string>
     <string name="upgrade_screen_preamble">Permission Pilot không có quảng cáo và tôn trọng quyền riêng tư của bạn. Việc nâng cấp ủng hộ quá trình phát triển liên tục.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play không khả dụng</string>
+    <string name="upgrade_screen_offers_unavailable_message">Không thể tải các tùy chọn mua hàng. Google Play có thể không khả dụng tạm thời — kiểm tra kết nối của bạn và thử lại.</string>
     <string name="upgrade_screen_subscription_trial_action">Bắt đầu dùng thử miễn phí</string>
     <string name="upgrade_screen_subscription_action">Đăng ký</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/năm, hủy bất cứ lúc nào</string>
-    <string name="upgrade_screen_iap_action">Mua Pro</string>
+    <string name="upgrade_screen_iap_action">Thanh toán một lần</string>
     <string name="upgrade_screen_iap_action_hint">Mua một lần với giá %s</string>
     <string name="upgrade_screen_restore_purchase_action">Khôi phục thanh toán</string>
     <string name="upgrade_screen_restore_purchase_message">Không tìm thấy giao dịch mua nào. Hãy kiểm tra xem bạn đã đăng nhập bằng tài khoản Google đúng chưa.</string>
+    <string name="upgrade_screen_restore_banner_title">Đã mua Pro rồi?</string>
+    <string name="upgrade_screen_restore_banner_body">Có vẻ như bạn đã nâng cấp lên Pro trên thiết bị này trước đó. Khôi phục mua hàng của bạn để mở khóa lại.</string>
     <string name="upgrade_screen_options_description">Đăng ký sẽ tự động gia hạn. Bạn có thể hủy bất kỳ lúc nào.</string>
     <string name="upgrade_title_suffix">Pro</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">Bạn là Pro — cảm ơn bạn!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Mua hàng Pro một lần của bạn mở khóa mọi tính năng Pro, mãi mãi.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Gói đăng ký của bạn mở khóa mọi tính năng Pro.</string>
+    <string name="upgrade_screen_owned_sub_title">Gói đăng ký của bạn</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Gói đăng ký của bạn đang hoạt động và tự động gia hạn.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Gói đăng ký của bạn được đặt để hết hạn và sẽ không gia hạn. Bạn sẽ giữ Pro cho đến khi nó kết thúc.</string>
+    <string name="upgrade_screen_owned_both_warning">Bạn sở hữu nâng cấp Pro một lần và cũng có gói đăng ký đang hoạt động. Bạn không cần cả hai — hủy gói đăng ký trong Google Play để tránh các khoản phí tiếp theo.</string>
+    <string name="upgrade_screen_manage_subscription_action">Quản lý gói đăng ký</string>
+    <string name="upgrade_screen_owned_iap_title">Pro Trọn đời</string>
+    <string name="upgrade_screen_owned_iap_body">Bạn sở hữu nâng cấp Pro một lần. Không có gói đăng ký, không có gia hạn.</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Chuyển sang mua một lần</string>
+    <string name="upgrade_screen_switch_purchase_note">Gói đăng ký của bạn sẽ không tự động gia hạn, vì vậy bạn có thể chuyển sang lần mua Pro vĩnh viễn ngay bây giờ.</string>
+    <string name="upgrade_screen_switch_locked_note">Để chuyển sang lần mua một lần, trước tiên hãy hủy gói đăng ký của bạn trong Google Play. Ưu đãi này sẽ được mở khóa khi bạn đặt để không tự động gia hạn.</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play chỉ kiểm tra tài khoản bạn đang đăng nhập. Lần mua một lần này riêng biệt từ gói đăng ký của bạn.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Gói đăng ký của bạn vẫn còn hoạt động và đang tự động gia hạn. Hãy hủy nó trong Google Play trước.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Không thể xác minh gói đăng ký của bạn với Google Play. Vui lòng thử lại.</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">Đang xác nhận lần mua của bạn</string>
+    <string name="upgrade_screen_grace_body">Đang chờ Google Play xác nhận lại lần mua Pro của bạn. Điều này thường tự động giải quyết.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Chúng tôi vẫn không thể xác nhận lại lần mua Pro của bạn với Google Play. Nếu điều này tiếp tục xảy ra, hãy thử khôi phục lần mua của bạn hoặc liên hệ với bộ phận hỗ trợ.</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">Trạng thái có vẻ không đúng?</string>
+    <string name="upgrade_screen_restore_status_body">Nếu bạn đã mua Pro nhưng nó không hiển thị, hãy chạy kiểm tra trực tiếp với Google Play.</string>
+    <string name="upgrade_screen_restore_success_message">Mua hàng đã được khôi phục.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Hãy đảm bảo bạn đã đăng nhập bằng tài khoản Google mà bạn đã sử dụng để mua hàng. Kiểm tra trực tiếp với Google Play vừa chạy.</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">Tùy chọn nâng cấp</string>
+    <string name="upgrade_screen_offers_body">Các tính năng giống nhau, chỉ là các mô hình định giá khác nhau.</string>
+    <string name="upgrade_screen_offers_or">hoặc</string>
+    <string name="upgrade_screen_subscription_offer_title">Gói đăng ký hàng năm</string>
+    <string name="upgrade_screen_subscription_offer_body">Gia hạn hàng năm sau khoảng thời gian dùng thử miễn phí. Hủy bất kỳ lúc nào trong Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Gia hạn hàng năm. Hủy bất kỳ lúc nào trong Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Mua một lần</string>
+    <string name="upgrade_screen_iap_offer_body">Một lần thanh toán, không có gia hạn.</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">Gói đăng ký vẫn còn hoạt động</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">Vừa kiểm tra Google Play, nhưng không thể xác nhận mua Pro cho tài khoản mà ứng dụng đang sử dụng.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Nhiều tài khoản có thể làm Google Play nhầm lẫn. Cài đặt ứng dụng từ trang web Google Play sẽ buộc nó liên kết với một tài khoản cụ thể.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Đồng bộ hóa Google Play có thể mất một lúc. Hãy thử khởi động lại, xóa bộ nhớ đệm Google Play Store hoặc chỉ chờ đợi.</string>
+    <string name="upgrade_screen_restore_contact_hint">Vẫn gặp vấn đề? Liên hệ hỗ trợ từ email đã thực hiện mua hàng và kèm theo số đơn hàng Google Play của bạn.</string>
 </resources>

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">Google Play 服务不可用。</string>
     <string name="upgrades_no_purchases_found_check_account">未找到购买记录。您使用的是正确的账户吗？</string>
+    <string name="upgrades_gplay_already_owned_title">已购买</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play 报告您已拥有此升级，但无法恢复。请检查您是否使用原始购买所用的 Google 帐户登录，然后尝试“恢复购买”。</string>
     <string name="upgrade_screen_preamble">Permission Pilot 无广告且尊重您的隐私。升级支持持续开发。</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play 不可用</string>
+    <string name="upgrade_screen_offers_unavailable_message">无法加载购买选项。Google Play 可能暂时不可用，请检查您的连接并重试。</string>
     <string name="upgrade_screen_subscription_trial_action">开始免费试用</string>
     <string name="upgrade_screen_subscription_action">订阅</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/年，随时可取消</string>
-    <string name="upgrade_screen_iap_action">购买专业版</string>
+    <string name="upgrade_screen_iap_action">一次性购买</string>
     <string name="upgrade_screen_iap_action_hint">一次性购买 %s</string>
     <string name="upgrade_screen_restore_purchase_action">恢复购买</string>
     <string name="upgrade_screen_restore_purchase_message">未找到购买记录。请确认您已使用正确的 Google 账户登录。</string>
+    <string name="upgrade_screen_restore_banner_title">已购买 Pro？</string>
+    <string name="upgrade_screen_restore_banner_body">看起来您之前在此设备上升级到 Pro。恢复您的购买以再次解锁。</string>
     <string name="upgrade_screen_options_description">订阅自动续费，可随时取消。</string>
     <string name="upgrade_title_suffix">专业版</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">您是 Pro 用户，感谢您！</string>
+    <string name="upgrade_screen_owned_hero_iap_body">您的一次性 Pro 购买永久解锁所有 Pro 功能。</string>
+    <string name="upgrade_screen_owned_hero_sub_body">您的订阅解锁所有 Pro 功能。</string>
+    <string name="upgrade_screen_owned_sub_title">您的订阅</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">您的订阅处于活跃状态，会自动续订。</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">您的订阅已设置为过期且不会续订。您将保留 Pro 直到订阅结束。</string>
+    <string name="upgrade_screen_owned_both_warning">您既拥有一次性 Pro 升级，也有一个活跃的订阅。您无需同时拥有两者，请在 Google Play 中取消订阅以避免继续扣费。</string>
+    <string name="upgrade_screen_manage_subscription_action">管理订阅</string>
+    <string name="upgrade_screen_owned_iap_title">终身 Pro</string>
+    <string name="upgrade_screen_owned_iap_body">您拥有一次性 Pro 升级。无需订阅，无需续订。</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">切换为一次性购买</string>
+    <string name="upgrade_screen_switch_purchase_note">您的订阅将不会续期，因此您现在可以切换到永久的一次性 Pro 购买。</string>
+    <string name="upgrade_screen_switch_locked_note">要切换到一次性购买，请先在 Google Play 中取消您的订阅。设置为不续期后，该优惠才会解锁。</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play 只会检查您当前登录的账户。一次性购买与您的订阅是分开的。</string>
+    <string name="upgrade_screen_sub_still_renewing_message">您的订阅仍然有效且将继续续期。请先在 Google Play 中取消。</string>
+    <string name="upgrade_screen_sub_check_failed_message">无法与 Google Play 验证您的订阅。请重试。</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">正在确认您的购买</string>
+    <string name="upgrade_screen_grace_body">正在等待 Google Play 重新确认您的 Pro 购买。这通常会自动解决。</string>
+    <string name="upgrade_screen_grace_diagnostics_body">我们仍无法与 Google Play 重新确认您的 Pro 购买。如果问题持续出现，请尝试恢复购买或联系支持。</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">状态看起来不对？</string>
+    <string name="upgrade_screen_restore_status_body">如果您已购买 Pro 但未显示，请针对 Google Play 运行实时检查。</string>
+    <string name="upgrade_screen_restore_success_message">购买已恢复。</string>
+    <string name="upgrade_screen_restore_webinstall_hint">请确保您使用购买时所用的 Google 账户登录。刚才已针对 Google Play 运行了实时检查。</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">升级选项</string>
+    <string name="upgrade_screen_offers_body">功能相同，只是定价模式不同。</string>
+    <string name="upgrade_screen_offers_or">或</string>
+    <string name="upgrade_screen_subscription_offer_title">年度订阅</string>
+    <string name="upgrade_screen_subscription_offer_body">免费试用后每年续约。可随时在 Google Play 中取消。</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">每年续订。可随时在 Google Play 中取消。</string>
+    <string name="upgrade_screen_iap_offer_title">一次性购买</string>
+    <string name="upgrade_screen_iap_offer_body">一次性付款，无需续订。</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">订阅仍在有效期内</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">已检查 Google Play，但无法为此应用所用的账户确认 Pro 购买。</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">多个账户可能会导致 Google Play 出现问题。通过 Google Play 网站安装应用可确保其与特定账户关联。</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Google Play 同步可能需要一些时间。请尝试重启、清除 Google Play Store 缓存或耐心等待。</string>
+    <string name="upgrade_screen_restore_contact_hint">问题仍未解决？请从进行购买的电子邮件地址联系支持，并提供您的 Google Play 订单号。</string>
 </resources>

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -2,14 +2,65 @@
 <resources>
     <string name="upgrades_gplay_unavailable_error">目前無法取用 Google Play 服務</string>
     <string name="upgrades_no_purchases_found_check_account">找不到購買紀錄，請確認使用的帳號是否正確。</string>
+    <string name="upgrades_gplay_already_owned_title">已購買</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play 報告您已擁有此升級，但無法復原。請檢查您是否使用原始購買所用的 Google 帳戶登入，然後嘗試「復原購買」。</string>
     <string name="upgrade_screen_preamble">Permission Pilot 無廣告且尊重您的隱私。升級可支持持續開發。</string>
+    <string name="upgrade_screen_offers_unavailable_title">Google Play 無法使用</string>
+    <string name="upgrade_screen_offers_unavailable_message">無法載入購買選項。Google Play 可能暫時無法使用——請檢查您的連線並重試。</string>
     <string name="upgrade_screen_subscription_trial_action">開始免費試用</string>
     <string name="upgrade_screen_subscription_action">訂閱</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/年，隨時可取消</string>
-    <string name="upgrade_screen_iap_action">購買 Pro</string>
+    <string name="upgrade_screen_iap_action">一次購買</string>
     <string name="upgrade_screen_iap_action_hint">一次性購買 %s</string>
     <string name="upgrade_screen_restore_purchase_action">還原購買</string>
     <string name="upgrade_screen_restore_purchase_message">找不到購買記錄。請確認您已使用正確的 Google 帳號登入。</string>
+    <string name="upgrade_screen_restore_banner_title">已購買 Pro？</string>
+    <string name="upgrade_screen_restore_banner_body">看起來您之前在此裝置上升級至 Pro。復原您的購買以重新解鎖。</string>
     <string name="upgrade_screen_options_description">訂閱自動續費。您可隨時取消。</string>
     <string name="upgrade_title_suffix">專業版</string>
+    <!-- Settings entry title (Play flavor) -->
+    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
+    <!-- Ownership / status -->
+    <string name="upgrade_screen_owned_hero_title">您已升級至 Pro——感謝您！</string>
+    <string name="upgrade_screen_owned_hero_iap_body">您的一次性 Pro 購買解鎖所有 Pro 功能，永久有效。</string>
+    <string name="upgrade_screen_owned_hero_sub_body">您的訂閱解鎖所有 Pro 功能。</string>
+    <string name="upgrade_screen_owned_sub_title">您的訂閱</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">您的訂閱處於有效狀態，將自動更新。</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">您的訂閱設定為過期且不會更新。在訂閱結束前，您將保持 Pro 狀態。</string>
+    <string name="upgrade_screen_owned_both_warning">您同時擁有一次性 Pro 升級和有效訂閱。您不需要兩者——取消 Google Play 中的訂閱以避免進一步扣費。</string>
+    <string name="upgrade_screen_manage_subscription_action">管理訂閱</string>
+    <string name="upgrade_screen_owned_iap_title">終身 Pro</string>
+    <string name="upgrade_screen_owned_iap_body">您擁有一次性 Pro 升級。無需訂閱，無需更新。</string>
+    <!-- Switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">切換為一次性購買</string>
+    <string name="upgrade_screen_switch_purchase_note">您的訂閱不會更新，因此您現在可以轉換為永久一次性 Pro 購買。</string>
+    <string name="upgrade_screen_switch_locked_note">若要切換到一次性購買，請先在 Google Play 中取消訂閱。將訂閱設為不自動續約後，此優惠即會解鎖。</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play 只會檢查您目前登入的帳戶。一次性購買與您的訂閱是分開的。</string>
+    <string name="upgrade_screen_sub_still_renewing_message">您的訂閱仍處於活動狀態且正在續約。請先在 Google Play 中取消訂閱。</string>
+    <string name="upgrade_screen_sub_check_failed_message">無法透過 Google Play 驗證您的訂閱。請重試。</string>
+    <!-- Grace (waiting for Play to re-confirm) -->
+    <string name="upgrade_screen_grace_title">正在確認您的購買</string>
+    <string name="upgrade_screen_grace_body">等待 Google Play 重新確認您的 Pro 購買。這通常會自動解決。</string>
+    <string name="upgrade_screen_grace_diagnostics_body">我們仍然無法透過 Google Play 重新確認您的 Pro 購買。如果問題持續發生，請嘗試恢復購買或聯絡支援。</string>
+    <!-- Restore -->
+    <string name="upgrade_screen_restore_status_title">狀態看起來有誤？</string>
+    <string name="upgrade_screen_restore_status_body">如果您已購買 Pro 但未顯示，請對 Google Play 執行即時檢查。</string>
+    <string name="upgrade_screen_restore_success_message">購買已恢復。</string>
+    <string name="upgrade_screen_restore_webinstall_hint">請確保您已登入購買時使用的 Google 帳戶。剛剛執行了 Google Play 即時檢查。</string>
+    <!-- Upgrade options card -->
+    <string name="upgrade_screen_offers_title">升級選項</string>
+    <string name="upgrade_screen_offers_body">功能相同，只是定價模式不同。</string>
+    <string name="upgrade_screen_offers_or">或</string>
+    <string name="upgrade_screen_subscription_offer_title">年度訂閱</string>
+    <string name="upgrade_screen_subscription_offer_body">免費試用後每年續訂。可在 Google Play 隨時取消。</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">每年續訂。可在 Google Play 隨時取消。</string>
+    <string name="upgrade_screen_iap_offer_title">一次性購買</string>
+    <string name="upgrade_screen_iap_offer_body">一次性付款，無需續訂。</string>
+    <!-- Subscription-still-renewing dialog (blocks the switch) -->
+    <string name="upgrade_screen_sub_still_renewing_title">訂閱仍然有效</string>
+    <!-- Failed-restore troubleshooting dialog -->
+    <string name="upgrade_screen_restore_checked_message">剛才檢查了 Google Play，但無法確認此應用程式所用帳戶的 Pro 購買記錄。</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">多個帳戶可能會導致 Google Play 混亂。透過 Google Play 網站安裝應用程式會強制將其與特定帳戶關聯。</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Google Play 同步可能需要一段時間。請嘗試重新啟動、清除 Google Play Store 快取或耐心等候。</string>
+    <string name="upgrade_screen_restore_contact_hint">仍未解決？請使用進行購買的電子郵件帳戶聯絡支援，並提供您的 Google Play 訂單編號。</string>
 </resources>

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -564,6 +564,8 @@
     <string name="upgrade_benefit_manifest_viewer">Blaai deur rou app-manifeste</string>
     <string name="general_upgrade_action">Opgradeer</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Opgradering-status en opsies</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">Watcher</string>
     <string name="watcher_dashboard_feature_title">Toestemmingswatcher</string>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -564,6 +564,8 @@
     <string name="upgrade_benefit_manifest_viewer">ደርቋል የመተግበሪያ ማኒፌስቶችን ከስዘ</string>
     <string name="general_upgrade_action">አሻሽል</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">ማሻሻያ ሁኔታ እና ምርጫ</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">ባለቸኛ</string>
     <string name="watcher_dashboard_feature_title">የፍቃድ ባለቸኛ</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -656,6 +656,8 @@
     <string name="upgrade_benefit_manifest_viewer">تصفح بيانات التطبيق الخام</string>
     <string name="general_upgrade_action">ترقية</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">حالة الترقية والخيارات</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">مراقب</string>
     <string name="watcher_dashboard_feature_title">مراقب الأذونات</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -564,6 +564,8 @@
     <string name="upgrade_benefit_manifest_viewer">Tətbiqin xam manifestalarına baxmaq</string>
     <string name="general_upgrade_action">Yüksəlt</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Yüksəltmə statusu və seçənəkləri</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">Nəzarətçi</string>
     <string name="watcher_dashboard_feature_title">İcazə Nəzarətçisi</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -610,6 +610,8 @@
     <string name="upgrade_benefit_manifest_viewer">Прагляд зыходных маніфестаў праграм</string>
     <string name="general_upgrade_action">Абнавіць</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Статус абнаўлення і варыянты</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">Назіральнік</string>
     <string name="watcher_dashboard_feature_title">Назіральнік дазволаў</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -564,6 +564,8 @@
     <string name="upgrade_benefit_manifest_viewer">Преглед на сурови манифести на приложения</string>
     <string name="general_upgrade_action">Надграждане</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Статус на обновлението и опции</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">Наблюдател</string>
     <string name="watcher_dashboard_feature_title">Наблюдател на разрешения</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -564,6 +564,8 @@
     <string name="upgrade_benefit_manifest_viewer">কাঁচা অ্যাপ ম্যানিফেস্ট ব্রাউজ করুন</string>
     <string name="general_upgrade_action">আপগ্রেড করুন</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">আপগ্রেড স্ট্যাটাস এবং বিকল্পসমূহ</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">রিপোর্টার</string>
     <string name="watcher_dashboard_feature_title">অনুমতি পর্যবেক্ষক</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -3,8 +3,8 @@
     <string name="app_name">Permission Pilot</string>
     <string name="label_help">Ajuda</string>
     <string name="general_error_label">Error</string>
-    <string name="general_load_error_title">No s\'ha pogut carregar les dades</string>
-    <string name="general_load_error_hint">Ha ocorregut un error en escannejar les aplicacions instal·lades.</string>
+    <string name="general_load_error_title">No s\'han pogut carregar les dades</string>
+    <string name="general_load_error_hint">S\'ha produït un error en escanejar les aplicacions instal·lades.</string>
     <string name="general_refresh_error_hint">L\'actualització ha fallat.</string>
     <string name="general_retry_action">Reintenta</string>
     <string name="general_share_action">Comparteix</string>
@@ -156,8 +156,8 @@
     <string name="apps_sort_install_source_label">Origen de la instal·lació</string>
     <string name="permissions_action_none_msg">Cap acció disponible per aquest permís</string>
     <string name="permissions_details_open_settings_action">Obre la configuració del sistema</string>
-    <string name="permissions_details_open_settings_content_description_x">Obrir els paràmetres del sistema per a %1$s</string>
-    <string name="permissions_details_open_settings_error">No s\'han pogut obrir els paràmetres per a aquest permís</string>
+    <string name="permissions_details_open_settings_content_description_x">Obre la configuració del sistema per a %1$s</string>
+    <string name="permissions_details_open_settings_error">No s\'ha pogut obrir la configuració per aquest permís</string>
     <string name="apps_filter_profile_secondary_label">Perfil(s) gestionat(s)</string>
     <string name="apps_filter_battery_optimization_label">Bateria personalitzada</string>
     <string name="apps_filter_accessibility_label">Accessibilitat</string>
@@ -564,6 +564,8 @@
     <string name="upgrade_benefit_manifest_viewer">Navega pels manifests d’aplicacions en brut</string>
     <string name="general_upgrade_action">Millora</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Estat de l\'actualització i opcions</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">Vigilant</string>
     <string name="watcher_dashboard_feature_title">Vigilant de permisos</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -610,6 +610,8 @@
     <string name="upgrade_benefit_manifest_viewer">Procházet surové manifesty aplikací</string>
     <string name="general_upgrade_action">Upgradovat</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Stav upgradu a možnosti</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">Hlídač</string>
     <string name="watcher_dashboard_feature_title">Hlídač oprávnění</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -564,6 +564,8 @@
     <string name="upgrade_benefit_manifest_viewer">Gennemse rå app-manifester</string>
     <string name="general_upgrade_action">Opgrader</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Opgraderingsstatus og indstillinger</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">Watcher</string>
     <string name="watcher_dashboard_feature_title">Tilladelsesovervåger</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -564,6 +564,8 @@
     <string name="upgrade_benefit_manifest_viewer">Roh-App-Manifeste durchsuchen</string>
     <string name="general_upgrade_action">Upgrade</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Upgrade-Status und Optionen</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">Watcher</string>
     <string name="watcher_dashboard_feature_title">Berechtigungs-Watcher</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -564,6 +564,8 @@
     <string name="upgrade_benefit_manifest_viewer">Περιήγηση σε raw manifests εφαρμογών</string>
     <string name="general_upgrade_action">Αναβάθμιση</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Κατάσταση αναβάθμισης και επιλογές</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">Παρατηρητής</string>
     <string name="watcher_dashboard_feature_title">Παρατηρητής Αδειών</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -564,6 +564,8 @@
     <string name="upgrade_benefit_manifest_viewer">Explorar manifiestos de apps sin procesar</string>
     <string name="general_upgrade_action">Actualizar</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Estado de actualización y opciones</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">Watcher</string>
     <string name="watcher_dashboard_feature_title">Permission Watcher</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -564,6 +564,8 @@
     <string name="upgrade_benefit_manifest_viewer">Selaa sovelluksen raakamanifesteja</string>
     <string name="general_upgrade_action">Päivitä</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Päivityksen tila ja vaihtoehdot</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">Tarkkailija</string>
     <string name="watcher_dashboard_feature_title">Luvantarkkailija</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -565,6 +565,8 @@
     <string name="upgrade_benefit_manifest_viewer">Parcourir les manifestes bruts des applis</string>
     <string name="general_upgrade_action">Surclasser</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Statut de la mise à niveau et options</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">Observateur</string>
     <string name="watcher_dashboard_feature_title">Observateur de permissions</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -564,6 +564,8 @@
     <string name="upgrade_benefit_manifest_viewer">कच्चे ऐप मेनिफेस्ट ब्राउज़ करें</string>
     <string name="general_upgrade_action">उन्नत करें</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">अपग्रेड की स्थिति और विकल्प</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">वॉचर</string>
     <string name="watcher_dashboard_feature_title">अनुमति वॉचर</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -587,6 +587,8 @@
     <string name="upgrade_benefit_manifest_viewer">Pregledaj neobrañene manifeste aplikacija</string>
     <string name="general_upgrade_action">Nadogradnja</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Stanje nadogradnje i mogućnosti</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">Pratič</string>
     <string name="watcher_dashboard_feature_title">Pratič dozvola</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -564,6 +564,8 @@
     <string name="upgrade_benefit_manifest_viewer">Nyers alkalmazás-manifestek böngészése</string>
     <string name="general_upgrade_action">Frissítés</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Frissítés állapota és lehetőségei</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">Figyelő</string>
     <string name="watcher_dashboard_feature_title">Jogosultság-figyelő</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -564,6 +564,8 @@
     <string name="upgrade_benefit_manifest_viewer">Sfoglia i manifest grezzi delle app</string>
     <string name="general_upgrade_action">Aggiorna</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Stato dell’aggiornamento e opzioni</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">Watcher</string>
     <string name="watcher_dashboard_feature_title">Watcher dei permessi</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -610,6 +610,8 @@
     <string name="upgrade_benefit_manifest_viewer">עיון במניפסטים גולמיים של אפליקציות</string>
     <string name="general_upgrade_action">שדרוג</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">סטטוס השדרוג ואפשרויות</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">צופה</string>
     <string name="watcher_dashboard_feature_title">צופה הרשאות</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -541,6 +541,8 @@
     <string name="upgrade_benefit_manifest_viewer">アプリの生のマニフェストを閲覧</string>
     <string name="general_upgrade_action">アップグレード</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">アップグレード状態とオプション</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">ウォッチャー</string>
     <string name="watcher_dashboard_feature_title">権限ウォッチャー</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -541,6 +541,8 @@
     <string name="upgrade_benefit_manifest_viewer">원시 앱 매니페스트 탐색</string>
     <string name="general_upgrade_action">업그레이드</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">업그레이드 상태 및 옵션</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">감시자</string>
     <string name="watcher_dashboard_feature_title">권한 감시자</string>

--- a/app/src/main/res/values-ku-rTR/strings.xml
+++ b/app/src/main/res/values-ku-rTR/strings.xml
@@ -564,6 +564,8 @@
     <string name="upgrade_benefit_manifest_viewer">Manîfestoyên xav ên sepaê bigere</string>
     <string name="general_upgrade_action">بەرزترکردن</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Rewşa Bulaş û Vebijark</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">چاودێر</string>
     <string name="watcher_dashboard_feature_title">چاودێری ئەجازە</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -564,6 +564,8 @@
     <string name="upgrade_benefit_manifest_viewer">Bla gjennom rå app-manifester</string>
     <string name="general_upgrade_action">Oppgrader</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Oppgraderingsstatus og alternativer</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">Vakt</string>
     <string name="watcher_dashboard_feature_title">Tillatelsesovervokat</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -564,6 +564,8 @@
     <string name="upgrade_benefit_manifest_viewer">Bekijk onbewerkte app-manifesten</string>
     <string name="general_upgrade_action">Upgraden</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Upgradestatus en opties</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">Watcher</string>
     <string name="watcher_dashboard_feature_title">Toestemmingswatcher</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -5,7 +5,7 @@
     <string name="general_error_label">Błąd</string>
     <string name="general_load_error_title">Nie można załadować danych</string>
     <string name="general_load_error_hint">Coś poszło nie tak podczas skanowania zainstalowanych aplikacji.</string>
-    <string name="general_refresh_error_hint">Odświeżanie nie powiodło się.</string>
+    <string name="general_refresh_error_hint">Odświeżanie nieudane.</string>
     <string name="general_retry_action">Ponów</string>
     <string name="general_share_action">Udostępnij</string>
     <string name="general_done_action">Gotowe</string>
@@ -610,6 +610,8 @@
     <string name="upgrade_benefit_manifest_viewer">Przeglądaj nieprzetworzone manifesty aplikacji</string>
     <string name="general_upgrade_action">Uaktualnij</string>
     <string name="upgrade_title_prefix">Pilot Uprawnień</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Status i opcje aktualizacji</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">Obserwator</string>
     <string name="watcher_dashboard_feature_title">Obserwator uprawnień</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -564,6 +564,8 @@
     <string name="upgrade_benefit_manifest_viewer">Navegar pelos manifestos brutos de apps</string>
     <string name="general_upgrade_action">Atualizar</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Status de atualização e opções</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">Observador</string>
     <string name="watcher_dashboard_feature_title">Observador de permissões</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -564,6 +564,8 @@
     <string name="upgrade_benefit_manifest_viewer">Navegar pelos manifestos brutos das aplicações</string>
     <string name="general_upgrade_action">Atualizar</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Estado e opções da atualização para Pro</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">Vigia</string>
     <string name="watcher_dashboard_feature_title">Vigia de permissões</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -587,6 +587,8 @@
     <string name="upgrade_benefit_manifest_viewer">Răsfoiește manifestele brute ale aplicațiilor</string>
     <string name="general_upgrade_action">Actualizează</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Status upgrade și opțiuni</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">Watcher</string>
     <string name="watcher_dashboard_feature_title">Permission Watcher</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -610,6 +610,8 @@
     <string name="upgrade_benefit_manifest_viewer">Просмотр разрых манифестов приложений</string>
     <string name="general_upgrade_action">Обновить</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Статус и параметры обновления</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">Наблюдатель</string>
     <string name="watcher_dashboard_feature_title">Наблюдатель разрешений</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -610,6 +610,8 @@
     <string name="upgrade_benefit_manifest_viewer">Prechádzať surové manifesty aplikácií</string>
     <string name="general_upgrade_action">Inovovať</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Stav upgradu a možnosti</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">Sleďovač</string>
     <string name="watcher_dashboard_feature_title">Sleďovač oprávnení</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -587,6 +587,8 @@
     <string name="upgrade_benefit_manifest_viewer">Прегледајте сирове манифесте апликација</string>
     <string name="general_upgrade_action">Надогради</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Статус унапређења и опције</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">Надзорник</string>
     <string name="watcher_dashboard_feature_title">Надзорник дозвола</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -564,6 +564,8 @@
     <string name="upgrade_benefit_manifest_viewer">Bläddra i råa appmanifest</string>
     <string name="general_upgrade_action">Uppgradera</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Uppgraderingsstatus och alternativ</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">Bevakning</string>
     <string name="watcher_dashboard_feature_title">Behörighetsbevakning</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -541,6 +541,8 @@
     <string name="upgrade_benefit_manifest_viewer">ดู Manifest ดิบของแอป</string>
     <string name="general_upgrade_action">อัปเกรด</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">สถานะการอัปเกรดและตัวเลือก</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">Watcher</string>
     <string name="watcher_dashboard_feature_title">ตัวตรวจจับสิทธิ์</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -564,6 +564,8 @@
     <string name="upgrade_benefit_manifest_viewer">Ham uygulama manifestolarına göz at</string>
     <string name="general_upgrade_action">Yükselt</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Yükseltme durumu ve seçenekleri</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">İzleyici</string>
     <string name="watcher_dashboard_feature_title">İzin İzleyici</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -610,6 +610,8 @@
     <string name="upgrade_benefit_manifest_viewer">Переглядати необроблені маніфести застосунків</string>
     <string name="general_upgrade_action">Оновити</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Статус оновлення та параметри</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">Спостерігач</string>
     <string name="watcher_dashboard_feature_title">Спостерігач дозволів</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -541,6 +541,8 @@
     <string name="upgrade_benefit_manifest_viewer">Duyệt manifest thô của ứng dụng</string>
     <string name="general_upgrade_action">Nâng cấp</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">Trạng thái nâng cấp và tùy chọn</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">Bộ theo dõi</string>
     <string name="watcher_dashboard_feature_title">Theo dõi Quyền</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -541,6 +541,8 @@
     <string name="upgrade_benefit_manifest_viewer">浏览原始应用清单</string>
     <string name="general_upgrade_action">升级</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">升级状态和选项</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">监控器</string>
     <string name="watcher_dashboard_feature_title">权限监控器</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -541,6 +541,8 @@
     <string name="upgrade_benefit_manifest_viewer">瀏覽原始應用程式清單</string>
     <string name="general_upgrade_action">升級</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
+    <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
+    <string name="settings_upgrade_description">升級狀態與選項</string>
     <!-- Permission Watcher -->
     <string name="watcher_tab_label">監控器</string>
     <string name="watcher_dashboard_feature_title">權限監控器</string>


### PR DESCRIPTION
## What changed

Updated app translations from Crowdin across 39 languages, covering the new Pro upgrade, purchase-restore and subscription-ownership screens added in recent releases.

Two contributions were rejected during validation and are not part of this update:

- The Portuguese (Portugal) store description had a Russian word substituted mid-sentence and the rest of that sentence truncated, so the whole file was left at its previous version.
- Three Kurdish (Sorani) strings had a stray Chinese character injected into the word for "search", and were restored to their previous translations.

## Technical Context

- Store-listing text is unchanged in this PR — the only incoming fastlane change was the corrupted pt-PT description, which was reverted.
- Widespread benign change across locales: `upgrade_screen_iap_action` moved from "Buy Pro" phrasing to "One-time purchase", tracking an earlier English source change.
- `upgrade_screen_owned_iap_title` is still untranslated ("Lifetime Pro") in Thai — that is Crowdin's current state and needs fixing upstream, not locally.
- Verified with `assembleFossDebug`; escaping, placeholder counts and format specifiers were checked per locale against the English sources.
