### PR TITLE
General: Path-scope Claude Code rules and split procedures into skills

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,11 +19,23 @@ Permission Pilot is an Android app that helps users understand and manage app pe
 
 ## Rules
 
-Detailed guidelines are in `.claude/rules/`:
-- `commit-guidelines.md` — Commit message format, PR description format, area prefixes
-- `build-commands.md` — Build, test, lint, screenshot, and release commands
-- `screenshots.md` — Play Store screenshot tracking, regeneration, and upload workflow
+Always loaded (`.claude/rules/`):
 - `architecture.md` — Module structure, patterns, base classes, data flow
 - `code-style.md` — Kotlin conventions, ViewModel/Compose patterns, logging
-- `testing.md` — Test locations, patterns, running tests
-- `localization.md` — String resources, naming conventions
+- `commit-guidelines.md` — Commit message format, PR description format, area prefixes
+- `build-commands.md` — Build, test, and lint commands
+
+Loaded only when touching matching files (`paths:` frontmatter):
+- `testing.md` — Test locations and patterns. Triggers on `app/src/{test,testGplay,testShared,androidTest,screenshotTest*}/`
+- `localization.md` — String resource conventions. Triggers on `app/src/*/res/values*/` and `fastlane/metadata/`
+- `screenshots.md`, `release.md` — one-line pointers that tell you to invoke the matching skill
+
+## Skills
+
+Multi-step procedures in `.claude/skills/`. The body loads only when invoked:
+- `/screenshots` — Play Store screenshot regeneration, smoke-locale tracking, and upload
+- `/release` — Version bumping and release tagging
+
+Read `testing.md` before deciding whether or how to add tests — a path trigger only fires once a matching file is actually read, so it won't have loaded while you're still deciding.
+
+**Do not add `paths:` to a skill.** On a skill it is restrictive, not additive: it gates the skill off entirely until a matching file is read, so `/screenshots` and `/release` become uninvocable by name. Path triggering for these two is handled by the pointer rules above instead.

--- a/.claude/rules/build-commands.md
+++ b/.claude/rules/build-commands.md
@@ -44,27 +44,7 @@
 
 ## Screenshots
 
-For the full regen + Play Store upload workflow (smoke-only tracking, on-demand full regen, manual upload), see `.claude/rules/screenshots.md`.
-
-```bash
-# Generate all localized screenshots (39 locales x 6 screens, batched)
-./fastlane/generate_screenshots.sh
-
-# Smoke test (6 locales for fast iteration)
-./fastlane/generate_screenshots.sh --smoke
-
-# Custom batch size
-./fastlane/generate_screenshots.sh --batch-size 4
-
-# Copy generated PNGs to fastlane metadata directories
-./fastlane/copy_screenshots.sh
-
-# Clean existing screenshots before copying
-./fastlane/copy_screenshots.sh --clean
-
-# Direct Gradle task (single batch, all locales — may OOM)
-./gradlew updateGplayDebugScreenshotTest
-```
+Screenshot generation and Play Store upload is a multi-step procedure — invoke the `/screenshots` skill.
 
 ## Release
 
@@ -72,11 +52,4 @@ For the full regen + Play Store upload workflow (smoke-only tracking, on-demand 
 ./gradlew assembleFossRelease assembleGplayRelease
 ```
 
-## Context Management
-
-When running gradle builds or tests, use the Task tool with a sub-agent to keep verbose output isolated from the main conversation context. The sub-agent should report back only:
-- Success or failure
-- Compilation errors with file paths and line numbers
-- Warning counts
-
-Run gradle directly in the main context only when the user explicitly requests full output.
+Version bumping and tagging is a separate procedure — invoke the `/release` skill.

--- a/.claude/rules/commit-guidelines.md
+++ b/.claude/rules/commit-guidelines.md
@@ -96,3 +96,7 @@ granted/denied status for BIND_DEVICE_ADMIN.
 
 - **Issue references**: Use "Closes #123", "Fixes #123", or "Resolves #123"
 - **Breaking changes**: Mark with "BREAKING:" prefix if applicable
+
+## Length
+
+Match the length of commit bodies and PR descriptions to what the change needs. Cover the substance, then stop — no filler sections, no redundant summaries, no restating the diff. A one-line change gets a one-line body. Both sections of the PR description are allowed to be short; an empty "Technical Context" is better than an invented one.

--- a/.claude/rules/localization.md
+++ b/.claude/rules/localization.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - "app/src/*/res/values*/**"
+  - "fastlane/metadata/**"
+---
+
 # Localization Guidelines
 
 ## String Extraction

--- a/.claude/rules/release.md
+++ b/.claude/rules/release.md
@@ -1,10 +1,12 @@
+---
+paths:
+  - "tools/release/**"
+  - "version.properties"
+  - "VERSION"
+  - ".github/workflows/**"
+  - ".github/RELEASING.md"
+---
+
 # Release
 
-Operator-facing release docs: see `.github/RELEASING.md`.
-
-## AI-relevant facts
-
-- `tools/release/bump.sh` is the single source of truth for version logic. Its versionCode formula must stay in sync with `buildSrc/src/main/java/ProjectConfig.kt`.
-- CI calls `bash tools/release/bump.sh --mode=check` on every PR through the `check-release-tooling` job in `code-checks.yml`. If you touch `version.properties` or `VERSION` by hand, run that command locally before committing.
-- `release-prepare.yml` is the only sanctioned path for bumping versions and creating release tags. Do not suggest editing `version.properties` directly, creating tags manually, or running the old `release.sh`.
-- `validate-tag` in `release-tag.yml` delegates to `bump.sh --mode=check --expected-tag=<tag>`. Both tag format and version file consistency are validated inside the script, not in YAML.
+You are working with release tooling. Invoke the `/release` skill before bumping a version or creating a tag — `bump.sh` is the single source of truth for version logic and `release-prepare.yml` is the only sanctioned path for bumps and tags.

--- a/.claude/rules/screenshots.md
+++ b/.claude/rules/screenshots.md
@@ -1,61 +1,11 @@
-# Play Store Screenshots
+---
+paths:
+  - "fastlane/**"
+  - "app/src/screenshotTest/**"
+  - "app/src/screenshotTestGplayDebug/**"
+  - "app/src/debug/java/eu/darken/myperm/screenshots/**"
+---
 
-## What's tracked in git
+# Screenshots
 
-- **Smoke locales (6)** — `en-US`, `de-DE`, `ja-JP`, `ar`, `zh-CN`, `pt-BR`. PNGs under `fastlane/metadata/android/<locale>/images/phoneScreenshots/` are committed for these locales only.
-- **Other 33 locales** — gitignored. Generated on demand for upload, not committed.
-
-The `.gitignore` rule (lines following `app/src/screenshotTest*/reference/`) ignores all phone screenshots and `!`-includes only the 6 smoke locales. The smoke set matches `SMOKE_LOCALES` in `fastlane/generate_screenshots.sh`.
-
-The `--smoke` mode of `generate_screenshots.sh` is also useful for fast UI iteration on representative LTR/RTL/CJK locales without rendering all 39.
-
-## Why smoke-only
-
-- **Reviewable diffs** — a screenshot refresh that only touches 6 × 6 = 36 PNGs is reviewable; 234 PNGs is not.
-- **Repo size** — keeps binary churn out of git history.
-- **Fastlane behavior** — `supply` skips locales with no local screenshot files, so unpushed locales keep whatever Play Store currently has. This is current Fastlane uploader behavior, not a Play Store guarantee.
-
-## Full regeneration + upload (on demand)
-
-1. **Generate** all 39 locales:
-   ```bash
-   ./fastlane/generate_screenshots.sh
-   ```
-   Batched gradle screenshot rendering (~20 batches, ~10–15 min). The script exits non-zero if the final PNG count differs from the expected 234 (39 × 6).
-
-2. **Copy** rendered PNGs into fastlane metadata dirs:
-   ```bash
-   ./fastlane/copy_screenshots.sh --clean
-   ```
-   Output: `fastlane/metadata/android/<locale>/images/phoneScreenshots/*.png` for all 39 locales.
-
-3. **Verify** count before upload:
-   ```bash
-   find fastlane/metadata/android -path "*/images/phoneScreenshots/*.png" | wc -l   # expect 234
-   ```
-
-4. **Upload** to Play Store:
-   ```bash
-   cd fastlane && bundle exec fastlane screenshots_only
-   ```
-   The lane invokes `remove_unsupported_languages.sh` first, which deletes `ckb-IR` and `ku-TR` translation dirs (and harmlessly errors on the other 14 absent dirs in its list).
-
-5. **Restore** working tree post-upload:
-   ```bash
-   git clean -fdX fastlane/metadata/android      # removes only ignored files (the 33 non-smoke screenshot sets)
-   git checkout -- fastlane/metadata/android/ckb-IR fastlane/metadata/android/ku-TR
-   ```
-   `git clean -fdX` removes only gitignored files, so tracked screenshots, translations, and listing assets are untouched. The `git checkout` restores the two translation dirs the lane deleted.
-
-## After the first smoke-only upload
-
-Spot-check at least one **non-smoke** locale (e.g. `fr-FR`) in Play Console → Store listing → that locale, and confirm screenshots are still present. This validates the "Fastlane skips locales with no local files" assumption against current Play Store behavior. If non-smoke locales lose their screenshots, the workflow needs adjustment (e.g. always upload the full 39 set, or revert the gitignore split).
-
-## When smoke screenshots change
-
-Re-rendering the 6 smoke locales is part of the normal `--smoke` test loop:
-```bash
-./fastlane/generate_screenshots.sh --smoke
-./fastlane/copy_screenshots.sh --clean
-```
-Resulting changes to the 6 smoke locale PNGs go into a normal commit (typically `Apps:` / `Permissions:` / `General:` depending on what UI changed).
+You are working with the Play Store screenshot pipeline. Invoke the `/screenshots` skill before regenerating, copying, or uploading screenshots — it covers the smoke-locale git split, the on-demand full regen, and the post-upload working-tree restore.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,3 +1,13 @@
+---
+paths:
+  - "app/src/test/**"
+  - "app/src/testGplay/**"
+  - "app/src/testShared/**"
+  - "app/src/androidTest/**"
+  - "app/src/screenshotTest/**"
+  - "app/src/screenshotTestGplayDebug/**"
+---
+
 # Testing Guidelines
 
 ## Test Locations
@@ -53,4 +63,4 @@ Compose preview-based screenshot tests (enabled by `android.experimental.enableS
 - **Screen content under test**: `app/src/debug/java/eu/darken/myperm/screenshots/ScreenshotContent.kt` — edit this file when updating what a screenshot shows
 - **Driven by**: `fastlane/generate_screenshots.sh`, which runs `./gradlew updateGplayDebugScreenshotTest` and patches `PlayStoreLocales.kt` per batch
 
-See `.claude/rules/build-commands.md` for the fastlane wrapper commands (`generate_screenshots.sh`, `copy_screenshots.sh`).
+For the fastlane wrapper commands (`generate_screenshots.sh`, `copy_screenshots.sh`) and the Play Store upload workflow, invoke the `/screenshots` skill.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,6 +21,7 @@
     "jvm-tools@claude-code-cafe": true,
     "frontend-design@claude-plugins-official": true,
     "kotlin-lsp@claude-plugins-official": true,
-    "support-investigator@claude-code-cafe": true
+    "support-investigator@claude-code-cafe": true,
+    "google-play@claude-code-cafe": true
   }
 }

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: release
+description: Version bumping and release tagging rules. bump.sh is the single source of truth for version logic; release-prepare.yml is the only sanctioned path for bumps and tags.
+when_to_use: When cutting a release, bumping a version, creating a release tag, or editing version.properties, VERSION, tools/release/, or the release CI workflows.
+---
+
+# Release
+
+Operator-facing release docs: see `.github/RELEASING.md`.
+
+## AI-relevant facts
+
+- `tools/release/bump.sh` is the single source of truth for version logic. Its versionCode formula must stay in sync with `buildSrc/src/main/java/ProjectConfig.kt`.
+- CI calls `bash tools/release/bump.sh --mode=check` on every PR through the `check-release-tooling` job in `code-checks.yml`. If you touch `version.properties` or `VERSION` by hand, run that command locally before committing.
+- `release-prepare.yml` is the only sanctioned path for bumping versions and creating release tags. Do not suggest editing `version.properties` directly, creating tags manually, or running the old `release.sh`.
+- `validate-tag` in `release-tag.yml` delegates to `bump.sh --mode=check --expected-tag=<tag>`. Both tag format and version file consistency are validated inside the script, not in YAML.

--- a/.claude/skills/screenshots/SKILL.md
+++ b/.claude/skills/screenshots/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: screenshots
+description: Play Store screenshot pipeline — regenerate localized screenshots, copy them into fastlane metadata, and upload to Play Store. Covers the smoke-only git tracking split and the post-upload working-tree restore.
+when_to_use: When regenerating, refreshing, or uploading Play Store screenshots, when smoke-locale PNGs need re-rendering after a UI change, or when working in fastlane/ or app/src/screenshotTest*/.
+effort: low
+---
+
+# Play Store Screenshots
+
+## What's tracked in git
+
+- **Smoke locales (6)** — `en-US`, `de-DE`, `ja-JP`, `ar`, `zh-CN`, `pt-BR`. PNGs under `fastlane/metadata/android/<locale>/images/phoneScreenshots/` are committed for these locales only.
+- **Other 33 locales** — gitignored. Generated on demand for upload, not committed.
+
+The `.gitignore` rule (lines following `app/src/screenshotTest*/reference/`) ignores all phone screenshots and `!`-includes only the 6 smoke locales. The smoke set matches `SMOKE_LOCALES` in `fastlane/generate_screenshots.sh`.
+
+The `--smoke` mode of `generate_screenshots.sh` is also useful for fast UI iteration on representative LTR/RTL/CJK locales without rendering all 39.
+
+## Why smoke-only
+
+- **Reviewable diffs** — a screenshot refresh that only touches 6 × 6 = 36 PNGs is reviewable; 234 PNGs is not.
+- **Repo size** — keeps binary churn out of git history.
+- **Fastlane behavior** — `supply` skips locales with no local screenshot files, so unpushed locales keep whatever Play Store currently has. This is current Fastlane uploader behavior, not a Play Store guarantee.
+
+## Full regeneration + upload (on demand)
+
+1. **Generate** all 39 locales:
+   ```bash
+   ./fastlane/generate_screenshots.sh
+   ```
+   Batched gradle screenshot rendering (~20 batches, ~10–15 min). The script exits non-zero if the final PNG count differs from the expected 234 (39 × 6).
+
+2. **Copy** rendered PNGs into fastlane metadata dirs:
+   ```bash
+   ./fastlane/copy_screenshots.sh --clean
+   ```
+   Output: `fastlane/metadata/android/<locale>/images/phoneScreenshots/*.png` for all 39 locales.
+
+3. **Verify** count before upload:
+   ```bash
+   find fastlane/metadata/android -path "*/images/phoneScreenshots/*.png" | wc -l   # expect 234
+   ```
+
+4. **Upload** to Play Store:
+   ```bash
+   cd fastlane && bundle exec fastlane screenshots_only
+   ```
+   The lane invokes `remove_unsupported_languages.sh` first, which deletes `ckb-IR` and `ku-TR` translation dirs (and harmlessly errors on the other 14 absent dirs in its list).
+
+5. **Restore** working tree post-upload:
+   ```bash
+   git clean -fdX fastlane/metadata/android      # removes only ignored files (the 33 non-smoke screenshot sets)
+   git checkout -- fastlane/metadata/android/ckb-IR fastlane/metadata/android/ku-TR
+   ```
+   `git clean -fdX` removes only gitignored files, so tracked screenshots, translations, and listing assets are untouched. The `git checkout` restores the two translation dirs the lane deleted.
+
+## After the first smoke-only upload
+
+Spot-check at least one **non-smoke** locale (e.g. `fr-FR`) in Play Console → Store listing → that locale, and confirm screenshots are still present. This validates the "Fastlane skips locales with no local files" assumption against current Play Store behavior. If non-smoke locales lose their screenshots, the workflow needs adjustment (e.g. always upload the full 39 set, or revert the gitignore split).
+
+## When smoke screenshots change
+
+Re-rendering the 6 smoke locales is part of the normal `--smoke` test loop:
+```bash
+./fastlane/generate_screenshots.sh --smoke
+./fastlane/copy_screenshots.sh --clean
+```
+Resulting changes to the 6 smoke locale PNGs go into a normal commit (typically `Apps:` / `Permissions:` / `General:` depending on what UI changed).


### PR DESCRIPTION
## What changed

No user-facing behavior change — this only touches Claude Code configuration under `.claude/`.

Every file in `.claude/rules/` loads unconditionally at session start, so each session carried the Play Store screenshot pipeline, the release procedure, test conventions and localization rules whether or not the task involved them. This scopes them so they load when relevant instead.

Also enables the `google-play` plugin in `settings.json`.

## Technical Context

- **Mechanism**: `.claude/rules/*.md` supports a `paths:` YAML frontmatter field — glob patterns that defer the rule until Claude reads a matching file. Rules without `paths` still load at launch.
- **`paths:` behaves differently on skills — this is the trap.** On a rule it defers; on a skill it *gates*, making the skill uninvocable by name until a matching file is read. An earlier revision of this branch set `paths:` on both skills, which broke `/screenshots` and `/release` cold — the exact intent-triggered case the split was meant to serve. The skills now carry no `paths:`, and `CLAUDE.md` documents the rule so it isn't reintroduced.
- **Two-part trigger**: the procedures live in `.claude/skills/` (body loads on invocation), and `rules/screenshots.md` / `rules/release.md` remain as one-line path-scoped pointers. Working inside `fastlane/` or `tools/release/` surfaces the pointer; asking for the workflow by name reaches the skill directly.
- **`effort: low` on the screenshot skill**: it runs fixed shell scripts and counts PNGs. Applied only there, not to any judgment-heavy path.
- **De-duplication**: the build-runner instruction existed in both the user-level `CLAUDE.md` and `build-commands.md`, and conflicted with the general "don't spawn subagents unless asked" guidance. It now lives in one place, framed as context isolation rather than a verification step.

### Verification

Run in fresh headless sessions against this branch:

| Probe | Result |
| --- | --- |
| `testing.md` loads after reading a test file | LOADED |
| `testing.md` absent with no matching read (control) | NONE |
| `Skill(screenshots)` invoked cold | loads |
| Pointer rule present after reading `fastlane/Fastfile` | YES |
| Pointer rule absent with no matching read (control) | NO |

Always-on instruction budget: 533 → 397 lines.