### PR TITLE
General: Improve the reliability of the upgrade and supporter screens

### DIFF
--- a/app/src/foss/java/eu/darken/myperm/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/foss/java/eu/darken/myperm/common/upgrade/ui/UpgradeScreen.kt
@@ -34,6 +34,10 @@ import eu.darken.myperm.common.error.ErrorEventHandler
 import eu.darken.myperm.common.navigation.NavigationEventHandler
 import eu.darken.myperm.common.navigation.Nav
 import androidx.compose.ui.unit.dp
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 
 // Which presentation the FOSS upgrade screen shows: the classic support pitch, or one of the
 // status views behind the settings "upgrade status" entry.
@@ -82,12 +86,13 @@ fun UpgradeScreenHost(
         }
     }
 
-    val view by vm.state.collectAsStateWithLifecycle()
+    val state by vm.state.collectAsStateWithLifecycle()
 
     UpgradeScreen(
         // Until the route binding lands (one frame): the default route keeps rendering the pitch
         // exactly as before, only the manage route waits for the status decision.
-        view = view ?: FossUpgradeView.PITCH.takeIf { !route.manage },
+        view = state?.view ?: FossUpgradeView.PITCH.takeIf { !route.manage },
+        supporterSince = state?.supporterSince,
         snackbarHostState = snackbarHostState,
         onGithubSponsors = vm::goGithubSponsors,
         onShowUpgradeOptions = vm::onShowUpgradeOptions,
@@ -98,6 +103,7 @@ fun UpgradeScreenHost(
 @Composable
 internal fun UpgradeScreen(
     view: FossUpgradeView? = FossUpgradeView.PITCH,
+    supporterSince: Instant? = null,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     onGithubSponsors: () -> Unit = {},
     onShowUpgradeOptions: () -> Unit = {},
@@ -128,6 +134,7 @@ internal fun UpgradeScreen(
 
             FossUpgradeView.STATUS_UPGRADED -> UpgradeStatusUpgradedContent(
                 paddingValues = paddingValues,
+                supporterSince = supporterSince,
                 onGithubSponsors = onGithubSponsors,
             )
         }
@@ -221,6 +228,7 @@ private fun UpgradeStatusFreeContent(
 @Composable
 private fun UpgradeStatusUpgradedContent(
     paddingValues: PaddingValues,
+    supporterSince: Instant? = null,
     onGithubSponsors: () -> Unit,
 ) {
     UpgradeScreenContent(
@@ -243,6 +251,15 @@ private fun UpgradeStatusUpgradedContent(
                 text = stringResource(R.string.upgrade_screen_status_upgraded_body),
                 style = MaterialTheme.typography.bodyMedium,
             )
+            supporterSince?.let { since ->
+                val formatter = remember {
+                    DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withZone(ZoneId.systemDefault())
+                }
+                Text(
+                    text = stringResource(R.string.upgrade_screen_supporter_since, formatter.format(since)),
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
         }
 
         UpgradeSectionCard(
@@ -300,6 +317,9 @@ private fun UpgradeScreenStatusFreePreview() {
 @Composable
 private fun UpgradeScreenStatusUpgradedPreview() {
     PreviewWrapper {
-        UpgradeScreen(view = FossUpgradeView.STATUS_UPGRADED)
+        UpgradeScreen(
+            view = FossUpgradeView.STATUS_UPGRADED,
+            supporterSince = Instant.ofEpochMilli(1_700_000_000_000L),
+        )
     }
 }

--- a/app/src/foss/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModel.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
+import java.time.Instant
 import javax.inject.Inject
 
 @HiltViewModel
@@ -43,20 +44,34 @@ class UpgradeViewModel @Inject constructor(
     // gets a status view first; the pitch only appears once a free user asks for the upgrade
     // options. Upgrading wins over that choice — completing the sponsor flow from the pitch must
     // land on the upgraded status, not back on the ask. null until the route is bound.
-    internal val state: StateFlow<FossUpgradeView?> = combine(
+    internal val state: StateFlow<State?> = combine(
         routeFlow,
         upgradeRepo.upgradeInfo,
         handle.getStateFlow(KEY_SHOW_UPGRADE_OPTIONS, false),
     ) { route, info, showOptions ->
-        when {
+        val view = when {
             route == null -> null
             route.manage && info.isPro -> FossUpgradeView.STATUS_UPGRADED
             route.manage && !showOptions -> FossUpgradeView.STATUS_FREE
             else -> FossUpgradeView.PITCH
         }
+        // Derived in the same emission as the view on purpose: a sibling flow would let the
+        // upgraded status render for a frame without the date it is supposed to carry.
+        view?.let {
+            State(
+                view = it,
+                supporterSince = info.upgradedAt.takeIf { _ -> it == FossUpgradeView.STATUS_UPGRADED },
+            )
+        }
     }.safeStateIn(
         initialValue = null,
-        onError = { FossUpgradeView.PITCH },
+        onError = { State(view = FossUpgradeView.PITCH) },
+    )
+
+    // internal like FossUpgradeView: the view enum is a screen-local presentation detail.
+    internal data class State(
+        val view: FossUpgradeView,
+        val supporterSince: Instant? = null,
     )
 
     init {
@@ -108,18 +123,21 @@ class UpgradeViewModel @Inject constructor(
 
     fun checkSponsorReturn() = launch {
         val pressedAt = handle.remove<Long>(KEY_SPONSOR_PRESSED_AT) ?: return@launch
+
+        // Evaluated before the duration: an already upgraded supporter (recurring donation button)
+        // has nothing left to unlock, and persisting again would rewrite their upgradedAt — visibly
+        // resetting the "supporter since" date the status screen shows them.
+        if (upgradeRepo.upgradeInfo.first().isPro) {
+            log(TAG) { "checkSponsorReturn(): Already upgraded, staying quiet" }
+            return@launch
+        }
+
         val elapsed = SystemClock.elapsedRealtime() - pressedAt
         log(TAG) { "checkSponsorReturn(): elapsed=${elapsed}ms" }
 
         if (elapsed < SPONSOR_DELAY_MS) {
-            // The nudge belongs to the unlock heuristic. An already upgraded user (recurring
-            // donation button) has nothing to unlock — peeking at the page needs no feedback.
-            if (upgradeRepo.upgradeInfo.first().isPro) {
-                log(TAG) { "checkSponsorReturn(): Too quick, but already upgraded, staying quiet" }
-            } else {
-                log(TAG) { "checkSponsorReturn(): Too quick, showing snackbar" }
-                snackbarEvents.tryEmit(R.string.upgrade_foss_sponsor_returned_early)
-            }
+            log(TAG) { "checkSponsorReturn(): Too quick, showing snackbar" }
+            snackbarEvents.tryEmit(R.string.upgrade_foss_sponsor_returned_early)
         } else {
             log(TAG) { "checkSponsorReturn(): Delay passed, persisting upgrade" }
             upgradeRepo.persistUpgrade()

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/BillingCache.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/BillingCache.kt
@@ -14,26 +14,34 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.myperm.common.datastore.basicReader
 import eu.darken.myperm.common.datastore.basicWriter
 import eu.darken.myperm.common.datastore.createValue
+import eu.darken.myperm.common.debug.logging.Logging.Priority.WARN
+import eu.darken.myperm.common.debug.logging.log
+import eu.darken.myperm.common.debug.logging.logTag
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
 
+// Retained PP resilience: installs that predate the DataStore move still carry their upgrade
+// state in the "settings_gplay" SharedPreferences file, and a corrupted store resets to empty
+// instead of crashing the app on every read.
+private val Context.billingCacheDataStore by preferencesDataStore(
+    name = "settings_gplay",
+    produceMigrations = { ctx -> listOf(SharedPreferencesMigration(ctx, "settings_gplay")) },
+    corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
+)
+
 @Singleton
-class BillingCache @Inject constructor(
-    @ApplicationContext private val context: Context,
+class BillingCache internal constructor(
+    private val dataStore: DataStore<Preferences>,
 ) {
 
-    // Retained PP resilience: installs that predate the DataStore move still carry their upgrade
-    // state in the "settings_gplay" SharedPreferences file, and a corrupted store resets to empty
-    // instead of crashing the app on every read.
-    private val Context.dataStore by preferencesDataStore(
-        name = "settings_gplay",
-        produceMigrations = { ctx -> listOf(SharedPreferencesMigration(ctx, "settings_gplay")) },
-        corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
-    )
+    @Inject constructor(@ApplicationContext context: Context) : this(context.billingCacheDataStore)
 
-    private val dataStore: DataStore<Preferences>
-        get() = context.dataStore
+    // Test seam: the bounded reads/writes below run on real dispatchers, so a virtual-time test
+    // cannot advance the production bound.
+    internal var cacheTimeoutMs: Long = CACHE_TIMEOUT_MS
 
     // Raw keys shared between the DataStoreValues and stampLastProState's transaction — one
     // source of truth for key name and encoding.
@@ -70,8 +78,15 @@ class BillingCache @Inject constructor(
         val proUnconfirmedSince: Long,
     )
 
+    // Bounded on purpose: a wedged DataStore file lock would otherwise hang the caller forever.
+    // A timeout must NOT fall back to the default snapshot -- that would report "never bought"
+    // for an install whose evidence merely couldn't be read, which is the exact distinction the
+    // debug-log header exists to make.
     suspend fun snapshot(): Snapshot {
-        val prefs = dataStore.data.first()
+        val prefs = withTimeoutOrNull(cacheTimeoutMs) { dataStore.data.first() } ?: run {
+            log(TAG, WARN) { "snapshot() timed out after ${cacheTimeoutMs}ms" }
+            throw IOException("BillingCache snapshot timed out after ${cacheTimeoutMs}ms")
+        }
         return Snapshot(
             lastProStateAt = prefs[lastProStateAtKey] ?: 0L,
             lastProStateSku = prefs[lastProStateSkuKey] ?: "",
@@ -87,11 +102,19 @@ class BillingCache @Inject constructor(
     // entitlement layer out of order) opened a still-valid episode that this older confirmation must
     // not erase.
     suspend fun stampLastProState(skuId: String, at: Long) {
-        dataStore.edit { prefs ->
-            prefs[lastProStateSkuKey] = skuId
-            prefs[lastProStateAtKey] = at
-            val episodeStart = prefs[proUnconfirmedSinceKey] ?: 0L
-            if (episodeStart in 1..at) prefs[proUnconfirmedSinceKey] = 0L
-        }
+        // Fail-soft: this decorates the entitlement path, it must never be the thing that blocks it.
+        withTimeoutOrNull(cacheTimeoutMs) {
+            dataStore.edit { prefs ->
+                prefs[lastProStateSkuKey] = skuId
+                prefs[lastProStateAtKey] = at
+                val episodeStart = prefs[proUnconfirmedSinceKey] ?: 0L
+                if (episodeStart in 1..at) prefs[proUnconfirmedSinceKey] = 0L
+            }
+        } ?: log(TAG, WARN) { "stampLastProState($skuId, $at) timed out after ${cacheTimeoutMs}ms, write skipped" }
+    }
+
+    companion object {
+        private const val CACHE_TIMEOUT_MS = 2_000L
+        private val TAG = logTag("Upgrade", "Gplay", "BillingCache")
     }
 }

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/UpgradeDiagnosticsGplay.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/UpgradeDiagnosticsGplay.kt
@@ -1,31 +1,63 @@
 package eu.darken.myperm.common.upgrade.core
 
+import eu.darken.myperm.common.debug.logging.Logging.Priority.WARN
+import eu.darken.myperm.common.debug.logging.asLog
+import eu.darken.myperm.common.debug.logging.log
+import eu.darken.myperm.common.debug.logging.logTag
 import eu.darken.myperm.common.upgrade.UpgradeDiagnostics
+import eu.darken.myperm.main.core.CurriculumVitae
+import kotlinx.coroutines.CancellationException
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Reports the local billing cache into the debug log header.
+ * Reports the local billing cache and the lifetime Pro-state history into the debug log header.
  *
  * `lastProStateAt > 0` is the "this install once confirmed a real Pro purchase" bit. It predates
  * the CurriculumVitae pro-state counters by years and lives in a DataStore that was never migrated
  * or renamed, so it survives update chains that the newer counters can't speak to. Without it in
  * the header, a purchase complaint can't be told apart from a never-bought install.
  *
- * Depends on [BillingCache] alone -- see [UpgradeDiagnostics] for why this must not pull in
- * UpgradeRepoGplay.
+ * Depends on [BillingCache] and [CurriculumVitae] alone -- see [UpgradeDiagnostics] for why this
+ * must not pull in UpgradeRepoGplay.
  */
 @Singleton
 class UpgradeDiagnosticsGplay @Inject constructor(
     private val billingCache: BillingCache,
+    private val curriculumVitae: CurriculumVitae,
 ) : UpgradeDiagnostics {
 
     override suspend fun debugInfo(): String {
-        val snapshot = billingCache.snapshot()
-        val lastProAt = snapshot.lastProStateAt.takeIf { it > 0 }?.let { Instant.ofEpochMilli(it) } ?: "never"
-        val lastProSku = snapshot.lastProStateSku.takeIf { it.isNotEmpty() } ?: "unknown/legacy"
-        val unconfirmedSince = snapshot.proUnconfirmedSince.takeIf { it > 0 }?.let { Instant.ofEpochMilli(it) } ?: "none"
-        return "BillingCache(lastProStateAt=$lastProAt, lastProStateSku=$lastProSku, proUnconfirmedSince=$unconfirmedSince)"
+        val cache = try {
+            val snapshot = billingCache.snapshot()
+            val lastProAt = snapshot.lastProStateAt.takeIf { it > 0 }?.let { Instant.ofEpochMilli(it) } ?: "never"
+            val lastProSku = snapshot.lastProStateSku.takeIf { it.isNotEmpty() } ?: "unknown/legacy"
+            val unconfirmedSince =
+                snapshot.proUnconfirmedSince.takeIf { it > 0 }?.let { Instant.ofEpochMilli(it) } ?: "none"
+            "BillingCache(lastProStateAt=$lastProAt, lastProStateSku=$lastProSku, " +
+                "proUnconfirmedSince=$unconfirmedSince)"
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Billing cache unavailable: ${e.asLog()}" }
+            "BillingCache=unavailable"
+        }
+        // Separate boundary from the cache read above on purpose: these are different DataStores,
+        // and the counters only cover installs new enough to have them. A failure to read one must
+        // not suppress the other's independent evidence.
+        val history = try {
+            curriculumVitae.proHistory().toString()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Pro history unavailable: ${e.asLog()}" }
+            "unavailable"
+        }
+        return "$cache, ProHistory=$history"
+    }
+
+    companion object {
+        private val TAG = logTag("Upgrade", "Gplay", "Diagnostics")
     }
 }

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -29,6 +30,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import eu.darken.myperm.R
 import eu.darken.myperm.common.compose.Preview2
@@ -49,8 +52,9 @@ fun UpgradeScreenHost(
     val context = LocalContext.current
     val activity = context as? android.app.Activity
 
-    // No screen-level resume refresh: MainActivity already refreshes the upgrade repo on every
-    // activity resume, which covers returning from Play after cancelling the subscription there.
+    // MainActivity's per-resume refresh only covers the entitlement, never the screen-local SKU
+    // query — so a transient Play outage would leave the retry card up until it's tapped by hand.
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) { vm.onResume() }
 
     // rememberSaveable, not remember: these are driven by one-shot events that are already consumed
     // from the flow, so a rotation while a dialog is up would drop it for good.
@@ -368,14 +372,24 @@ private fun UpgradeOffersBox(
         when (state) {
             GplayUpgradeUiState.Loading -> UpgradeActionCard { UpgradeLoadingBlock() }
             is GplayUpgradeUiState.Unavailable -> UpgradeInlineStateCard(
-                title = stringResource(R.string.upgrades_gplay_unavailable_error),
+                title = stringResource(R.string.upgrade_screen_offers_unavailable_title),
                 body = stringResource(R.string.upgrade_screen_offers_unavailable_message),
                 icon = Icons.TwoTone.WarningAmber,
             ) {
                 // Play can be slow rather than broken (cold store, first sign-in): let
                 // the user re-run the offer queries instead of leaving a dead screen.
+                // No reset needed: this composable unmounts the moment the state leaves Unavailable.
+                var retryTapped by remember { mutableStateOf(false) }
                 OutlinedButton(
-                    onClick = onRetry,
+                    // Guard inside the callback, not just via `enabled`: `enabled` only takes effect
+                    // after recomposition, so two taps in the same frame would both fire.
+                    onClick = {
+                        if (!retryTapped) {
+                            retryTapped = true
+                            onRetry()
+                        }
+                    },
+                    enabled = !retryTapped,
                     modifier = Modifier
                         .fillMaxWidth()
                         .testTag(UpgradeScreenTags.GPLAY_RETRY),

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModel.kt
@@ -266,6 +266,14 @@ class UpgradeViewModel @Inject constructor(
         retryTrigger.update { it + 1 }
     }
 
+    // Returning to the screen is the user's own "try again": a transient Play outage would
+    // otherwise leave the retry card up until it's tapped by hand. Only re-queries from the
+    // unavailable state — a loaded or still-loading screen has nothing to retry.
+    fun onResume() {
+        log(TAG) { "onResume()" }
+        if (state.value is GplayUpgradeUiState.Unavailable) retrySkuQuery()
+    }
+
     // Acquires the single action slot. Rejects while ANY other entitlement action of this ViewModel
     // runs, and while the repo reports a Play launch in flight (which may belong to another VM
     // instance — the repo CAS remains the authoritative gate, this only avoids the pointless tap).

--- a/app/src/main/java/eu/darken/myperm/common/debug/recording/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/myperm/common/debug/recording/core/RecorderModule.kt
@@ -16,9 +16,9 @@ import eu.darken.myperm.common.debug.logging.log
 import eu.darken.myperm.common.debug.logging.logTag
 import eu.darken.myperm.common.flow.DynamicStateFlow
 import eu.darken.myperm.common.upgrade.UpgradeDiagnostics
-import eu.darken.myperm.main.core.CurriculumVitae
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.withContext
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -42,7 +43,6 @@ class RecorderModule @Inject constructor(
     @AppScope private val appScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
     private val installId: InstallId,
-    private val curriculumVitae: CurriculumVitae,
     private val upgradeDiagnostics: UpgradeDiagnostics,
 ) {
 
@@ -99,11 +99,18 @@ class RecorderModule @Inject constructor(
 
                         try {
                             logRecordingHeader()
-                        } catch (e: CancellationException) {
-                            // The recorder is already running at this point: bailing out without
-                            // stopping it would leave a live recorder the module no longer tracks.
-                            newRecorder.stop()
-                            currentLogDir = null
+                        } catch (e: Exception) {
+                            // The recorder is already live but not yet committed to the state: an
+                            // exception escaping the header would abandon it where stopRecorder()
+                            // can't reach it.
+                            withContext(NonCancellable) {
+                                try {
+                                    newRecorder.stop()
+                                } catch (stopError: Exception) {
+                                    e.addSuppressed(stopError)
+                                }
+                                currentLogDir = null
+                            }
                             throw e
                         }
 
@@ -145,20 +152,6 @@ class RecorderModule @Inject constructor(
         log(TAG, INFO) { "Build.Fingerprint: ${Build.FINGERPRINT}" }
         log(TAG, INFO) { "BuildConfig.Versions: ${BuildConfigWrap.VERSION_DESCRIPTION}" }
 
-        try {
-            // Billing complaints usually arrive as debug logs: having the lifetime grace/Pro-loss
-            // history in the header saves a support round-trip.
-            log(TAG, INFO) { "Pro history: ${curriculumVitae.proHistory()}" }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            // Diagnostics only — a broken history read must not stop the recorder from starting.
-            log(TAG, WARN) { "Pro history unavailable: ${e.asLog()}" }
-        }
-
-        // Separate boundary from the block above on purpose: these read different DataStores, and
-        // the counters above only cover installs new enough to have them. A failure to read one
-        // must not suppress the other's independent evidence.
         try {
             upgradeDiagnostics.debugInfo()?.let { log(TAG, INFO) { "Upgrade diagnostics: $it" } }
         } catch (e: CancellationException) {

--- a/app/src/test/java/eu/darken/myperm/common/debug/recording/core/RecorderModuleDiagnosticsTest.kt
+++ b/app/src/test/java/eu/darken/myperm/common/debug/recording/core/RecorderModuleDiagnosticsTest.kt
@@ -1,11 +1,11 @@
 package eu.darken.myperm.common.debug.recording.core
 
 import androidx.test.core.app.ApplicationProvider
+import eu.darken.myperm.common.BuildConfigWrap
 import eu.darken.myperm.common.InstallId
 import eu.darken.myperm.common.debug.logging.FileLogger
 import eu.darken.myperm.common.debug.logging.Logging
 import eu.darken.myperm.common.upgrade.UpgradeDiagnostics
-import eu.darken.myperm.main.core.CurriculumVitae
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -13,8 +13,13 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -28,10 +33,11 @@ import testhelper.coroutine.TestDispatcherProvider
 import testhelpers.TestApplication
 
 /**
- * The recording header reads two independent diagnostics sources. Both reads happen AFTER the
- * recorder is already writing, so a failure in either must never abort the state update — that
+ * The recording header reads diagnostics that live outside the recorder. Those reads happen AFTER
+ * the recorder is already writing, so a guarded failure must never abort the state update — that
  * would leave a running recorder the module no longer knows about, i.e. a debug recording that
- * can't be stopped or collected.
+ * can't be stopped or collected. Failures that DO escape the header have to take the uncommitted
+ * recorder down with them.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33], application = TestApplication::class)
@@ -39,7 +45,6 @@ class RecorderModuleDiagnosticsTest : BaseTest() {
 
     private fun buildModule(
         scope: CoroutineScope,
-        curriculumVitae: CurriculumVitae,
         upgradeDiagnostics: UpgradeDiagnostics,
     ) = RecorderModule(
         context = ApplicationProvider.getApplicationContext(),
@@ -48,123 +53,41 @@ class RecorderModuleDiagnosticsTest : BaseTest() {
         installId = mockk<InstallId>(relaxed = true).apply {
             every { id } returns "abcdef12-0000-0000-0000-000000000000"
         },
-        curriculumVitae = curriculumVitae,
         upgradeDiagnostics = upgradeDiagnostics,
     )
 
-    private fun emptyHistory() = CurriculumVitae.ProHistory(
-        lastState = null,
-        graceEngagedCount = 0,
-        graceEngagedLast = null,
-        proLostCount = 0,
-        proLostLast = null,
-    )
-
-    @Test
-    fun `both diagnostics sources are read into the header`() = runTest {
-        val cv = mockk<CurriculumVitae>()
-        coEvery { cv.proHistory() } returns emptyHistory()
-        val diagnostics = mockk<UpgradeDiagnostics>()
-        coEvery { diagnostics.debugInfo() } returns "BillingCache(...)"
-
-        val module = buildModule(backgroundScope, cv, diagnostics)
-
-        val logDir = module.startRecorder()
-        logDir.exists() shouldBe true
-
-        coVerify { cv.proHistory() }
-        coVerify { diagnostics.debugInfo() }
-
-        module.stopRecorder().shouldNotBeNull()
-    }
-
-    @Test
-    fun `a failing pro-history read still leaves a tracked recording`() = runTest {
-        val cv = mockk<CurriculumVitae>()
-        coEvery { cv.proHistory() } throws IllegalStateException("history unreadable")
-        val diagnostics = mockk<UpgradeDiagnostics>()
-        coEvery { diagnostics.debugInfo() } returns "BillingCache(...)"
-
-        val module = buildModule(backgroundScope, cv, diagnostics)
-
-        module.startRecorder().shouldNotBeNull()
-        module.state.first { it.isRecording }.logDir.shouldNotBeNull()
-        // The other source is independent: its evidence must still be collected.
-        coVerify { diagnostics.debugInfo() }
-
-        module.stopRecorder().shouldNotBeNull()
-    }
-
     @Test
     fun `a failing upgrade-diagnostics read still leaves a tracked recording`() = runTest {
-        val cv = mockk<CurriculumVitae>()
-        coEvery { cv.proHistory() } returns emptyHistory()
         val diagnostics = mockk<UpgradeDiagnostics>()
         coEvery { diagnostics.debugInfo() } throws IllegalStateException("cache unreadable")
 
-        val module = buildModule(backgroundScope, cv, diagnostics)
-
-        module.startRecorder().shouldNotBeNull()
-        module.state.first { it.isRecording }.logDir.shouldNotBeNull()
-        coVerify { cv.proHistory() }
-
-        module.stopRecorder().shouldNotBeNull()
-    }
-
-    @Test
-    fun `both reads failing still leaves a tracked recording`() = runTest {
-        val cv = mockk<CurriculumVitae>()
-        coEvery { cv.proHistory() } throws IllegalStateException("history unreadable")
-        val diagnostics = mockk<UpgradeDiagnostics>()
-        coEvery { diagnostics.debugInfo() } throws IllegalStateException("cache unreadable")
-
-        val module = buildModule(backgroundScope, cv, diagnostics)
+        val module = buildModule(backgroundScope, diagnostics)
 
         val logDir = module.startRecorder()
         logDir.exists() shouldBe true
         module.state.first { it.isRecording }.logDir shouldBe logDir
+        module.currentLogDir shouldBe logDir
+        coVerify { diagnostics.debugInfo() }
 
         module.stopRecorder().shouldNotBeNull()
     }
 
     /**
-     * Cancellation is the one thing the header reads deliberately rethrow, so it is the one failure
-     * that can abort the state update. The recorder is already live at that point: it has to be
-     * stopped on the way out, or it keeps writing into a session the module no longer tracks.
+     * Cancellation is one of the failures that escape the header, so it is one of the failures that
+     * can abort the state update. The recorder is already live at that point: it has to be stopped
+     * on the way out, or it keeps writing into a session the module no longer tracks.
      *
      * The start is launched, not awaited: an aborted update never flips isRecording, so
      * startRecorder() stays suspended. The virtual-time delay is what lets the module's own
      * background collectors run to completion.
      */
     @Test
-    fun `a cancelled pro-history read stops the recorder instead of leaking it`() = runTest {
-        val fileLoggersBefore = Logging.loggers.filterIsInstance<FileLogger>()
-        val cv = mockk<CurriculumVitae>()
-        coEvery { cv.proHistory() } throws CancellationException("scope died mid-read")
-        val diagnostics = mockk<UpgradeDiagnostics>()
-        coEvery { diagnostics.debugInfo() } returns "BillingCache(...)"
-
-        val module = buildModule(backgroundScope, cv, diagnostics)
-
-        backgroundScope.launch { module.startRecorder() }
-        delay(1_000)
-
-        coVerify { cv.proHistory() }
-        module.state.first().isRecording shouldBe false
-        module.currentLogDir.shouldBeNull()
-        // The recorder that was already writing when the header aborted got stopped.
-        Logging.loggers.filterIsInstance<FileLogger>() shouldBe fileLoggersBefore
-    }
-
-    @Test
     fun `a cancelled upgrade-diagnostics read stops the recorder instead of leaking it`() = runTest {
         val fileLoggersBefore = Logging.loggers.filterIsInstance<FileLogger>()
-        val cv = mockk<CurriculumVitae>()
-        coEvery { cv.proHistory() } returns emptyHistory()
         val diagnostics = mockk<UpgradeDiagnostics>()
         coEvery { diagnostics.debugInfo() } throws CancellationException("scope died mid-read")
 
-        val module = buildModule(backgroundScope, cv, diagnostics)
+        val module = buildModule(backgroundScope, diagnostics)
 
         backgroundScope.launch { module.startRecorder() }
         delay(1_000)
@@ -172,6 +95,42 @@ class RecorderModuleDiagnosticsTest : BaseTest() {
         coVerify { diagnostics.debugInfo() }
         module.state.first().isRecording shouldBe false
         module.currentLogDir.shouldBeNull()
+        // The recorder that was already writing when the header aborted got stopped: its file
+        // logger is no longer installed.
         Logging.loggers.filterIsInstance<FileLogger>() shouldBe fileLoggersBefore
+    }
+
+    /**
+     * Same window as above, but for an ordinary failure instead of a cancellation. The header's
+     * injected sources are individually guarded, so the escape path is one of the unguarded first
+     * log lines — here the build description read.
+     */
+    @Test
+    fun `a failing header read stops the uncommitted recorder`() = runTest {
+        val fileLoggersBefore = Logging.loggers.filterIsInstance<FileLogger>()
+        val diagnostics = mockk<UpgradeDiagnostics>()
+        coEvery { diagnostics.debugInfo() } returns "BillingCache(...)"
+
+        mockkObject(BuildConfigWrap)
+        every { BuildConfigWrap.VERSION_DESCRIPTION } throws IllegalStateException("build info unreadable")
+
+        // Own scope: the escaping exception fails the collector, which must not fail the test's own
+        // scope. SupervisorJob keeps the module's state flow alive so it can be inspected after.
+        val moduleScope = CoroutineScope(coroutineContext + SupervisorJob() + CoroutineExceptionHandler { _, _ -> })
+        try {
+            val module = buildModule(moduleScope, diagnostics)
+
+            moduleScope.launch { module.startRecorder() }
+            delay(1_000)
+
+            module.state.first().isRecording shouldBe false
+            module.currentLogDir.shouldBeNull()
+            // Non-vacuity: without the guard's cleanup the started recorder's file logger would
+            // still be installed here.
+            Logging.loggers.filterIsInstance<FileLogger>() shouldBe fileLoggersBefore
+        } finally {
+            moduleScope.cancel()
+            unmockkObject(BuildConfigWrap)
+        }
     }
 }

--- a/app/src/test/java/eu/darken/myperm/common/debug/recording/core/RecorderModuleTest.kt
+++ b/app/src/test/java/eu/darken/myperm/common/debug/recording/core/RecorderModuleTest.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import eu.darken.myperm.common.InstallId
 import eu.darken.myperm.common.coroutine.DispatcherProvider
 import eu.darken.myperm.common.upgrade.UpgradeDiagnostics
-import eu.darken.myperm.main.core.CurriculumVitae
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -34,7 +33,6 @@ class RecorderModuleTest {
     private lateinit var installId: InstallId
     private lateinit var dispatcherProvider: DispatcherProvider
     private lateinit var appScope: CoroutineScope
-    private lateinit var curriculumVitae: CurriculumVitae
     private lateinit var upgradeDiagnostics: UpgradeDiagnostics
 
     @BeforeEach
@@ -54,7 +52,6 @@ class RecorderModuleTest {
 
         // Inert diagnostics: the header reads are covered by RecorderModuleDiagnosticsTest, these
         // fixtures only need them to not touch storage.
-        curriculumVitae = mockk(relaxed = true)
         upgradeDiagnostics = mockk(relaxed = true)
     }
 
@@ -73,7 +70,6 @@ class RecorderModuleTest {
             appScope = appScope,
             dispatcherProvider = dispatcherProvider,
             installId = installId,
-            curriculumVitae = curriculumVitae,
             upgradeDiagnostics = upgradeDiagnostics,
         )
     }
@@ -98,9 +94,8 @@ class RecorderModuleTest {
             appScope = pausedScope,
             dispatcherProvider = TestDispatcherProvider(StandardTestDispatcher()),
             installId = installId,
-            // Strict mocks: the construction path must not read either diagnostics source, so any
-            // call here fails the "construction touches no storage" assertion this test exists for.
-            curriculumVitae = mockk(),
+            // Strict mock: the construction path must not read the diagnostics source, so any call
+            // here fails the "construction touches no storage" assertion this test exists for.
             upgradeDiagnostics = mockk(),
         )
         pausedScope.cancel()

--- a/app/src/testFoss/java/eu/darken/myperm/common/upgrade/ui/FossUpgradeScreenHostTest.kt
+++ b/app/src/testFoss/java/eu/darken/myperm/common/upgrade/ui/FossUpgradeScreenHostTest.kt
@@ -1,0 +1,105 @@
+package eu.darken.myperm.common.upgrade.ui
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.SavedStateHandle
+import eu.darken.myperm.common.compose.PreviewWrapper
+import eu.darken.myperm.common.navigation.Nav
+import eu.darken.myperm.common.upgrade.core.UpgradeRepoFoss
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowSystemClock
+import testhelper.BaseTest
+import testhelper.coroutine.TestDispatcherProvider
+import testhelpers.TestApplication
+import java.time.Duration
+
+/**
+ * Host-level counterpart to the ViewModel's sponsor-return tests: those prove the ViewModel reacts,
+ * they cannot prove the screen actually bridges the lifecycle to it. Only a real STOP/RESUME
+ * round-trip catches a missing or mis-scoped lifecycle effect, or a tracker that isn't seeded from
+ * the handle after a recreation.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class FossUpgradeScreenHostTest : BaseTest() {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    private var persisted = 0
+
+    private fun mockRepo(): UpgradeRepoFoss = mockk<UpgradeRepoFoss>(relaxed = true).apply {
+        every { upgradeInfo } returns MutableStateFlow(UpgradeRepoFoss.Info())
+        coEvery { persistUpgrade() } answers { persisted++ }
+    }
+
+    private fun buildVm(
+        repo: UpgradeRepoFoss,
+        handle: SavedStateHandle = SavedStateHandle(),
+    ) = UpgradeViewModel(
+        handle = handle,
+        dispatcherProvider = TestDispatcherProvider(),
+        upgradeRepo = repo,
+    )
+
+    @Test
+    fun `a stop-resume round-trip after a sponsor launch runs the return check`() {
+        // The real ViewModel instance, passed explicitly: hiltViewModel() has nothing to resolve
+        // here. The route is passed explicitly too -- PP binds it through the host's own
+        // LaunchedEffect, not from a SavedStateHandle.
+        val vm = buildVm(mockRepo())
+
+        composeRule.setContent {
+            PreviewWrapper {
+                UpgradeScreenHost(route = Nav.Main.Upgrade(), vm = vm)
+            }
+        }
+        composeRule.waitForIdle()
+
+        vm.goGithubSponsors()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+
+        // CREATED, not STARTED: only that far down does the activity emit ON_STOP, which is what
+        // "the browser took the foreground" looks like to the return tracker.
+        composeRule.activityRule.scenario.moveToState(Lifecycle.State.CREATED)
+        composeRule.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+        composeRule.waitForIdle()
+
+        composeRule.waitUntil { persisted == 1 }
+        vm.hasPendingSponsorLaunch() shouldBe false
+    }
+
+    @Test
+    fun `a recreated screen consumes the pending sponsor launch on the first resume`() {
+        // Process death while the browser was in front: the fresh screen's tracker never saw the
+        // ON_STOP, so it has to be seeded from the handle or the first return is swallowed.
+        val handle = SavedStateHandle()
+        buildVm(mockRepo(), handle).goGithubSponsors()
+
+        val recreatedVm = buildVm(mockRepo(), handle)
+        recreatedVm.hasPendingSponsorLaunch() shouldBe true
+
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+
+        composeRule.setContent {
+            PreviewWrapper {
+                UpgradeScreenHost(route = Nav.Main.Upgrade(), vm = recreatedVm)
+            }
+        }
+        composeRule.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+        composeRule.waitForIdle()
+
+        composeRule.waitUntil { persisted == 1 }
+        recreatedVm.hasPendingSponsorLaunch() shouldBe false
+    }
+}

--- a/app/src/testFoss/java/eu/darken/myperm/common/upgrade/ui/FossUpgradeScreenTest.kt
+++ b/app/src/testFoss/java/eu/darken/myperm/common/upgrade/ui/FossUpgradeScreenTest.kt
@@ -15,6 +15,10 @@ import eu.darken.myperm.common.compose.PreviewWrapper
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import testhelpers.compose.BaseComposeRobolectricTest
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 
 class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
 
@@ -85,17 +89,37 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
 
     @Test
     fun `upgraded status view thanks the supporter and offers a recurring donation`() {
+        val since = Instant.ofEpochMilli(1_700_000_000_000L)
         composeRule.setUpgradeContent {
-            UpgradeScreen(view = FossUpgradeView.STATUS_UPGRADED)
+            UpgradeScreen(view = FossUpgradeView.STATUS_UPGRADED, supporterSince = since)
         }
 
         composeRule.onAllNodesWithText("${context.getString(R.string.upgrade_title_prefix)} ${context.getString(R.string.upgrade_title_suffix)}").assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_STATUS_UPGRADED).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_status_upgraded_body))
             .assertCountEquals(1)
+        val formatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withZone(ZoneId.systemDefault())
+        composeRule.onAllNodesWithText(
+            context.getString(R.string.upgrade_screen_supporter_since, formatter.format(since))
+        ).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_DONATE).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SHOW_OPTIONS).assertCountEquals(0)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SPONSOR).assertCountEquals(0)
+    }
+
+    @Test
+    fun `the supporter-since line stays away without a date`() {
+        // UpgradeRepoFoss can report an upgrade whose record predates the timestamp field: no date
+        // line instead of a bogus one.
+        composeRule.setUpgradeContent {
+            UpgradeScreen(view = FossUpgradeView.STATUS_UPGRADED, supporterSince = null)
+        }
+
+        val formatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withZone(ZoneId.systemDefault())
+        composeRule.onAllNodesWithText(
+            context.getString(R.string.upgrade_screen_supporter_since, formatter.format(Instant.EPOCH))
+        ).assertCountEquals(0)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_STATUS_UPGRADED).assertCountEquals(1)
     }
 
     @Test

--- a/app/src/testFoss/java/eu/darken/myperm/common/upgrade/ui/FossUpgradeViewModelTest.kt
+++ b/app/src/testFoss/java/eu/darken/myperm/common/upgrade/ui/FossUpgradeViewModelTest.kt
@@ -76,37 +76,69 @@ class FossUpgradeViewModelTest : BaseTest() {
     fun `manage route shows the free status to non-upgraded users`() = runTest2(context = testDispatcher) {
         val vm = buildVm()
 
-        val view = async { vm.state.first { it != null } }
+        val view = async { vm.state.first { it != null }!! }
         vm.bindRoute(Nav.Main.Upgrade(manage = true))
         advanceUntilIdle()
 
-        view.await() shouldBe FossUpgradeView.STATUS_FREE
+        view.await().view shouldBe FossUpgradeView.STATUS_FREE
     }
 
     @Test
     fun `manage route shows the upgraded status to supporters`() = runTest2(context = testDispatcher) {
         val vm = buildVm(repo = mockRepo(MutableStateFlow(upgradedInfo())))
 
-        val view = async { vm.state.first { it != null } }
+        val view = async { vm.state.first { it != null }!! }
         vm.bindRoute(Nav.Main.Upgrade(manage = true))
         advanceUntilIdle()
 
-        view.await() shouldBe FossUpgradeView.STATUS_UPGRADED
+        view.await().view shouldBe FossUpgradeView.STATUS_UPGRADED
+    }
+
+    @Test
+    fun `supporterSince reflects the repo's upgradedAt`() = runTest2(context = testDispatcher) {
+        // Derived in the same emission as the view: the upgraded status must never render a frame
+        // without the date it is supposed to carry.
+        val vm = buildVm(repo = mockRepo(MutableStateFlow(upgradedInfo())))
+
+        val state = async { vm.state.first { it != null }!! }
+        vm.bindRoute(Nav.Main.Upgrade(manage = true))
+        advanceUntilIdle()
+
+        state.await() shouldBe UpgradeViewModel.State(
+            view = FossUpgradeView.STATUS_UPGRADED,
+            supporterSince = Instant.EPOCH,
+        )
+    }
+
+    @Test
+    fun `only the upgraded status carries a supporter-since date`() = runTest2(context = testDispatcher) {
+        // The pitch and the free status have no supporter date to show; carrying a stale one would
+        // let it leak into a view that must not claim an upgrade.
+        val vm = buildVm(repo = mockRepo(MutableStateFlow(upgradedInfo())))
+
+        val state = async { vm.state.first { it != null }!! }
+        vm.bindRoute(Nav.Main.Upgrade(forced = true))
+        advanceUntilIdle()
+
+        state.await() shouldBe UpgradeViewModel.State(
+            view = FossUpgradeView.PITCH,
+            supporterSince = null,
+        )
     }
 
     @Test
     fun `default and forced routes show the pitch`() = runTest2(context = testDispatcher) {
         val defaultVm = buildVm()
-        val defaultView = async { defaultVm.state.first { it != null } }
+        val defaultView = async { defaultVm.state.first { it != null }!! }
         defaultVm.bindRoute(Nav.Main.Upgrade())
 
         val forcedVm = buildVm()
-        val forcedView = async { forcedVm.state.first { it != null } }
+        val forcedView = async { forcedVm.state.first { it != null }!! }
         forcedVm.bindRoute(Nav.Main.Upgrade(forced = true))
         advanceUntilIdle()
 
-        defaultView.await() shouldBe FossUpgradeView.PITCH
-        forcedView.await() shouldBe FossUpgradeView.PITCH
+        defaultView.await().view shouldBe FossUpgradeView.PITCH
+        forcedView.await().view shouldBe FossUpgradeView.PITCH
     }
 
     @Test
@@ -114,15 +146,15 @@ class FossUpgradeViewModelTest : BaseTest() {
         val vm = buildVm()
         vm.bindRoute(Nav.Main.Upgrade(manage = true))
 
-        val freeView = async { vm.state.first { it != null } }
+        val freeView = async { vm.state.first { it != null }!! }
         advanceUntilIdle()
-        freeView.await() shouldBe FossUpgradeView.STATUS_FREE
+        freeView.await().view shouldBe FossUpgradeView.STATUS_FREE
 
-        val pitchView = async { vm.state.first { it == FossUpgradeView.PITCH } }
+        val pitchView = async { vm.state.first { it?.view == FossUpgradeView.PITCH }!! }
         vm.onShowUpgradeOptions()
         advanceUntilIdle()
 
-        pitchView.await() shouldBe FossUpgradeView.PITCH
+        pitchView.await().view shouldBe FossUpgradeView.PITCH
     }
 
     @Test
@@ -135,11 +167,11 @@ class FossUpgradeViewModelTest : BaseTest() {
 
         // Same handle, fresh ViewModel — as after the process was killed on the pitch.
         val recreatedVm = buildVm(handle = handle)
-        val view = async { recreatedVm.state.first { it != null } }
+        val view = async { recreatedVm.state.first { it != null }!! }
         recreatedVm.bindRoute(Nav.Main.Upgrade(manage = true))
         advanceUntilIdle()
 
-        view.await() shouldBe FossUpgradeView.PITCH
+        view.await().view shouldBe FossUpgradeView.PITCH
     }
 
     @Test
@@ -151,15 +183,15 @@ class FossUpgradeViewModelTest : BaseTest() {
         vm.bindRoute(Nav.Main.Upgrade(manage = true))
         vm.onShowUpgradeOptions()
 
-        val pitchView = async { vm.state.first { it != null } }
+        val pitchView = async { vm.state.first { it != null }!! }
         advanceUntilIdle()
-        pitchView.await() shouldBe FossUpgradeView.PITCH
+        pitchView.await().view shouldBe FossUpgradeView.PITCH
 
-        val upgradedView = async { vm.state.first { it == FossUpgradeView.STATUS_UPGRADED } }
+        val upgradedView = async { vm.state.first { it?.view == FossUpgradeView.STATUS_UPGRADED }!! }
         info.value = upgradedInfo()
         advanceUntilIdle()
 
-        upgradedView.await() shouldBe FossUpgradeView.STATUS_UPGRADED
+        upgradedView.await().view shouldBe FossUpgradeView.STATUS_UPGRADED
     }
 
     @Test
@@ -266,5 +298,33 @@ class FossUpgradeViewModelTest : BaseTest() {
         coVerify(exactly = 1) { repo.persistUpgrade() }
         // Consumed: a later resume must not re-run the unlock.
         recreatedVm.hasPendingSponsorLaunch() shouldBe false
+    }
+
+    /**
+     * The recurring-donation button on the upgraded status screen goes to the same sponsors page,
+     * so an existing supporter routinely comes back past the delay. Persisting again would rewrite
+     * upgradedAt and visibly reset the "supporter since" date they are being shown.
+     */
+    @Test
+    fun `a returning supporter is not re-upgraded and keeps their supporter-since date`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val repo = mockRepo(MutableStateFlow(upgradedInfo()))
+        val vm = buildVm(repo = repo)
+        vm.bindRoute(Nav.Main.Upgrade(manage = true))
+
+        val before = async { vm.state.first { it != null }!! }
+        advanceUntilIdle()
+        before.await().supporterSince shouldBe Instant.EPOCH
+
+        vm.goGithubSponsors()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { repo.persistUpgrade() }
+        vm.state.value!!.supporterSince shouldBe Instant.EPOCH
+        // The launch is still consumed: a stale pending launch would fire on some later resume.
+        vm.hasPendingSponsorLaunch() shouldBe false
     }
 }

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/BillingCacheCorruptionTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/BillingCacheCorruptionTest.kt
@@ -1,0 +1,66 @@
+package eu.darken.myperm.common.upgrade.core
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelper.BaseTest
+import testhelpers.TestApplication
+import java.io.File
+
+/**
+ * PP keeps a [androidx.datastore.core.handlers.ReplaceFileCorruptionHandler] on the billing cache:
+ * a truncated or garbled `settings_gplay.preferences_pb` (interrupted write, storage fault) must
+ * reset the store to empty instead of throwing on every single read for the rest of the install's
+ * life — the upgrade screen and the debug-log header both read this store.
+ *
+ * The corrupt file is written BEFORE the cache is constructed — the store is only parsed on its
+ * first read, so a store created first would never see it.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class BillingCacheCorruptionTest : BaseTest() {
+
+    // One test method on purpose: DataStore forbids two active instances on the same file, and
+    // BillingCache is a @Singleton in production.
+    @Test
+    fun `a corrupted preferences file resets to defaults instead of failing every read`() = runTest {
+        // Real time on purpose: snapshot() is bounded by cacheTimeoutMs, and the real DataStore
+        // does its I/O off the test scheduler -- under virtual time the bound would fire instantly
+        // while nothing else is scheduled.
+        withContext(Dispatchers.IO) {
+            resetBillingCacheDataStore()
+            val context: Context = ApplicationProvider.getApplicationContext()
+
+            val storeFile = File(context.filesDir, "datastore/settings_gplay.preferences_pb")
+            storeFile.parentFile!!.mkdirs()
+            // Field number 0 is not a legal protobuf tag, so the preferences parser rejects this
+            // outright -- the same CorruptionException a half-written file produces.
+            storeFile.writeBytes(byteArrayOf(0x00, 0x01, 0x02, 0x03))
+
+            val cache = BillingCache(context)
+
+            // Not an exception, and not a hang: the never-bought triple. Losing the evidence is the
+            // accepted cost of a corrupted file; bricking every read is not.
+            cache.snapshot() shouldBe BillingCache.Snapshot(
+                lastProStateAt = 0L,
+                lastProStateSku = "",
+                proUnconfirmedSince = 0L,
+            )
+
+            // And the store is usable again afterwards, rather than re-throwing on the next write.
+            cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 4_242L)
+            cache.snapshot() shouldBe BillingCache.Snapshot(
+                lastProStateAt = 4_242L,
+                lastProStateSku = OurSku.Iap.PRO_UPGRADE.id,
+                proUnconfirmedSince = 0L,
+            )
+        }
+    }
+}

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/BillingCacheIsolation.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/BillingCacheIsolation.kt
@@ -1,0 +1,25 @@
+package eu.darken.myperm.common.upgrade.core
+
+/**
+ * Drops the cached DataStore behind the file-level `billingCacheDataStore` delegate.
+ *
+ * The delegate is a process-wide singleton (that is what makes it correct in production), but
+ * Robolectric reuses ONE sandbox classloader for every test class with the same `@Config`, while
+ * giving each test method a fresh `filesDir`. Without this reset the second test class to touch
+ * BillingCache gets the first class's live DataStore -- still serving the first class's values and
+ * still pointing at its deleted temp file. Every test here depends on a pristine FIRST access:
+ * that is when the SharedPreferences migration runs and when a corrupt file is detected.
+ *
+ * Fails loudly rather than silently no-op'ing: a renamed field would otherwise turn the isolation
+ * off and leave the tests passing on leaked state.
+ */
+internal fun resetBillingCacheDataStore() {
+    val delegateField = Class.forName("eu.darken.myperm.common.upgrade.core.BillingCacheKt")
+        .getDeclaredField("billingCacheDataStore\$delegate")
+        .apply { isAccessible = true }
+    val delegate = requireNotNull(delegateField.get(null)) { "billingCacheDataStore delegate is null" }
+    delegate.javaClass
+        .getDeclaredField("INSTANCE")
+        .apply { isAccessible = true }
+        .set(delegate, null)
+}

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/BillingCacheLegacyMigrationTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/BillingCacheLegacyMigrationTest.kt
@@ -3,7 +3,9 @@ package eu.darken.myperm.common.upgrade.core
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -28,36 +30,42 @@ class BillingCacheLegacyMigrationTest : BaseTest() {
     // BillingCache is a @Singleton in production.
     @Test
     fun `legacy SharedPreferences upgrade state survives the DataStore migration`() = runTest {
-        val context: Context = ApplicationProvider.getApplicationContext()
-        context.getSharedPreferences("settings_gplay", Context.MODE_PRIVATE)
-            .edit()
-            .putLong("gplay.cache.lastProAt", LEGACY_PRO_AT)
-            .putString("gplay.cache.lastProSku", OurSku.Iap.PRO_UPGRADE.id)
-            .commit()
+        // Real time on purpose: snapshot()/stampLastProState() are bounded by cacheTimeoutMs, and
+        // the real DataStore does its I/O off the test scheduler -- under virtual time the bound
+        // would fire instantly while nothing else is scheduled.
+        withContext(Dispatchers.IO) {
+            resetBillingCacheDataStore()
+            val context: Context = ApplicationProvider.getApplicationContext()
+            context.getSharedPreferences("settings_gplay", Context.MODE_PRIVATE)
+                .edit()
+                .putLong("gplay.cache.lastProAt", LEGACY_PRO_AT)
+                .putString("gplay.cache.lastProSku", OurSku.Iap.PRO_UPGRADE.id)
+                .commit()
 
-        val cache = BillingCache(context)
+            val cache = BillingCache(context)
 
-        cache.lastProStateAt.value() shouldBe LEGACY_PRO_AT
-        cache.lastProStateSku.value() shouldBe OurSku.Iap.PRO_UPGRADE.id
-        // The third key is new in this schema: legacy stores have no episode, so it must read as
-        // "no unconfirmed episode" rather than as a stale grace start.
-        cache.proUnconfirmedSince.value() shouldBe 0L
+            cache.lastProStateAt.value() shouldBe LEGACY_PRO_AT
+            cache.lastProStateSku.value() shouldBe OurSku.Iap.PRO_UPGRADE.id
+            // The third key is new in this schema: legacy stores have no episode, so it must read as
+            // "no unconfirmed episode" rather than as a stale grace start.
+            cache.proUnconfirmedSince.value() shouldBe 0L
 
-        cache.snapshot() shouldBe BillingCache.Snapshot(
-            lastProStateAt = LEGACY_PRO_AT,
-            lastProStateSku = OurSku.Iap.PRO_UPGRADE.id,
-            proUnconfirmedSince = 0L,
-        )
+            cache.snapshot() shouldBe BillingCache.Snapshot(
+                lastProStateAt = LEGACY_PRO_AT,
+                lastProStateSku = OurSku.Iap.PRO_UPGRADE.id,
+                proUnconfirmedSince = 0L,
+            )
 
-        // The migrated values are ordinary DataStore entries afterwards: the atomic stamp
-        // transaction has to keep operating on them consistently.
-        cache.stampLastProState(OurSku.Sub.PRO_UPGRADE.id, LEGACY_PRO_AT + 1_000L)
+            // The migrated values are ordinary DataStore entries afterwards: the atomic stamp
+            // transaction has to keep operating on them consistently.
+            cache.stampLastProState(OurSku.Sub.PRO_UPGRADE.id, LEGACY_PRO_AT + 1_000L)
 
-        cache.snapshot() shouldBe BillingCache.Snapshot(
-            lastProStateAt = LEGACY_PRO_AT + 1_000L,
-            lastProStateSku = OurSku.Sub.PRO_UPGRADE.id,
-            proUnconfirmedSince = 0L,
-        )
+            cache.snapshot() shouldBe BillingCache.Snapshot(
+                lastProStateAt = LEGACY_PRO_AT + 1_000L,
+                lastProStateSku = OurSku.Sub.PRO_UPGRADE.id,
+                proUnconfirmedSince = 0L,
+            )
+        }
     }
 
     companion object {

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/BillingCacheTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/BillingCacheTest.kt
@@ -1,68 +1,106 @@
 package eu.darken.myperm.common.upgrade.core
 
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
 import androidx.test.core.app.ApplicationProvider
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import testhelper.BaseTest
 import testhelpers.TestApplication
+import java.io.IOException
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33], application = TestApplication::class)
 class BillingCacheTest : BaseTest() {
 
-    // One test method on purpose: BillingCache is a @Singleton in production, and DataStore
-    // forbids two active instances on the same file — a second BillingCache in this process
-    // would crash, not exercise anything real.
+    // One real-instance test method on purpose: BillingCache is a @Singleton in production, and
+    // DataStore forbids two active instances on the same file — a second real BillingCache in this
+    // process would crash, not exercise anything real.
     @Test
     fun `stampLastProState round-trips through the DataStoreValues`() = runTest {
-        // Real DataStore, no mocks: this catches an encoding mismatch between the raw keys the
-        // atomic stamp transaction writes and the keys/types the DataStoreValues read.
-        val cache = BillingCache(ApplicationProvider.getApplicationContext())
+        // Real time on purpose: the reads/writes below are bounded by cacheTimeoutMs, and the real
+        // DataStore does its I/O off the test scheduler -- under virtual time the bound would fire
+        // instantly while nothing else is scheduled.
+        withContext(Dispatchers.IO) {
+            resetBillingCacheDataStore()
+            // Real DataStore, no mocks: this catches an encoding mismatch between the raw keys the
+            // atomic stamp transaction writes and the keys/types the DataStoreValues read.
+            val context: Context = ApplicationProvider.getApplicationContext()
+            val cache = BillingCache(context)
 
-        cache.lastProStateAt.value() shouldBe 0L
-        cache.lastProStateSku.value() shouldBe ""
+            cache.lastProStateAt.value() shouldBe 0L
+            cache.lastProStateSku.value() shouldBe ""
 
-        // Defaults on a never-Pro install: this exact triple is what the debug-log header reports
-        // as "never / unknown-legacy / none", and it's the signal that separates a never-bought
-        // install from one whose entitlement went missing.
-        cache.snapshot() shouldBe BillingCache.Snapshot(
-            lastProStateAt = 0L,
-            lastProStateSku = "",
-            proUnconfirmedSince = 0L,
-        )
+            // Defaults on a never-Pro install: this exact triple is what the debug-log header reports
+            // as "never / unknown-legacy / none", and it's the signal that separates a never-bought
+            // install from one whose entitlement went missing.
+            cache.snapshot() shouldBe BillingCache.Snapshot(
+                lastProStateAt = 0L,
+                lastProStateSku = "",
+                proUnconfirmedSince = 0L,
+            )
 
-        cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1234L)
+            cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1234L)
 
-        cache.lastProStateAt.value() shouldBe 1234L
-        cache.lastProStateSku.value() shouldBe OurSku.Iap.PRO_UPGRADE.id
+            cache.lastProStateAt.value() shouldBe 1234L
+            cache.lastProStateSku.value() shouldBe OurSku.Iap.PRO_UPGRADE.id
 
-        cache.stampLastProState(OurSku.Sub.PRO_UPGRADE.id, 5678L)
+            cache.stampLastProState(OurSku.Sub.PRO_UPGRADE.id, 5678L)
 
-        cache.lastProStateAt.value() shouldBe 5678L
-        cache.lastProStateSku.value() shouldBe OurSku.Sub.PRO_UPGRADE.id
+            cache.lastProStateAt.value() shouldBe 5678L
+            cache.lastProStateSku.value() shouldBe OurSku.Sub.PRO_UPGRADE.id
 
-        // Occurrence-aware episode clear: a confirmation closes an episode that began at or before
-        // it, but must leave a NEWER episode intact — a connection failure that occurred after this
-        // confirmation but was processed out of order opened a still-valid episode.
-        cache.proUnconfirmedSince.value(4_000L)
-        cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 5_000L) // confirmation newer than episode
-        cache.proUnconfirmedSince.value() shouldBe 0L
+            // Occurrence-aware episode clear: a confirmation closes an episode that began at or before
+            // it, but must leave a NEWER episode intact — a connection failure that occurred after this
+            // confirmation but was processed out of order opened a still-valid episode.
+            cache.proUnconfirmedSince.value(4_000L)
+            cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 5_000L) // confirmation newer than episode
+            cache.proUnconfirmedSince.value() shouldBe 0L
 
-        cache.proUnconfirmedSince.value(9_000L)
-        cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 8_000L) // confirmation older than episode
-        cache.proUnconfirmedSince.value() shouldBe 9_000L
+            cache.proUnconfirmedSince.value(9_000L)
+            cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 8_000L) // confirmation older than episode
+            cache.proUnconfirmedSince.value() shouldBe 9_000L
 
-        // snapshot() must agree with the individual reads. It exists so the debug-log header reads
-        // all three in ONE DataStore emission: three separate reads can straddle a concurrent
-        // stampLastProState and report a combination that never existed.
-        cache.snapshot() shouldBe BillingCache.Snapshot(
-            lastProStateAt = 8_000L,
-            lastProStateSku = OurSku.Iap.PRO_UPGRADE.id,
-            proUnconfirmedSince = 9_000L,
-        )
+            // snapshot() must agree with the individual reads. It exists so the debug-log header reads
+            // all three in ONE DataStore emission: three separate reads can straddle a concurrent
+            // stampLastProState and report a combination that never existed.
+            cache.snapshot() shouldBe BillingCache.Snapshot(
+                lastProStateAt = 8_000L,
+                lastProStateSku = OurSku.Iap.PRO_UPGRADE.id,
+                proUnconfirmedSince = 9_000L,
+            )
+        }
     }
+
+    @Test
+    fun `a wedged datastore is bounded, reads fail loudly and writes fail soft`() = runTest {
+        // Fake store, no file: a second real DataStore on the same file would crash this process.
+        val cache = BillingCache(HangingPreferencesDataStore()).apply { cacheTimeoutMs = 50L }
+
+        // A timeout must not masquerade as a default snapshot -- "never bought" and "couldn't read
+        // the evidence" are the two things the debug-log header exists to tell apart.
+        shouldThrow<IOException> { cache.snapshot() }
+
+        // The write only decorates the entitlement path, it must never block it.
+        cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1234L)
+    }
+}
+
+/** DataStore that never answers -- stands in for a wedged file lock. */
+internal class HangingPreferencesDataStore : DataStore<Preferences> {
+    override val data: Flow<Preferences> = flow { awaitCancellation() }
+
+    override suspend fun updateData(transform: suspend (Preferences) -> Preferences): Preferences =
+        awaitCancellation()
 }

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/UpgradeDiagnosticsGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/UpgradeDiagnosticsGplayTest.kt
@@ -1,17 +1,33 @@
 package eu.darken.myperm.common.upgrade.core
 
+import eu.darken.myperm.main.core.CurriculumVitae
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import io.mockk.coEvery
 import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import testhelper.BaseTest
 
 class UpgradeDiagnosticsGplayTest : BaseTest() {
 
-    private fun create(snapshot: BillingCache.Snapshot) = UpgradeDiagnosticsGplay(
-        billingCache = mockk<BillingCache>().apply { coEvery { this@apply.snapshot() } returns snapshot },
+    private val proHistory = CurriculumVitae.ProHistory(
+        lastState = CurriculumVitae.ProState.PURCHASED,
+        graceEngagedCount = 2,
+        graceEngagedLast = null,
+        proLostCount = 0,
+        proLostLast = null,
+    )
+
+    private fun create(
+        snapshot: () -> BillingCache.Snapshot,
+        history: () -> CurriculumVitae.ProHistory = { proHistory },
+    ) = UpgradeDiagnosticsGplay(
+        billingCache = mockk<BillingCache>().apply { coEvery { this@apply.snapshot() } answers { snapshot() } },
+        curriculumVitae = mockk<CurriculumVitae>().apply { coEvery { proHistory() } answers { history() } },
     )
 
     @Test
@@ -19,20 +35,104 @@ class UpgradeDiagnosticsGplayTest : BaseTest() {
         // The whole point of this line in the log header is telling "never bought" apart from
         // "bought once, entitlement now missing". A raw 0 reads as a 1970 timestamp.
         val info = create(
-            BillingCache.Snapshot(lastProStateAt = 0L, lastProStateSku = "", proUnconfirmedSince = 0L)
+            { BillingCache.Snapshot(lastProStateAt = 0L, lastProStateSku = "", proUnconfirmedSince = 0L) }
         ).debugInfo()
 
-        info shouldBe "BillingCache(lastProStateAt=never, lastProStateSku=unknown/legacy, proUnconfirmedSince=none)"
+        info shouldContain
+            "BillingCache(lastProStateAt=never, lastProStateSku=unknown/legacy, proUnconfirmedSince=none)"
+    }
+
+    @Test
+    fun `the pro history rides along so a complaint arrives with both records`() = runTest {
+        val info = create(
+            { BillingCache.Snapshot(lastProStateAt = 0L, lastProStateSku = "", proUnconfirmedSince = 0L) }
+        ).debugInfo()
+
+        info shouldContain "ProHistory=$proHistory"
+    }
+
+    @Test
+    fun `a broken history read still reports the billing cache`() = runTest {
+        // Different DataStores: one failing must not suppress the other's independent evidence.
+        val info = create(
+            snapshot = {
+                BillingCache.Snapshot(
+                    lastProStateAt = 1_700_000_000_000L,
+                    lastProStateSku = OurSku.Iap.PRO_UPGRADE.id,
+                    proUnconfirmedSince = 0L,
+                )
+            },
+            history = { throw IllegalStateException("storage is full") },
+        ).debugInfo()
+
+        info shouldContain "lastProStateSku=${OurSku.Iap.PRO_UPGRADE.id}"
+        info shouldContain "ProHistory=unavailable"
+    }
+
+    @Test
+    fun `a broken billing cache read still reports the pro history`() = runTest {
+        // Mirror image of the above: the billing cache DataStore failing must not suppress the
+        // lifetime pro-state counters, which live in a different store.
+        var historyReads = 0
+        val info = create(
+            snapshot = { throw IllegalStateException("datastore is corrupt") },
+            history = { historyReads++; proHistory },
+        ).debugInfo()
+
+        historyReads shouldBe 1
+        info shouldContain "BillingCache=unavailable"
+        info shouldContain "ProHistory=$proHistory"
+    }
+
+    @Test
+    fun `a cancelled billing cache read is not swallowed`() = runTest {
+        shouldThrow<CancellationException> {
+            create(
+                snapshot = { throw CancellationException("scope died") },
+            ).debugInfo()
+        }
+    }
+
+    @Test
+    fun `a cancelled history read is not swallowed`() = runTest {
+        // Symmetric to the cache read: cancellation is not a diagnostics failure, it means the
+        // caller's scope died and the header read must unwind with it.
+        shouldThrow<CancellationException> {
+            create(
+                snapshot = {
+                    BillingCache.Snapshot(lastProStateAt = 0L, lastProStateSku = "", proUnconfirmedSince = 0L)
+                },
+                history = { throw CancellationException("scope died") },
+            ).debugInfo()
+        }
+    }
+
+    @Test
+    fun `a wedged billing cache is reported as unavailable, not as a never-pro install`() = runTest {
+        // End-to-end over a real BillingCache whose store never answers: the bounded read throws,
+        // and the header must say the evidence is missing instead of claiming "never bought".
+        val diagnostics = UpgradeDiagnosticsGplay(
+            billingCache = BillingCache(HangingPreferencesDataStore()).apply { cacheTimeoutMs = 50L },
+            curriculumVitae = mockk<CurriculumVitae>().apply { coEvery { proHistory() } returns proHistory },
+        )
+
+        val info = diagnostics.debugInfo()
+
+        info shouldContain "BillingCache=unavailable"
+        info shouldNotContain "lastProStateAt=never"
+        info shouldContain "ProHistory=$proHistory"
     }
 
     @Test
     fun `a confirmed purchase reports an instant and the sku`() = runTest {
         val info = create(
-            BillingCache.Snapshot(
-                lastProStateAt = 1_700_000_000_000L,
-                lastProStateSku = OurSku.Iap.PRO_UPGRADE.id,
-                proUnconfirmedSince = 0L,
-            )
+            {
+                BillingCache.Snapshot(
+                    lastProStateAt = 1_700_000_000_000L,
+                    lastProStateSku = OurSku.Iap.PRO_UPGRADE.id,
+                    proUnconfirmedSince = 0L,
+                )
+            }
         ).debugInfo()
 
         info shouldContain "lastProStateAt=2023-11-14T22:13:20Z"
@@ -43,11 +143,13 @@ class UpgradeDiagnosticsGplayTest : BaseTest() {
     @Test
     fun `an open unconfirmed episode is reported as an instant`() = runTest {
         val info = create(
-            BillingCache.Snapshot(
-                lastProStateAt = 1_700_000_000_000L,
-                lastProStateSku = OurSku.Sub.PRO_UPGRADE.id,
-                proUnconfirmedSince = 1_700_000_500_000L,
-            )
+            {
+                BillingCache.Snapshot(
+                    lastProStateAt = 1_700_000_000_000L,
+                    lastProStateSku = OurSku.Sub.PRO_UPGRADE.id,
+                    proUnconfirmedSince = 1_700_000_500_000L,
+                )
+            }
         ).debugInfo()
 
         info shouldContain "proUnconfirmedSince=2023-11-14T22:21:40Z"

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/GplayUpgradeScreenHostTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/GplayUpgradeScreenHostTest.kt
@@ -1,0 +1,79 @@
+package eu.darken.myperm.common.upgrade.ui
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.SavedStateHandle
+import eu.darken.myperm.common.compose.PreviewWrapper
+import eu.darken.myperm.common.navigation.Nav
+import eu.darken.myperm.common.upgrade.core.UpgradeRepoGplay
+import eu.darken.myperm.common.upgrade.core.billing.GplayServiceUnavailableException
+import eu.darken.myperm.common.upgrade.core.billing.Sku
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelper.BaseTest
+import testhelper.coroutine.TestDispatcherProvider
+import testhelpers.TestApplication
+
+/**
+ * Host-level counterpart to the ViewModel's `onResume` tests: those prove the ViewModel re-queries,
+ * they cannot prove the screen actually asks it to. Only a real lifecycle round-trip catches a
+ * missing or mis-scoped ON_RESUME effect.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class GplayUpgradeScreenHostTest : BaseTest() {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    private fun mockRepo(): UpgradeRepoGplay = mockk<UpgradeRepoGplay>(relaxed = true).apply {
+        every { upgradeInfo } returns MutableStateFlow(UpgradeRepoGplay.Info(false, null, null, isSettled = true))
+        every { wasEverPro } returns MutableStateFlow(false)
+        every { proUnconfirmedSince } returns MutableStateFlow(0L)
+        // Relaxed mocks return a no-op Flow that never emits -- the state combine would starve.
+        every { autoRestoreBusy } returns MutableStateFlow(false)
+        every { purchaseLaunchSku } returns MutableStateFlow<Sku?>(null)
+    }
+
+    @Test
+    fun `returning to the screen re-runs a failed offers query`() {
+        val repo = mockRepo()
+        var queries = 0
+        coEvery { repo.querySkus(any()) } coAnswers {
+            queries++
+            throw GplayServiceUnavailableException(RuntimeException("Play hiccup"))
+        }
+        val vm = UpgradeViewModel(
+            handle = SavedStateHandle(mapOf("forced" to false)),
+            dispatcherProvider = TestDispatcherProvider(),
+            upgradeRepo = repo,
+            webpageTool = mockk(relaxed = true),
+        )
+
+        // The real ViewModel instance, passed explicitly: hiltViewModel() has nothing to resolve
+        // here. The route is passed explicitly too -- PP binds it through the host's own
+        // LaunchedEffect, not from a SavedStateHandle.
+        composeRule.setContent {
+            PreviewWrapper {
+                UpgradeScreenHost(route = Nav.Main.Upgrade(), vm = vm)
+            }
+        }
+
+        composeRule.waitUntil { vm.state.value is GplayUpgradeUiState.Unavailable }
+        val baseline = queries
+
+        composeRule.activityRule.scenario.moveToState(Lifecycle.State.STARTED)
+        composeRule.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+        composeRule.waitForIdle()
+
+        composeRule.waitUntil { queries > baseline }
+    }
+}

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/GplayUpgradeScreenTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/GplayUpgradeScreenTest.kt
@@ -148,6 +148,9 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_IAP).assertCountEquals(0)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_RESTORE).assertCountEquals(0)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_UNAVAILABLE).assertCountEquals(1)
+        // The card names the problem in its own title. The generic billing-error string is for the
+        // error dialog, not for a card that already carries the explanatory body below it.
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_offers_unavailable_title)).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_offers_unavailable_message)).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_benefits_title)).assertCountEquals(1)
     }
@@ -284,7 +287,7 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
     }
 
     @Test
-    fun `unavailable state offers a retry that fires the callback`() {
+    fun `unavailable state offers a retry that fires once and then latches`() {
         var retryClicks = 0
         composeRule.setUpgradeContent {
             UpgradeScreen(
@@ -299,6 +302,12 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         // would silently miss the button.
         composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_RETRY).performScrollTo().performClick()
         composeRule.runOnIdle { check(retryClicks == 1) { "expected 1 retry click, got $retryClicks" } }
+
+        // Latched: the state stays Unavailable until the re-query answers, so an impatient second
+        // tap would stack another query generation onto the first.
+        composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_RETRY).assertIsNotEnabled()
+        composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_RETRY).performClick()
+        composeRule.runOnIdle { check(retryClicks == 1) { "expected the retry to stay latched, got $retryClicks" } }
     }
 
     @Test

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/GplayUpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/GplayUpgradeViewModelTest.kt
@@ -139,6 +139,48 @@ class GplayUpgradeViewModelTest : BaseTest() {
     }
 
     @Test
+    fun `returning to an unavailable screen re-runs the offers query`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // Leaving to fix Play (sign in, update the store) and coming back is the user's own retry:
+        // without this the failed card sits there until it is tapped by hand.
+        val repo = mockRepo()
+        coEvery { repo.querySkus(any()) } throws GplayServiceUnavailableException(RuntimeException("Play hiccup"))
+        val vm = buildVm(repo)
+
+        val unavailable = async { vm.state.first { it is GplayUpgradeUiState.Unavailable } }
+        advanceUntilIdle()
+        unavailable.await().shouldBeInstanceOf<GplayUpgradeUiState.Unavailable>()
+        coVerify(exactly = 2) { repo.querySkus(any()) }
+
+        vm.onResume()
+        advanceUntilIdle()
+
+        coVerify(exactly = 4) { repo.querySkus(any()) }
+    }
+
+    @Test
+    fun `returning to a loaded screen does not re-run the offers query`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // A working screen has nothing to retry -- re-querying on every resume would put avoidable
+        // load on Play and could flicker the offer cards.
+        val repo = mockRepo()
+        coEvery { repo.querySkus(any()) } returns emptyList()
+        val vm = buildVm(repo)
+
+        val loaded = async { vm.state.first { it is GplayUpgradeUiState.Loaded } }
+        advanceUntilIdle()
+        loaded.await().shouldBeInstanceOf<GplayUpgradeUiState.Loaded>()
+        coVerify(exactly = 2) { repo.querySkus(any()) }
+
+        vm.onResume()
+        advanceUntilIdle()
+
+        coVerify(exactly = 2) { repo.querySkus(any()) }
+    }
+
+    @Test
     fun `a single failed product type keeps the screen loaded and surfaces the error once`() = runTest2(
         context = testDispatcher,
     ) {


### PR DESCRIPTION
## What changed

FOSS version: the supporter status screen now shows since when you've been supporting the project. A supporter re-visiting the sponsors page from their status screen can no longer accidentally reset that date by donating again.

Google Play version: if prices couldn't be loaded, returning to the upgrade screen now retries automatically, the error card gets its own "Google Play unavailable" title, and the retry button can't be double-triggered.

For support: a slow or wedged billing cache can no longer hang debug-log recording or misreport a paying user as never-Pro — and a debug recording that fails while starting no longer leaves an invisible recorder running.

## Technical Context

- Continues the family-wide convergence on the shared canonical billing/upgrade implementation (follow-up to #381): bounded `BillingCache` snapshot/stamp (2s seam; a timed-out snapshot throws so the debug-log header reports `BillingCache=unavailable` instead of misreading a wedged cache as never-Pro), the pro-history fold into `UpgradeDiagnosticsGplay` with per-source failure isolation, the widened recorder start-failure guard (`catch(Exception)` + `NonCancellable` stop), and the offers-unavailable polish (title, tap latch, ON_RESUME re-query — the activity-level per-resume refresh covers only the entitlement, never the screen-local SKU query).
- The `BillingCache` constructor now takes the DataStore; the delegate keeps both retained resilience args — the `settings_gplay` SharedPreferences migration AND the corruption handler — and each now has its own regression test (the corruption handler had none before).
- Supporter-since is derived in the same emission as the view state, so the upgraded status never renders without its date. Stored supporter records have carried `upgradedAt` non-nullably since the schema's introduction — long-time supporters see their real date, no migration.
- Guarding that date: `checkSponsorReturn()` consumes the pending launch key and returns quietly when the install is already Pro, so the recurring-donation button can no longer rewrite `upgradedAt`.
- Review guidance: new host-level lifecycle tests for both flavors (`createAndroidComposeRule`, real ViewModel, real lifecycle transitions) prove the ON_RESUME re-query, the ON_STOP/ON_RESUME sponsor-return wiring, and the recreation seeding — the recreation test composes into an already-resumed activity so only constructor seeding can make it pass. A small test-only reflection helper resets the file-level DataStore delegate between Robolectric test classes (one sandbox classloader, three test classes on the same file); it fails loudly if the delegate's internals change.
