### PR TITLE
General: Make supporter status and debug logs more dependable

### DIFF
--- a/app/src/foss/java/eu/darken/myperm/common/upgrade/core/UpgradeRepoFoss.kt
+++ b/app/src/foss/java/eu/darken/myperm/common/upgrade/core/UpgradeRepoFoss.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.shareIn
-import kotlinx.coroutines.launch
 import java.time.Instant
 import java.util.UUID
 import javax.inject.Inject
@@ -48,9 +47,11 @@ class UpgradeRepoFoss @Inject constructor(
         .setupCommonEventHandlers(TAG) { "upgradeInfo" }
         .shareIn(appScope, SharingStarted.WhileSubscribed(3000L, 0L), replay = 1)
 
-    fun openGithubSponsorsPage() = appScope.launch {
+    // Synchronous so the caller learns whether the page actually opened: the FOSS unlock heuristic
+    // only arms on a successful launch, and a fire-and-forget coroutine can't report that back.
+    fun openGithubSponsorsPage(): Boolean {
         log(TAG) { "openGithubSponsorsPage()" }
-        webpageTool.open(upgradeSite)
+        return webpageTool.open(upgradeSite)
     }
 
     // Writes PP's RETAINED persistence schema: existing supporter records are serialized with

--- a/app/src/foss/java/eu/darken/myperm/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/foss/java/eu/darken/myperm/common/upgrade/ui/UpgradeScreen.kt
@@ -95,6 +95,7 @@ fun UpgradeScreenHost(
         supporterSince = state?.supporterSince,
         snackbarHostState = snackbarHostState,
         onGithubSponsors = vm::goGithubSponsors,
+        onOpenSponsors = vm::openSponsors,
         onShowUpgradeOptions = vm::onShowUpgradeOptions,
         onNavigateUp = vm::navUp,
     )
@@ -106,6 +107,7 @@ internal fun UpgradeScreen(
     supporterSince: Instant? = null,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     onGithubSponsors: () -> Unit = {},
+    onOpenSponsors: () -> Unit = {},
     onShowUpgradeOptions: () -> Unit = {},
     onNavigateUp: () -> Unit = {},
 ) {
@@ -135,7 +137,7 @@ internal fun UpgradeScreen(
             FossUpgradeView.STATUS_UPGRADED -> UpgradeStatusUpgradedContent(
                 paddingValues = paddingValues,
                 supporterSince = supporterSince,
-                onGithubSponsors = onGithubSponsors,
+                onOpenSponsors = onOpenSponsors,
             )
         }
     }
@@ -229,7 +231,7 @@ private fun UpgradeStatusFreeContent(
 private fun UpgradeStatusUpgradedContent(
     paddingValues: PaddingValues,
     supporterSince: Instant? = null,
-    onGithubSponsors: () -> Unit,
+    onOpenSponsors: () -> Unit,
 ) {
     UpgradeScreenContent(
         paddingValues = paddingValues,
@@ -268,7 +270,7 @@ private fun UpgradeStatusUpgradedContent(
         ) {
             UpgradeSectionBody(text = stringResource(R.string.upgrade_screen_recurring_body))
             OutlinedButton(
-                onClick = onGithubSponsors,
+                onClick = onOpenSponsors,
                 modifier = Modifier
                     .fillMaxWidth()
                     .testTag(UpgradeScreenTags.FOSS_DONATE),

--- a/app/src/foss/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModel.kt
@@ -106,9 +106,28 @@ class UpgradeViewModel @Inject constructor(
         handle[KEY_SHOW_UPGRADE_OPTIONS] = true
     }
 
+    /** Armed variant: the pitch's sponsor button, which starts the return-after-5s unlock heuristic. */
     fun goGithubSponsors() {
         log(TAG) { "goGithubSponsors()" }
+        if (hasPendingSponsorLaunch()) {
+            log(TAG) { "A sponsor launch is already awaiting its return" }
+            return
+        }
+        // Only arm the heuristic if the launch was actually accepted; otherwise an unrelated later
+        // background/foreground round-trip would grant supporter status with no page ever shown.
+        if (!upgradeRepo.openGithubSponsorsPage()) {
+            log(TAG) { "Sponsor page didn't open; not arming the unlock heuristic" }
+            return
+        }
         handle[KEY_SPONSOR_PRESSED_AT] = SystemClock.elapsedRealtime()
+    }
+
+    /**
+     * Unarmed variant: the status view's donate button. An existing supporter re-visiting the page
+     * must not re-arm the unlock heuristic — there is nothing left to unlock.
+     */
+    fun openSponsors() {
+        log(TAG) { "openSponsors()" }
         upgradeRepo.openGithubSponsorsPage()
     }
 

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/BillingCache.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/BillingCache.kt
@@ -15,8 +15,10 @@ import eu.darken.myperm.common.datastore.basicReader
 import eu.darken.myperm.common.datastore.basicWriter
 import eu.darken.myperm.common.datastore.createValue
 import eu.darken.myperm.common.debug.logging.Logging.Priority.WARN
+import eu.darken.myperm.common.debug.logging.asLog
 import eu.darken.myperm.common.debug.logging.log
 import eu.darken.myperm.common.debug.logging.logTag
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeoutOrNull
 import java.io.IOException
@@ -103,14 +105,24 @@ class BillingCache internal constructor(
     // not erase.
     suspend fun stampLastProState(skuId: String, at: Long) {
         // Fail-soft: this decorates the entitlement path, it must never be the thing that blocks it.
-        withTimeoutOrNull(cacheTimeoutMs) {
-            dataStore.edit { prefs ->
-                prefs[lastProStateSkuKey] = skuId
-                prefs[lastProStateAtKey] = at
-                val episodeStart = prefs[proUnconfirmedSinceKey] ?: 0L
-                if (episodeStart in 1..at) prefs[proUnconfirmedSinceKey] = 0L
-            }
-        } ?: log(TAG, WARN) { "stampLastProState($skuId, $at) timed out after ${cacheTimeoutMs}ms, write skipped" }
+        // A wedged file lock (timeout) and a broken write (IOException, corrupt file, no disk space)
+        // are the same to the caller — the stamp is lost, the bookkeeping around it carries on.
+        try {
+            withTimeoutOrNull(cacheTimeoutMs) {
+                dataStore.edit { prefs ->
+                    prefs[lastProStateSkuKey] = skuId
+                    prefs[lastProStateAtKey] = at
+                    val episodeStart = prefs[proUnconfirmedSinceKey] ?: 0L
+                    if (episodeStart in 1..at) prefs[proUnconfirmedSinceKey] = 0L
+                }
+            } ?: log(TAG, WARN) { "stampLastProState($skuId, $at) timed out after ${cacheTimeoutMs}ms, write skipped" }
+        } catch (e: CancellationException) {
+            // Caught before the general case on purpose: our caller going away is not a write
+            // failure, and swallowing it would break their structured concurrency.
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "stampLastProState($skuId, $at) failed, write skipped: ${e.asLog()}" }
+        }
     }
 
     companion object {

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/UpgradeDiagnosticsGplay.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/UpgradeDiagnosticsGplay.kt
@@ -7,6 +7,7 @@ import eu.darken.myperm.common.debug.logging.logTag
 import eu.darken.myperm.common.upgrade.UpgradeDiagnostics
 import eu.darken.myperm.main.core.CurriculumVitae
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.withTimeoutOrNull
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -28,6 +29,10 @@ class UpgradeDiagnosticsGplay @Inject constructor(
     private val curriculumVitae: CurriculumVitae,
 ) : UpgradeDiagnostics {
 
+    // Test seam: the bounded read below runs on real dispatchers, so a virtual-time test cannot
+    // advance the production bound. Same pattern as BillingCache.cacheTimeoutMs.
+    internal var historyTimeoutMs: Long = HISTORY_TIMEOUT_MS
+
     override suspend fun debugInfo(): String {
         val cache = try {
             val snapshot = billingCache.snapshot()
@@ -47,7 +52,12 @@ class UpgradeDiagnosticsGplay @Inject constructor(
         // and the counters only cover installs new enough to have them. A failure to read one must
         // not suppress the other's independent evidence.
         val history = try {
-            curriculumVitae.proHistory().toString()
+            // Bounded like the cache read above: a wedged DataStore file lock would otherwise hold
+            // the debug-log header — and with it the start of the recording — forever.
+            withTimeoutOrNull(historyTimeoutMs) { curriculumVitae.proHistory().toString() } ?: run {
+                log(TAG, WARN) { "Pro history timed out after ${historyTimeoutMs}ms" }
+                "unavailable"
+            }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -58,6 +68,7 @@ class UpgradeDiagnosticsGplay @Inject constructor(
     }
 
     companion object {
+        private const val HISTORY_TIMEOUT_MS = 2_000L
         private val TAG = logTag("Upgrade", "Gplay", "Diagnostics")
     }
 }

--- a/app/src/main/java/eu/darken/myperm/common/WebpageTool.kt
+++ b/app/src/main/java/eu/darken/myperm/common/WebpageTool.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import dagger.Reusable
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.myperm.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.myperm.common.debug.logging.asLog
 import eu.darken.myperm.common.debug.logging.log
 import javax.inject.Inject
 
@@ -14,14 +15,18 @@ class WebpageTool @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
 
-    fun open(address: String) {
+    // Returns whether an activity was actually started, so callers that gate behaviour on the page
+    // having opened (e.g. the FOSS sponsor unlock heuristic) don't fire when no browser handled it.
+    fun open(address: String): Boolean {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse(address)).apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
-        try {
+        return try {
             context.startActivity(intent)
+            true
         } catch (e: Exception) {
-            log(ERROR) { "Failed to launch" }
+            log(ERROR) { "Failed to launch: ${e.asLog()}" }
+            false
         }
     }
 

--- a/app/src/main/java/eu/darken/myperm/common/debug/recording/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/myperm/common/debug/recording/core/RecorderModule.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -45,6 +46,10 @@ class RecorderModule @Inject constructor(
     private val installId: InstallId,
     private val upgradeDiagnostics: UpgradeDiagnostics,
 ) {
+
+    // Test seam: the header read below is bounded on real dispatchers, so a virtual-time test cannot
+    // advance the production bound. Same pattern as BillingCache.cacheTimeoutMs.
+    internal var headerReadTimeoutMs: Long = HEADER_READ_TIMEOUT_MS
 
     // Lazy to keep Hilt construction off the filesystem — getExternalFilesDir()
     // does mkdirs and can ANR on main thread during App.onCreate on slow devices.
@@ -153,13 +158,31 @@ class RecorderModule @Inject constructor(
         log(TAG, INFO) { "BuildConfig.Versions: ${BuildConfigWrap.VERSION_DESCRIPTION}" }
 
         try {
-            upgradeDiagnostics.debugInfo()?.let { log(TAG, INFO) { "Upgrade diagnostics: $it" } }
+            // Diagnostics only — a broken read must not stop the recorder from starting. Bounded on
+            // top of that: debug recording is what a user reaches for when the app is ALREADY
+            // misbehaving, so a source that never answers (a stuck DataStore file lock, a billing
+            // store that doesn't respond) must not hold up the start of the recording either.
+            val read = withTimeoutOrNull(headerReadTimeoutMs) { HeaderRead(upgradeDiagnostics.debugInfo()) }
+            when {
+                read == null -> log(TAG, WARN) {
+                    "Upgrade diagnostics unavailable, read did not finish within ${headerReadTimeoutMs}ms"
+                }
+                // Completion is tracked separately from the value: a flavor that legitimately has
+                // nothing to report (FOSS) returns null and gets no line at all, not an "unavailable".
+                read.value != null -> log(TAG, INFO) { "Upgrade diagnostics: ${read.value}" }
+            }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             log(TAG, WARN) { "Upgrade diagnostics unavailable: ${e.asLog()}" }
         }
     }
+
+    /**
+     * Completion marker for a header read: tells a source that legitimately has nothing to report
+     * (no diagnostics on FOSS) apart from one that never answered within the deadline.
+     */
+    private class HeaderRead<T>(val value: T)
 
     private fun createSessionDir(): File {
         val sdf = SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'", Locale.US)
@@ -278,6 +301,9 @@ class RecorderModule @Inject constructor(
         internal val TAG = logTag("Debug", "Log", "Recorder", "Module")
         private const val FORCE_FILE = "myperm_force_debug_run"
         internal const val MIN_RECORDING_MS = 5_000L
+
+        // Budget for the header's diagnostics read.
+        private const val HEADER_READ_TIMEOUT_MS = 5_000L
 
         @VisibleForTesting
         internal fun parseTriggerContent(content: String): TriggerInfo? {

--- a/app/src/test/java/eu/darken/myperm/common/WebpageToolTest.kt
+++ b/app/src/test/java/eu/darken/myperm/common/WebpageToolTest.kt
@@ -1,0 +1,48 @@
+package eu.darken.myperm.common
+
+import android.app.Application
+import android.content.ActivityNotFoundException
+import android.content.ContextWrapper
+import android.content.Intent
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import testhelper.BaseTest
+import testhelpers.TestApplication
+
+/**
+ * The return value is a contract, not a convenience: the FOSS sponsor unlock heuristic only arms
+ * when the launch was actually accepted. The single broad catch has to report the failure back.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class WebpageToolTest : BaseTest() {
+
+    private val application: Application
+        get() = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `a launched page reports success`() {
+        WebpageTool(application).open(URL) shouldBe true
+
+        shadowOf(application).nextStartedActivity!!.data shouldBe Uri.parse(URL)
+    }
+
+    @Test
+    fun `a missing browser reports failure`() {
+        val context = object : ContextWrapper(application) {
+            override fun startActivity(intent: Intent) = throw ActivityNotFoundException("No browser")
+        }
+
+        WebpageTool(context).open(URL) shouldBe false
+    }
+
+    companion object {
+        private const val URL = "https://github.com/sponsors/d4rken"
+    }
+}

--- a/app/src/test/java/eu/darken/myperm/common/debug/recording/core/RecorderModuleDiagnosticsTest.kt
+++ b/app/src/test/java/eu/darken/myperm/common/debug/recording/core/RecorderModuleDiagnosticsTest.kt
@@ -3,9 +3,11 @@ package eu.darken.myperm.common.debug.recording.core
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.myperm.common.BuildConfigWrap
 import eu.darken.myperm.common.InstallId
+import eu.darken.myperm.common.coroutine.DispatcherProvider
 import eu.darken.myperm.common.debug.logging.FileLogger
 import eu.darken.myperm.common.debug.logging.Logging
 import eu.darken.myperm.common.upgrade.UpgradeDiagnostics
+import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -18,12 +20,19 @@ import io.mockk.unmockkObject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -31,6 +40,8 @@ import org.robolectric.annotation.Config
 import testhelper.BaseTest
 import testhelper.coroutine.TestDispatcherProvider
 import testhelpers.TestApplication
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.system.measureTimeMillis
 
 /**
  * The recording header reads diagnostics that live outside the recorder. Those reads happen AFTER
@@ -43,18 +54,66 @@ import testhelpers.TestApplication
 @Config(sdk = [33], application = TestApplication::class)
 class RecorderModuleDiagnosticsTest : BaseTest() {
 
+    private val logLines = CopyOnWriteArrayList<String>()
+    private val logCapture = object : Logging.Logger {
+        override fun log(priority: Logging.Priority, tag: String, message: String, metaData: Map<String, Any>?) {
+            logLines.add(message)
+        }
+    }
+
+    @Before
+    fun installLogCapture() {
+        Logging.install(logCapture)
+    }
+
+    @After
+    fun removeLogCapture() {
+        Logging.remove(logCapture)
+    }
+
     private fun buildModule(
         scope: CoroutineScope,
         upgradeDiagnostics: UpgradeDiagnostics,
+        dispatcherProvider: DispatcherProvider = TestDispatcherProvider(),
     ) = RecorderModule(
         context = ApplicationProvider.getApplicationContext(),
         appScope = scope,
-        dispatcherProvider = TestDispatcherProvider(),
+        dispatcherProvider = dispatcherProvider,
         installId = mockk<InstallId>(relaxed = true).apply {
             every { id } returns "abcdef12-0000-0000-0000-000000000000"
         },
         upgradeDiagnostics = upgradeDiagnostics,
     )
+
+    /**
+     * Real dispatchers on purpose: the header's read deadline is wall-clock, so a virtual-time test
+     * would skip past it instead of exercising it — an ignored seam has to fail this, not pass after
+     * the full production budget. The seam is set before [RecorderModule.startRecorder] so no header
+     * read can run against the production bound.
+     *
+     * The block runs inside its own deadline: a missing or mis-wired production bound must fail this
+     * test rather than wedge the gradle worker on a read that never answers.
+     */
+    private fun withRealtimeModule(
+        upgradeDiagnostics: UpgradeDiagnostics,
+        headerTimeoutMs: Long = 300L,
+        block: suspend (RecorderModule) -> Unit,
+    ) {
+        val fileLoggersBefore = Logging.loggers.filterIsInstance<FileLogger>()
+        val moduleScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        val module = buildModule(moduleScope, upgradeDiagnostics, TestDispatcherProvider(Dispatchers.IO))
+        module.headerReadTimeoutMs = headerTimeoutMs
+        try {
+            runBlocking { withTimeout(TEST_ENVELOPE_MS) { block(module) } }
+        } finally {
+            // Stop the recorder BEFORE the scope goes: cancelling the scope alone leaves the
+            // recorder's globally installed FileLogger and its trigger file behind for every later
+            // test in this process.
+            runBlocking { withTimeoutOrNull(TEST_ENVELOPE_MS) { module.stopRecorder() } }
+            moduleScope.cancel()
+        }
+        Logging.loggers.filterIsInstance<FileLogger>() shouldBe fileLoggersBefore
+    }
 
     @Test
     fun `a failing upgrade-diagnostics read still leaves a tracked recording`() = runTest {
@@ -132,5 +191,45 @@ class RecorderModuleDiagnosticsTest : BaseTest() {
             moduleScope.cancel()
             unmockkObject(BuildConfigWrap)
         }
+    }
+
+    /**
+     * Debug recording is what a user reaches for when the app is ALREADY misbehaving, so a
+     * diagnostics source that never answers must not be the thing that denies them the log.
+     */
+    @Test
+    fun `a wedged upgrade diagnostics read does not hold up the recording`() {
+        val diagnostics = mockk<UpgradeDiagnostics>()
+        coEvery { diagnostics.debugInfo() } coAnswers { awaitCancellation() }
+
+        withRealtimeModule(diagnostics, headerTimeoutMs = 300L) { module ->
+            val elapsed = measureTimeMillis { module.startRecorder() }
+
+            module.state.first().isRecording shouldBe true
+            logLines.any { it.startsWith("Upgrade diagnostics unavailable") } shouldBe true
+            // Non-vacuity: without the bound this would sit on the wedged read forever.
+            elapsed shouldBeLessThan 1_500L
+        }
+    }
+
+    @Test
+    fun `a flavor without diagnostics is not reported as unavailable`() {
+        // FOSS has nothing to report and returns null: no diagnostics line at all, and above all
+        // not one claiming the read failed or timed out.
+        val diagnostics = mockk<UpgradeDiagnostics>()
+        coEvery { diagnostics.debugInfo() } returns null
+
+        withRealtimeModule(diagnostics) { module ->
+            module.startRecorder()
+
+            module.state.first().isRecording shouldBe true
+            logLines.any { it.startsWith("Upgrade diagnostics") } shouldBe false
+        }
+    }
+
+    companion object {
+        // Independent of the production bound: a missing or mis-wired one has to fail the test, not
+        // hang the gradle worker.
+        private const val TEST_ENVELOPE_MS = 10_000L
     }
 }

--- a/app/src/testFoss/java/eu/darken/myperm/common/upgrade/ui/FossUpgradeScreenHostTest.kt
+++ b/app/src/testFoss/java/eu/darken/myperm/common/upgrade/ui/FossUpgradeScreenHostTest.kt
@@ -40,6 +40,7 @@ class FossUpgradeScreenHostTest : BaseTest() {
 
     private fun mockRepo(): UpgradeRepoFoss = mockk<UpgradeRepoFoss>(relaxed = true).apply {
         every { upgradeInfo } returns MutableStateFlow(UpgradeRepoFoss.Info())
+        every { openGithubSponsorsPage() } returns true
         coEvery { persistUpgrade() } answers { persisted++ }
     }
 

--- a/app/src/testFoss/java/eu/darken/myperm/common/upgrade/ui/FossUpgradeScreenTest.kt
+++ b/app/src/testFoss/java/eu/darken/myperm/common/upgrade/ui/FossUpgradeScreenTest.kt
@@ -12,6 +12,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.compose.ui.semantics.SemanticsActions
 import eu.darken.myperm.R
 import eu.darken.myperm.common.compose.PreviewWrapper
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import testhelpers.compose.BaseComposeRobolectricTest
@@ -125,9 +126,16 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
     @Test
     fun `recurring donation button invokes the sponsors callback`() {
         var clicked = false
+        // The armed pitch callback must stay untouched here: a supporter donating again has nothing
+        // left to unlock, so the donate button goes through the unarmed callback.
+        var armed = false
 
         composeRule.setUpgradeContent {
-            UpgradeScreen(view = FossUpgradeView.STATUS_UPGRADED, onGithubSponsors = { clicked = true })
+            UpgradeScreen(
+                view = FossUpgradeView.STATUS_UPGRADED,
+                onGithubSponsors = { armed = true },
+                onOpenSponsors = { clicked = true },
+            )
         }
 
         composeRule.onNodeWithTag(UpgradeScreenTags.FOSS_DONATE)
@@ -135,6 +143,7 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
 
         composeRule.runOnIdle {
             assertTrue(clicked)
+            assertFalse(armed)
         }
     }
 }

--- a/app/src/testFoss/java/eu/darken/myperm/common/upgrade/ui/FossUpgradeViewModelTest.kt
+++ b/app/src/testFoss/java/eu/darken/myperm/common/upgrade/ui/FossUpgradeViewModelTest.kt
@@ -11,6 +11,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -61,6 +62,7 @@ class FossUpgradeViewModelTest : BaseTest() {
         info: MutableStateFlow<UpgradeRepoFoss.Info> = MutableStateFlow(UpgradeRepoFoss.Info()),
     ): UpgradeRepoFoss = mockk<UpgradeRepoFoss>(relaxed = true).apply {
         every { upgradeInfo } returns info
+        every { openGithubSponsorsPage() } returns true
     }
 
     private fun buildVm(
@@ -326,5 +328,70 @@ class FossUpgradeViewModelTest : BaseTest() {
         vm.state.value!!.supporterSince shouldBe Instant.EPOCH
         // The launch is still consumed: a stale pending launch would fire on some later resume.
         vm.hasPendingSponsorLaunch() shouldBe false
+    }
+
+    @Test
+    fun `a sponsor page that never opened arms nothing and a later retry still works`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // A silently failed launch must not leave the heuristic armed: an unrelated later
+        // background round-trip would otherwise hand out supporter status for free.
+        val repo = mockRepo()
+        every { repo.openGithubSponsorsPage() } returns false
+        val vm = buildVm(repo = repo)
+
+        vm.goGithubSponsors()
+        advanceUntilIdle()
+
+        vm.hasPendingSponsorLaunch() shouldBe false
+
+        // And the failure must not brick the button either — the next working attempt arms as usual.
+        every { repo.openGithubSponsorsPage() } returns true
+        vm.goGithubSponsors()
+        advanceUntilIdle()
+
+        vm.hasPendingSponsorLaunch() shouldBe true
+    }
+
+    @Test
+    fun `a second sponsor tap while a launch is pending opens the page only once`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val repo = mockRepo()
+        val vm = buildVm(repo = repo)
+
+        vm.goGithubSponsors()
+        vm.goGithubSponsors()
+        advanceUntilIdle()
+
+        verify(exactly = 1) { repo.openGithubSponsorsPage() }
+    }
+
+    @Test
+    fun `a long donate visit from the status view does not re-persist the upgrade`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // The status view's donate button is unarmed on purpose: a supporter browsing the sponsors
+        // page for a while must not run the unlock heuristic again and rewrite their upgrade date.
+        val repo = mockRepo(MutableStateFlow(upgradedInfo()))
+        val vm = buildVm(repo = repo)
+
+        val state = async { vm.state.first { it != null }!! }
+        vm.bindRoute(Nav.Main.Upgrade(manage = true))
+        advanceUntilIdle()
+        state.await().supporterSince shouldBe Instant.EPOCH
+
+        vm.openSponsors()
+        advanceUntilIdle()
+
+        verify(exactly = 1) { repo.openGithubSponsorsPage() }
+        vm.hasPendingSponsorLaunch() shouldBe false
+
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { repo.persistUpgrade() }
+        vm.state.value!!.supporterSince shouldBe Instant.EPOCH
     }
 }

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/BillingCacheTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/BillingCacheTest.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.test.core.app.ApplicationProvider
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.Flow
@@ -95,6 +96,28 @@ class BillingCacheTest : BaseTest() {
         // The write only decorates the entitlement path, it must never block it.
         cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1234L)
     }
+
+    @Test
+    fun `a failing datastore write does not abort the entitlement bookkeeping`() = runTest {
+        // A broken write (corrupt file, no disk space) is not the same failure as a wedged lock, and
+        // the timeout alone doesn't cover it -- the exception would propagate straight through the
+        // stamp into the caller that was only decorating its entitlement work.
+        val cache = BillingCache(ThrowingPreferencesDataStore())
+
+        cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1234L)
+
+        // Reads stay loud: a snapshot that can't be read must not look like "never bought".
+        shouldThrow<IOException> { cache.snapshot() }
+    }
+
+    @Test
+    fun `a cancelled stamp still cancels`() = runTest {
+        // Fail-soft must not extend to cancellation -- swallowing it would break the structured
+        // concurrency of whatever entitlement work is being torn down.
+        val cache = BillingCache(CancellingPreferencesDataStore())
+
+        shouldThrow<CancellationException> { cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1234L) }
+    }
 }
 
 /** DataStore that never answers -- stands in for a wedged file lock. */
@@ -103,4 +126,20 @@ internal class HangingPreferencesDataStore : DataStore<Preferences> {
 
     override suspend fun updateData(transform: suspend (Preferences) -> Preferences): Preferences =
         awaitCancellation()
+}
+
+/** DataStore whose I/O fails -- stands in for a corrupt file or a full disk. */
+internal class ThrowingPreferencesDataStore : DataStore<Preferences> {
+    override val data: Flow<Preferences> = flow { throw IOException("Preferences file is broken") }
+
+    override suspend fun updateData(transform: suspend (Preferences) -> Preferences): Preferences =
+        throw IOException("Preferences file is broken")
+}
+
+/** DataStore whose write is cancelled from the outside. */
+internal class CancellingPreferencesDataStore : DataStore<Preferences> {
+    override val data: Flow<Preferences> = flow { throw CancellationException("Torn down") }
+
+    override suspend fun updateData(transform: suspend (Preferences) -> Preferences): Preferences =
+        throw CancellationException("Torn down")
 }

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/UpgradeDiagnosticsGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/UpgradeDiagnosticsGplayTest.kt
@@ -8,7 +8,10 @@ import io.kotest.matchers.string.shouldNotContain
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import org.junit.jupiter.api.Test
 import testhelper.BaseTest
 
@@ -121,6 +124,33 @@ class UpgradeDiagnosticsGplayTest : BaseTest() {
         info shouldContain "BillingCache=unavailable"
         info shouldNotContain "lastProStateAt=never"
         info shouldContain "ProHistory=$proHistory"
+    }
+
+    @Test
+    fun `a wedged history is reported as unavailable`() = runTest {
+        // Counterpart to the wedged cache above: a never-answering CurriculumVitae store would hold
+        // the debug-log header -- and with it the start of the recording -- forever.
+        // Real time on purpose: under virtual time the bound would fire instantly while nothing else
+        // is scheduled, so an ignored seam would still pass.
+        withContext(Dispatchers.IO) {
+            val diagnostics = UpgradeDiagnosticsGplay(
+                billingCache = mockk<BillingCache>().apply {
+                    coEvery { snapshot() } returns BillingCache.Snapshot(
+                        lastProStateAt = 0L,
+                        lastProStateSku = "",
+                        proUnconfirmedSince = 0L,
+                    )
+                },
+                curriculumVitae = mockk<CurriculumVitae>().apply {
+                    coEvery { proHistory() } coAnswers { awaitCancellation() }
+                },
+            ).apply { historyTimeoutMs = 50L }
+
+            val info = diagnostics.debugInfo()
+
+            info shouldContain "BillingCache(lastProStateAt=never"
+            info shouldContain "ProHistory=unavailable"
+        }
     }
 
     @Test


### PR DESCRIPTION
## What changed

FOSS version: supporter status is now only granted when the GitHub Sponsors page launch actually went through — if no browser could handle the link, coming back to the app later no longer counts as a donation visit, and a second tap while a visit is pending doesn't fire twice. The "donate again" button on the supporter status screen now simply opens the page without re-running the unlock logic.

For support: debug-log recording now starts even when the billing storage is wedged — the log header's diagnostics read is bounded instead of waiting forever, exactly for the moment a user is trying to report a problem. A failed write to the purchase cache also no longer interrupts the surrounding entitlement bookkeeping.

## Technical Context

- Propagates the latest canonical billing/upgrade batch (follow-up to #383): `WebpageTool.open()` returns whether an activity was actually started — deliberately documented as "launch request accepted", not "page rendered"; a chooser can still appear and be dismissed, which the return-after-5s heuristic tolerates as before. `openGithubSponsorsPage()` is synchronous so `goGithubSponsors()` arms only on a successful launch, behind a single-flight guard; the status view's donate button routes through a new unarmed `openSponsors()`. The already-Pro return guard from the previous batch stays as defense-in-depth.
- `stampLastProState()` was fail-soft for timeouts only; thrown write exceptions now degrade to a logged skip (cancellation rethrown, covered by dedicated fakes). Reads stay loud.
- The recorder's single header read is bounded by a 5s seam with a completion marker distinguishing "timed out" from "legitimately nothing to report" (FOSS has no upgrade diagnostics and stays silent). The GPlay diagnostics' pro-history read gets the same 2s bound its billing-cache read already had.
- No resource changes: the FOSS flavor label here was already non-translatable with no locale variants.
- Review guidance: the wedge tests run on real dispatchers with short seams, elapsed ceilings, and an independent 10s envelope (a missing bound fails the test rather than hanging the worker); the test helper stops the recorder and asserts the global `FileLogger` set is restored, so a leaked recording can't pollute later tests; relaxed repo mocks now stub the Boolean launch explicitly, since MockK's relaxed `false` default would otherwise silently disarm every sponsor test.
