### PR TITLE
General: Make supporter status and debug logging more robust

### DIFF
--- a/app/src/foss/java/eu/darken/myperm/common/upgrade/core/FossCache.kt
+++ b/app/src/foss/java/eu/darken/myperm/common/upgrade/core/FossCache.kt
@@ -1,8 +1,10 @@
 package eu.darken.myperm.common.upgrade.core
 
 import android.content.Context
+import androidx.datastore.core.DataStore
 import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.SharedPreferencesMigration
+import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -20,12 +22,19 @@ private val Context.dataStore by preferencesDataStore(
 )
 
 @Singleton
-class FossCache @Inject constructor(
-    @ApplicationContext context: Context,
-    json: Json
+class FossCache internal constructor(
+    // Test seam: the store is handed in so a test can supply its own DataStore instead of the
+    // Context-bound production delegate.
+    private val dataStore: DataStore<Preferences>,
+    json: Json,
 ) {
 
-    val upgrade = context.dataStore.createValue<FossUpgrade?>(
+    @Inject constructor(
+        @ApplicationContext context: Context,
+        json: Json,
+    ) : this(context.dataStore, json)
+
+    val upgrade = dataStore.createValue<FossUpgrade?>(
         keyName = "foss.upgrade",
         json = json,
         defaultValue = null,

--- a/app/src/foss/java/eu/darken/myperm/common/upgrade/core/UpgradeRepoFoss.kt
+++ b/app/src/foss/java/eu/darken/myperm/common/upgrade/core/UpgradeRepoFoss.kt
@@ -2,6 +2,7 @@ package eu.darken.myperm.common.upgrade.core
 
 import eu.darken.myperm.common.WebpageTool
 import eu.darken.myperm.common.coroutine.AppScope
+import eu.darken.myperm.common.debug.logging.Logging.Priority.WARN
 import eu.darken.myperm.common.debug.logging.log
 import eu.darken.myperm.common.debug.logging.logTag
 import eu.darken.myperm.common.flow.setupCommonEventHandlers
@@ -57,14 +58,34 @@ class UpgradeRepoFoss @Inject constructor(
     // Writes PP's RETAINED persistence schema: existing supporter records are serialized with
     // `reason` (foss.upgrade.reason.*). Adopting canonical's `upgradeType` schema would decode
     // every stored record as null and strip those supporters' entitlement.
-    internal suspend fun persistUpgrade() {
+    /**
+     * Create-only-if-absent inside the store transaction: an existing record (and its upgradedAt —
+     * the user-visible "supporter since" date) is never replaced. The VM-level isPro guard alone is
+     * not race-free: it reads a shareIn replay that can be stale. Note the kept record is still
+     * re-encoded through the current schema — decoded fields are preserved exactly.
+     *
+     * Caveat from the kotlinx `createValue` default `fallbackToDefault = true`: a stored record that
+     * fails to decode reads as null and therefore counts as ABSENT to this transaction, i.e. it gets
+     * replaced. That matches the pre-existing read behaviour — such a record already presents the
+     * user as free — and re-creating it on the next successful sponsor visit is the recovery path.
+     *
+     * @return true if a new record was created, false if an existing record was kept.
+     */
+    internal suspend fun persistUpgrade(): Boolean {
         log(TAG) { "persistUpgrade()" }
-        fossCache.upgrade.value(
-            FossUpgrade(
+        val updated = fossCache.upgrade.update { existing ->
+            existing ?: FossUpgrade(
                 upgradedAt = Instant.now(),
                 reason = FossUpgrade.Reason.GITHUB_SPONSORS,
             )
-        )
+        }
+        val existing = updated.old
+        return if (existing == null) {
+            true
+        } else {
+            log(TAG, WARN) { "persistUpgrade(): Record already exists (upgradedAt=${existing.upgradedAt}), keeping it" }
+            false
+        }
     }
 
     override suspend fun refresh() {

--- a/app/src/foss/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModel.kt
@@ -143,24 +143,43 @@ class UpgradeViewModel @Inject constructor(
     fun checkSponsorReturn() = launch {
         val pressedAt = handle.remove<Long>(KEY_SPONSOR_PRESSED_AT) ?: return@launch
 
-        // Evaluated before the duration: an already upgraded supporter (recurring donation button)
-        // has nothing left to unlock, and persisting again would rewrite their upgradedAt — visibly
-        // resetting the "supporter since" date the status screen shows them.
-        if (upgradeRepo.upgradeInfo.first().isPro) {
-            log(TAG) { "checkSponsorReturn(): Already upgraded, staying quiet" }
-            return@launch
-        }
+        try {
+            // Evaluated before the duration: an already upgraded supporter (recurring donation
+            // button) has nothing left to unlock, so this fast path exists for the UX — return
+            // quietly, no redundant write attempt and no thanks toast for an unlock that already
+            // happened. Data integrity is not this guard's job: the repo's create-only transaction
+            // owns that.
+            if (upgradeRepo.upgradeInfo.first().isPro) {
+                log(TAG) { "checkSponsorReturn(): Already upgraded, staying quiet" }
+                return@launch
+            }
 
-        val elapsed = SystemClock.elapsedRealtime() - pressedAt
-        log(TAG) { "checkSponsorReturn(): elapsed=${elapsed}ms" }
+            val elapsed = SystemClock.elapsedRealtime() - pressedAt
+            log(TAG) { "checkSponsorReturn(): elapsed=${elapsed}ms" }
 
-        if (elapsed < SPONSOR_DELAY_MS) {
-            log(TAG) { "checkSponsorReturn(): Too quick, showing snackbar" }
-            snackbarEvents.tryEmit(R.string.upgrade_foss_sponsor_returned_early)
-        } else {
-            log(TAG) { "checkSponsorReturn(): Delay passed, persisting upgrade" }
-            upgradeRepo.persistUpgrade()
-            toastEvents.tryEmit(R.string.upgrade_screen_thanks_toast)
+            if (elapsed < SPONSOR_DELAY_MS) {
+                log(TAG) { "checkSponsorReturn(): Too quick, showing snackbar" }
+                snackbarEvents.tryEmit(R.string.upgrade_foss_sponsor_returned_early)
+            } else {
+                log(TAG) { "checkSponsorReturn(): Delay passed, persisting upgrade" }
+                val created = upgradeRepo.persistUpgrade()
+                if (created) {
+                    toastEvents.tryEmit(R.string.upgrade_screen_thanks_toast)
+                } else {
+                    // The isPro fast-path read a stale emission; the transaction kept the existing record.
+                    log(TAG) { "checkSponsorReturn(): Record already existed, staying quiet" }
+                }
+            }
+        } catch (e: Exception) {
+            // The marker was consumed above; neither a failed entitlement read nor a failed write may
+            // eat the user's valid sponsor visit — restore it so the next return/resume can retry the
+            // unlock. Conditional: the user may have armed a NEWER launch while this attempt was
+            // suspended, and that one must survive. Rethrow unconditionally: cancellation is not
+            // swallowed, other errors surface via the normal error path.
+            if (!handle.contains(KEY_SPONSOR_PRESSED_AT)) {
+                handle[KEY_SPONSOR_PRESSED_AT] = pressedAt
+            }
+            throw e
         }
     }
 

--- a/app/src/main/java/eu/darken/myperm/common/datastore/DataStoreValue.kt
+++ b/app/src/main/java/eu/darken/myperm/common/datastore/DataStoreValue.kt
@@ -43,18 +43,27 @@ class DataStoreValue<T>(
         update { newValue }
     }
 
-    suspend fun update(transform: (T) -> T) {
+    data class Updated<T>(
+        val old: T,
+        val new: T,
+    )
+
+    @Suppress("UNCHECKED_CAST")
+    suspend fun update(transform: (T) -> T): Updated<T> {
+        val values = arrayOfNulls<Any?>(2)
+
         dataStore.edit { prefs ->
-            val current = reader(prefs[key])
-            val newValue = transform(current)
+            val current = reader(prefs[key]).also { values[0] = it }
+            val newValue = transform(current).also { values[1] = it }
             val raw = writer(newValue)
-            @Suppress("UNCHECKED_CAST")
             if (raw != null) {
                 prefs[key as Preferences.Key<Any>] = raw
             } else {
                 prefs.remove(key)
             }
         }
+
+        return Updated(old = values[0] as T, new = values[1] as T)
     }
 
     var valueBlocking: T

--- a/app/src/main/java/eu/darken/myperm/common/debug/recording/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/myperm/common/debug/recording/core/RecorderModule.kt
@@ -51,6 +51,11 @@ class RecorderModule @Inject constructor(
     // advance the production bound. Same pattern as BillingCache.cacheTimeoutMs.
     internal var headerReadTimeoutMs: Long = HEADER_READ_TIMEOUT_MS
 
+    // Test seams for the two clocks the recording heuristics use. Same pattern as the header bound:
+    // the durations are wall-clock/monotonic, so virtual time cannot drive them.
+    internal var wallClock: () -> Long = System::currentTimeMillis
+    internal var monotonicClock: () -> Long = android.os.SystemClock::elapsedRealtime
+
     // Lazy to keep Hilt construction off the filesystem — getExternalFilesDir()
     // does mkdirs and can ANR on main thread during App.onCreate on slow devices.
     private val triggerFile: File by lazy {
@@ -94,7 +99,7 @@ class RecorderModule @Inject constructor(
                             log(TAG, INFO) { "Resuming recording in existing session: ${resumed.name}" }
                             recordingStartedAt
                         } else {
-                            System.currentTimeMillis()
+                            wallClock()
                         }
 
                         val logFile = File(sessionDir, "core.log")
@@ -125,6 +130,7 @@ class RecorderModule @Inject constructor(
                             recorder = newRecorder,
                             persistedLogDir = null,
                             recordingStartedAt = startTime,
+                            recordingStartedAtMonotonic = if (resumed != null) null else monotonicClock(),
                             logDir = sessionDir,
                         )
                     } else if (!shouldRecord && isRecording) {
@@ -140,6 +146,7 @@ class RecorderModule @Inject constructor(
                             recorder = null,
                             persistedLogDir = null,
                             recordingStartedAt = 0L,
+                            recordingStartedAtMonotonic = null,
                             logDir = null,
                         )
                     } else {
@@ -244,8 +251,12 @@ class RecorderModule @Inject constructor(
         val currentState = internalState.value()
         if (!currentState.isRecording) return StopResult.NotRecording
 
-        val duration = System.currentTimeMillis() - currentState.recordingStartedAt
-        if (duration < MIN_RECORDING_MS) return StopResult.TooShort
+        val duration = currentState.recordingStartedAtMonotonic
+            ?.let { monotonicClock() - it }             // live session: immune to wall-clock adjustments
+            ?: (wallClock() - currentState.recordingStartedAt)  // resumed: trigger file persists wall time only
+        // Negative = wall clock moved backward across a resume; fail open (no warning) rather than
+        // trap the user in TooShort.
+        if (duration in 0 until MIN_RECORDING_MS) return StopResult.TooShort
 
         val logDir = stopRecorder() ?: return StopResult.NotRecording
         val sessionId = DebugSessionManager.deriveBaseName(logDir)
@@ -265,6 +276,10 @@ class RecorderModule @Inject constructor(
         val shouldRecord: Boolean = false,
         internal val recorder: Recorder? = null,
         val recordingStartedAt: Long = 0L,
+        // Monotonic base for the duration heuristic, null when there is none: a resumed session's
+        // only start time is the persisted wall clock, and a monotonic value from a previous process
+        // or boot is meaningless. Nullable rather than 0L — 0 is a legal elapsedRealtime near boot.
+        val recordingStartedAtMonotonic: Long? = null,
         val logDir: File? = null,
         internal val persistedLogDir: File? = null,
     ) {
@@ -277,7 +292,7 @@ class RecorderModule @Inject constructor(
     internal fun readTriggerFile(): TriggerInfo? {
         return try {
             val content = triggerFile.readText()
-            parseTriggerContent(content)
+            parseTriggerContent(content, wallClock())
         } catch (e: Exception) {
             log(TAG, WARN) { "Failed to read trigger file: $e" }
             null
@@ -300,13 +315,26 @@ class RecorderModule @Inject constructor(
     companion object {
         internal val TAG = logTag("Debug", "Log", "Recorder", "Module")
         private const val FORCE_FILE = "myperm_force_debug_run"
-        internal const val MIN_RECORDING_MS = 5_000L
+
+        /**
+         * Duration heuristic for "did you forget to reproduce the issue?". A recording stopped
+         * this quickly usually contains nothing but the recorder starting and stopping, which
+         * costs a support round-trip to re-request.
+         *
+         * It stays a prompt because short recordings can be perfectly valid: a crash is logged
+         * and flushed immediately, so the reproduction is already on disk. "Stop anyway" works —
+         * the [StopResult.TooShort] consumers (the Support and ContactForm screens) stop via
+         * their direct [stopRecorder] path, which has no duration check.
+         */
+        internal const val MIN_RECORDING_MS = 10_000L
 
         // Budget for the header's diagnostics read.
         private const val HEADER_READ_TIMEOUT_MS = 5_000L
 
+        // The trigger file stores wall-clock timestamps: it has to survive reboots, which monotonic
+        // time does not. [now] is the module's wall clock, defaulted for direct test calls.
         @VisibleForTesting
-        internal fun parseTriggerContent(content: String): TriggerInfo? {
+        internal fun parseTriggerContent(content: String, now: Long = System.currentTimeMillis()): TriggerInfo? {
             if (content.isBlank()) return null
             val lines = content.trim().lines()
             if (lines.size != 2) return null
@@ -315,7 +343,6 @@ class RecorderModule @Inject constructor(
             if (!dir.exists() || !dir.isDirectory) return null
 
             val timestamp = lines[1].toLongOrNull() ?: return null
-            val now = System.currentTimeMillis()
             if (timestamp < 1 || timestamp > now + 60_000L) return null
 
             return TriggerInfo(logDir = dir, startedAt = timestamp)

--- a/app/src/main/java/eu/darken/myperm/common/flow/DynamicStateFlow.kt
+++ b/app/src/main/java/eu/darken/myperm/common/flow/DynamicStateFlow.kt
@@ -5,7 +5,10 @@ import eu.darken.myperm.common.debug.logging.asLog
 import eu.darken.myperm.common.debug.logging.log
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.runBlocking
@@ -129,17 +132,27 @@ class DynamicStateFlow<T>(
      *
      * Any errors that occurred during [action] will be rethrown by this method.
      */
-    suspend fun updateBlocking(action: suspend T.() -> T): T {
+    suspend fun updateBlocking(action: suspend T.() -> T): T = coroutineScope {
         val update: Update<T> = Update(onModify = action)
+
+        // Subscribe BEFORE emitting: UNDISPATCHED runs the awaiter synchronously up to its first
+        // suspension inside first's collect, so the collector is registered on the shared flow
+        // before the update can be processed. Emitting first is a lost wakeup: a fast producer
+        // plus a reactive collector (RecorderModule reacts to every state with its own update)
+        // can process our update AND a successor before we subscribe, displacing our State from
+        // the replay-1 cache — the await then never completes.
+        val awaiter = async(start = CoroutineStart.UNDISPATCHED) {
+            internalFlow.first { it.updatedBy == update }
+        }
         updateActions.emit(update)
 
         lTag?.let { log(it, VERBOSE) { "Waiting for update." } }
-        val ourUpdate = internalFlow.first { it.updatedBy == update }
+        val ourUpdate = awaiter.await()
         lTag?.let { log(it, VERBOSE) { "Finished waiting, got $ourUpdate" } }
 
         ourUpdate.error?.let { throw it }
 
-        return ourUpdate.value
+        ourUpdate.value
     }
 
     private data class Update<T>(

--- a/app/src/test/java/eu/darken/myperm/common/debug/recording/core/RecorderModuleDurationTest.kt
+++ b/app/src/test/java/eu/darken/myperm/common/debug/recording/core/RecorderModuleDurationTest.kt
@@ -1,0 +1,237 @@
+package eu.darken.myperm.common.debug.recording.core
+
+import android.content.Context
+import eu.darken.myperm.common.InstallId
+import eu.darken.myperm.common.coroutine.DispatcherProvider
+import eu.darken.myperm.common.debug.logging.FileLogger
+import eu.darken.myperm.common.debug.logging.Logging
+import eu.darken.myperm.common.upgrade.UpgradeDiagnostics
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import testhelper.coroutine.TestDispatcherProvider
+import java.io.File
+
+/**
+ * The "that recording looks too short" prompt is a duration heuristic, and duration was measured
+ * against the wall clock. A clock adjustment mid-recording (NTP sync, the user changing the time)
+ * therefore either invented a long recording out of a short one or trapped a long recording in the
+ * warning. A live session now measures monotonically; only a session resumed from the trigger file
+ * has to fall back to the persisted wall time, because monotonic time does not survive a reboot.
+ */
+class RecorderModuleDurationTest {
+
+    @TempDir
+    lateinit var externalDir: File
+
+    @TempDir
+    lateinit var cacheDir: File
+
+    private lateinit var context: Context
+    private lateinit var installId: InstallId
+    private lateinit var dispatcherProvider: DispatcherProvider
+    private lateinit var appScope: CoroutineScope
+    private lateinit var upgradeDiagnostics: UpgradeDiagnostics
+
+    @BeforeEach
+    fun setup() {
+        File(externalDir, "debug/logs").mkdirs()
+        File(cacheDir, "debug/logs").mkdirs()
+
+        context = mockk(relaxed = true)
+        every { context.getExternalFilesDir(null) } returns externalDir
+        every { context.cacheDir } returns cacheDir
+
+        installId = mockk()
+        every { installId.id } returns "abcdef12-0000-0000-0000-000000000000"
+
+        dispatcherProvider = TestDispatcherProvider()
+        appScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher())
+
+        // Inert diagnostics: the header reads are covered by RecorderModuleDiagnosticsTest, these
+        // fixtures only need them to not touch storage.
+        upgradeDiagnostics = mockk(relaxed = true)
+    }
+
+    @AfterEach
+    fun teardown() {
+        appScope.cancel()
+    }
+
+    // Test-controlled clocks, handed to the module's two seams. The durations under test are
+    // wall-clock/monotonic, so virtual time cannot drive them.
+    private class TestClocks(var wall: Long, var monotonic: Long)
+
+    /**
+     * The recorder is stopped in a nested finally, before the scope goes: cancelling the scope alone
+     * does NOT uninstall a running recorder's globally installed [FileLogger], and the forward-jump
+     * case deliberately ends still recording. A leaked logger must fail THIS test rather than write
+     * into every later one.
+     *
+     * [seededTrigger] is a persisted wall-clock start time for a resumable session. It is written
+     * BEFORE the module is constructed — seeding it afterwards races the init collector, which on
+     * the unconfined dispatcher resumes the session during construction. That also means a resumed
+     * session's start runs against the default clocks; only the seams the assertions depend on
+     * (the stop-time reads) are under test control there.
+     */
+    private fun withModule(
+        clocks: TestClocks,
+        seededTrigger: Long? = null,
+        block: suspend (RecorderModule) -> Unit,
+    ) {
+        val fileLoggersBefore = Logging.loggers.filterIsInstance<FileLogger>()
+        val triggerFile = File(externalDir, "myperm_force_debug_run")
+        if (seededTrigger != null) {
+            // PP's real two-line trigger format: session dir + wall-clock start time.
+            val sessionDir = File(externalDir, "debug/logs/myperm_resumed_session").also { it.mkdirs() }
+            triggerFile.writeText("${sessionDir.absolutePath}\n$seededTrigger")
+        } else if (triggerFile.exists()) {
+            triggerFile.delete()
+        }
+
+        var module: RecorderModule? = null
+        try {
+            try {
+                val created = RecorderModule(
+                    context = context,
+                    appScope = appScope,
+                    dispatcherProvider = dispatcherProvider,
+                    installId = installId,
+                    upgradeDiagnostics = upgradeDiagnostics,
+                ).apply {
+                    wallClock = { clocks.wall }
+                    monotonicClock = { clocks.monotonic }
+                }
+                module = created
+                // Envelope: a wedged start or stop must fail in seconds, not hold the gradle worker.
+                runBlocking {
+                    withTimeout(TEST_ENVELOPE_MS) {
+                        if (seededTrigger != null) created.state.first { it.isRecording }
+                        block(created)
+                    }
+                }
+            } finally {
+                module?.let { runBlocking { withTimeoutOrNull(TEST_ENVELOPE_MS) { it.stopRecorder() } } }
+            }
+        } finally {
+            appScope.cancel()
+            if (triggerFile.exists()) triggerFile.delete()
+            // Remove stragglers after asserting so one failure can't cascade into later tests.
+            val leaked = Logging.loggers.filterIsInstance<FileLogger>() - fileLoggersBefore.toSet()
+            leaked.forEach { Logging.remove(it) }
+            leaked shouldBe emptyList<FileLogger>()
+        }
+    }
+
+    @Test
+    fun `an eight second recording warns`() {
+        val clocks = TestClocks(wall = WALL_BASE, monotonic = 100_000L)
+        withModule(clocks) { module ->
+            module.startRecorder()
+
+            clocks.monotonic += 8_000L
+            module.requestStopRecorder() shouldBe RecorderModule.StopResult.TooShort
+            module.state.first().isRecording shouldBe true
+
+            // "Stop anyway" is the user's own next step, and past the threshold it stops cleanly.
+            clocks.monotonic += 3_000L
+            module.requestStopRecorder().shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
+            module.state.first().isRecording shouldBe false
+        }
+    }
+
+    @Test
+    fun `a ten second recording stops`() {
+        val clocks = TestClocks(wall = WALL_BASE, monotonic = 100_000L)
+        withModule(clocks) { module ->
+            module.startRecorder()
+
+            clocks.monotonic += 10_000L
+
+            val result = module.requestStopRecorder()
+            result.shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
+            result.logDir.exists() shouldBe true
+            result.sessionId.isNotEmpty() shouldBe true
+            module.state.first().isRecording shouldBe false
+        }
+    }
+
+    @Test
+    fun `a backward wall-clock jump does not warn on a long recording`() {
+        val clocks = TestClocks(wall = WALL_BASE, monotonic = 100_000L)
+        withModule(clocks) { module ->
+            module.startRecorder()
+
+            // Twelve real seconds of recording, and an NTP sync that moves the wall clock an hour
+            // back. Wall-clock measurement would report a negative duration here.
+            clocks.monotonic += 12_000L
+            clocks.wall -= 3_600_000L
+
+            module.requestStopRecorder().shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
+        }
+    }
+
+    @Test
+    fun `a forward wall-clock jump does not skip the warning`() {
+        val clocks = TestClocks(wall = WALL_BASE, monotonic = 100_000L)
+        withModule(clocks) { module ->
+            module.startRecorder()
+
+            // Three real seconds of recording, and a clock correction an hour forward. Wall-clock
+            // measurement would call this a one-hour recording and skip the prompt.
+            clocks.monotonic += 3_000L
+            clocks.wall += 3_600_000L
+
+            module.requestStopRecorder() shouldBe RecorderModule.StopResult.TooShort
+            module.state.first().isRecording shouldBe true
+        }
+    }
+
+    @Test
+    fun `a resumed session measures from the persisted start time`() {
+        // Resumed after a process death: there is no monotonic base to measure against, so the
+        // persisted wall-clock start is all the module has.
+        val base = System.currentTimeMillis()
+        val startedAt = base - 8_000L
+        val clocks = TestClocks(wall = base, monotonic = 100_000L)
+
+        withModule(clocks, seededTrigger = startedAt) { module ->
+            module.requestStopRecorder() shouldBe RecorderModule.StopResult.TooShort
+
+            clocks.wall = startedAt + 10_000L
+            module.requestStopRecorder().shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
+        }
+    }
+
+    @Test
+    fun `a resumed session with a future start time fails open`() {
+        // The persisted start lies in the future (the wall clock moved backward across the resume).
+        // A negative duration must not trap the user in the warning.
+        val base = System.currentTimeMillis()
+        val clocks = TestClocks(wall = base, monotonic = 100_000L)
+
+        withModule(clocks, seededTrigger = base + 60_000L) { module ->
+            module.requestStopRecorder().shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
+        }
+    }
+
+    companion object {
+        // Independent of any production bound: a wedged wait has to fail the test, not hang the
+        // gradle worker.
+        private const val TEST_ENVELOPE_MS = 10_000L
+        private const val WALL_BASE = 1_800_000_000_000L
+    }
+}

--- a/app/src/test/java/eu/darken/myperm/common/flow/DynamicStateFlowTest.kt
+++ b/app/src/test/java/eu/darken/myperm/common/flow/DynamicStateFlowTest.kt
@@ -9,15 +9,21 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Test
 import testhelper.BaseTest
 import testhelper.coroutine.runTest2
 import testhelper.flow.test
 import java.io.IOException
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.concurrent.thread
 
 
@@ -276,6 +282,54 @@ class DynamicStateFlowTest : BaseTest() {
         testCollector.latestValues shouldBe listOf(2, 3, 0)
 
         testCollector.cancelAndJoin()
+    }
+
+    /**
+     * Pre-fix, [DynamicStateFlow.updateBlocking] emitted its update BEFORE subscribing to the
+     * shared flow. Under contention its awaited State could be displaced from the replay-1 cache
+     * by a successor update before the subscription existed, and the await then never completed
+     * (jstack-verified: the pre-fix suite wedged a CI runner until the 6h job timeout). This pins
+     * the subscribe-before-emit contract, and the timeout envelope turns any regression into a
+     * fast failure instead of another wedged runner.
+     */
+    @Test
+    fun `concurrent blocking updates survive a reactive collector`() {
+        val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        try {
+            val hotData = DynamicStateFlow(
+                loggingTag = "tag",
+                parentScope = scope,
+                startValueProvider = { 0 },
+            )
+
+            // Mirrors RecorderModule: a collector that reacts to every state with an update of its
+            // own, keeping the producer busy between the other callers' updates. The echo updates
+            // are value-neutral so the final count stays exact, and capped so the echo terminates.
+            val echoes = AtomicInteger(0)
+            scope.launch {
+                hotData.flow.collect { value ->
+                    if (value % 2 == 1 && echoes.getAndIncrement() < 100) {
+                        hotData.updateAsync { this + 0 }
+                    }
+                }
+            }
+
+            runBlocking {
+                withTimeout(20_000) {
+                    val workers = (1..2).map {
+                        launch(Dispatchers.IO) {
+                            repeat(100) { hotData.updateBlocking { this + 1 } }
+                        }
+                    }
+                    workers.forEach { it.join() }
+                    workers.all { it.isCompleted } shouldBe true
+
+                    hotData.flow.first() shouldBe 200
+                }
+            }
+        } finally {
+            scope.cancel()
+        }
     }
 
     @Test

--- a/app/src/testFoss/java/eu/darken/myperm/common/upgrade/core/UpgradeRepoFossPersistTest.kt
+++ b/app/src/testFoss/java/eu/darken/myperm/common/upgrade/core/UpgradeRepoFossPersistTest.kt
@@ -1,0 +1,139 @@
+package eu.darken.myperm.common.upgrade.core
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import eu.darken.myperm.common.WebpageTool
+import eu.darken.myperm.common.serialization.SerializationModule
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import testhelper.BaseTest
+import java.io.File
+import java.time.Instant
+
+/**
+ * The FOSS supporter record is create-only-if-absent: the sponsor-return heuristic can fire again
+ * for someone who is already a supporter (the recurring-donation button, or a stale entitlement
+ * replay), and a rewrite would move their "supporter since" date — and, for the legacy records
+ * every existing supporter has, replace their stored reason too.
+ *
+ * Driven through a real DataStore on a temp file via [FossCache]'s test seam, because the guarantee
+ * is the store transaction's, not the caller's.
+ */
+class UpgradeRepoFossPersistTest : BaseTest() {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    // One store scope per test: the DataStore keeps its own actor alive on it.
+    private var storeScope: CoroutineScope? = null
+
+    @AfterEach
+    fun teardown() {
+        storeScope?.cancel()
+        storeScope = null
+    }
+
+    private class Harness(val cache: FossCache, val repo: UpgradeRepoFoss)
+
+    // Unique file name per test method: DataStore forbids two active instances on the same file.
+    private fun TestScope.buildHarness(storeName: String): Harness {
+        val scope = CoroutineScope(Dispatchers.IO + SupervisorJob()).also { storeScope = it }
+        val dataStore = PreferenceDataStoreFactory.create(
+            scope = scope,
+            produceFile = { File(tempDir, "$storeName.preferences_pb") },
+        )
+        val cache = FossCache(dataStore, SerializationModule().json())
+        val repo = UpgradeRepoFoss(
+            // backgroundScope: the repo's shareIn keeps a collector alive for the scope's lifetime.
+            appScope = backgroundScope,
+            fossCache = cache,
+            webpageTool = mockk<WebpageTool>(relaxed = true),
+        )
+        return Harness(cache, repo)
+    }
+
+    @Test
+    fun `persistUpgrade keeps an existing legacy record`() = runTest {
+        val harness = buildHarness("legacy_record")
+        // A legacy 2022-schema value: a rewrite would corrupt BOTH the date and the reason.
+        harness.cache.upgrade.value(
+            FossUpgrade(
+                upgradedAt = Instant.EPOCH,
+                reason = FossUpgrade.Reason.NO_MONEY,
+            )
+        )
+
+        harness.repo.persistUpgrade() shouldBe false
+
+        harness.cache.upgrade.value() shouldBe FossUpgrade(
+            upgradedAt = Instant.EPOCH,
+            reason = FossUpgrade.Reason.NO_MONEY,
+        )
+        harness.repo.upgradeInfo.first().apply {
+            isPro shouldBe true
+            upgradedAt shouldBe Instant.EPOCH
+        }
+    }
+
+    @Test
+    fun `persistUpgrade creates on an empty store`() = runTest {
+        val harness = buildHarness("empty_store")
+        harness.cache.upgrade.value() shouldBe null
+
+        // Plain, untruncated: PP's InstantSerializer is ISO-8601 and preserves nanoseconds, so the
+        // stored value can be compared against a nanosecond-precision bracket.
+        val before = Instant.now()
+        harness.repo.persistUpgrade() shouldBe true
+        val after = Instant.now()
+
+        val created = harness.cache.upgrade.value()
+        created shouldNotBe null
+        created!!.reason shouldBe FossUpgrade.Reason.GITHUB_SPONSORS
+        (created.upgradedAt >= before) shouldBe true
+        (created.upgradedAt <= after) shouldBe true
+
+        // Boolean-proven keep: immune to a timestamp collision between the two writes.
+        harness.repo.persistUpgrade() shouldBe false
+        harness.cache.upgrade.value() shouldBe created
+    }
+
+    @Test
+    fun `concurrent persists elect exactly one creator`() = runTest {
+        val harness = buildHarness("concurrent")
+        harness.cache.upgrade.value() shouldBe null
+
+        val before = Instant.now()
+        val gate = CompletableDeferred<Unit>()
+        val racers = List(2) {
+            async(Dispatchers.IO) {
+                gate.await()
+                harness.repo.persistUpgrade()
+            }
+        }
+        gate.complete(Unit)
+        val results = racers.awaitAll()
+        val after = Instant.now()
+
+        // Exactly one creator: the loser must report the record it found, not a second creation.
+        results.sorted() shouldBe listOf(false, true)
+
+        val record = harness.cache.upgrade.value()
+        record shouldNotBe null
+        record!!.reason shouldBe FossUpgrade.Reason.GITHUB_SPONSORS
+        (record.upgradedAt >= before) shouldBe true
+        (record.upgradedAt <= after) shouldBe true
+    }
+}

--- a/app/src/testFoss/java/eu/darken/myperm/common/upgrade/ui/FossUpgradeScreenHostTest.kt
+++ b/app/src/testFoss/java/eu/darken/myperm/common/upgrade/ui/FossUpgradeScreenHostTest.kt
@@ -41,7 +41,7 @@ class FossUpgradeScreenHostTest : BaseTest() {
     private fun mockRepo(): UpgradeRepoFoss = mockk<UpgradeRepoFoss>(relaxed = true).apply {
         every { upgradeInfo } returns MutableStateFlow(UpgradeRepoFoss.Info())
         every { openGithubSponsorsPage() } returns true
-        coEvery { persistUpgrade() } answers { persisted++ }
+        coEvery { persistUpgrade() } answers { persisted++; true }
     }
 
     private fun buildVm(

--- a/app/src/testFoss/java/eu/darken/myperm/common/upgrade/ui/FossUpgradeViewModelTest.kt
+++ b/app/src/testFoss/java/eu/darken/myperm/common/upgrade/ui/FossUpgradeViewModelTest.kt
@@ -1,5 +1,6 @@
 package eu.darken.myperm.common.upgrade.ui
 
+import android.os.SystemClock
 import androidx.lifecycle.SavedStateHandle
 import eu.darken.myperm.R
 import eu.darken.myperm.common.navigation.NavEvent
@@ -8,15 +9,21 @@ import eu.darken.myperm.common.upgrade.core.FossUpgrade
 import eu.darken.myperm.common.upgrade.core.UpgradeRepoFoss
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -33,6 +40,7 @@ import testhelper.BaseTest
 import testhelpers.TestApplication
 import testhelper.coroutine.TestDispatcherProvider
 import testhelper.coroutine.runTest2
+import java.io.IOException
 import java.time.Duration
 import java.time.Instant
 
@@ -63,6 +71,9 @@ class FossUpgradeViewModelTest : BaseTest() {
     ): UpgradeRepoFoss = mockk<UpgradeRepoFoss>(relaxed = true).apply {
         every { upgradeInfo } returns info
         every { openGithubSponsorsPage() } returns true
+        // Explicit: a relaxed mock would answer the Boolean with false, i.e. "record already
+        // existed", silently turning every thanks-toast assertion below into a no-op.
+        coEvery { persistUpgrade() } returns true
     }
 
     private fun buildVm(
@@ -304,8 +315,9 @@ class FossUpgradeViewModelTest : BaseTest() {
 
     /**
      * The recurring-donation button on the upgraded status screen goes to the same sponsors page,
-     * so an existing supporter routinely comes back past the delay. Persisting again would rewrite
-     * upgradedAt and visibly reset the "supporter since" date they are being shown.
+     * so an existing supporter routinely comes back past the delay. The store transaction keeps the
+     * existing record either way, so this is about the feedback: no redundant write attempt, and no
+     * thanks toast for an unlock that already happened.
      */
     @Test
     fun `a returning supporter is not re-upgraded and keeps their supporter-since date`() = runTest2(
@@ -328,6 +340,163 @@ class FossUpgradeViewModelTest : BaseTest() {
         vm.state.value!!.supporterSince shouldBe Instant.EPOCH
         // The launch is still consumed: a stale pending launch would fire on some later resume.
         vm.hasPendingSponsorLaunch() shouldBe false
+    }
+
+    @Test
+    fun `a sponsor return whose record already existed stays quiet`() = runTest2(context = testDispatcher) {
+        // The isPro fast path reads a shareIn replay that can be stale, so a supporter's return can
+        // get past it. Only the store transaction knows the record is already there — it keeps it
+        // and reports "not created", and there is no unlock to thank anyone for.
+        val repo = mockRepo()
+        coEvery { repo.persistUpgrade() } returns false
+        val vm = buildVm(repo = repo)
+
+        val nudges = mutableListOf<Int>()
+        val thanks = mutableListOf<Int>()
+        val snackbarCollector = launch(start = CoroutineStart.UNDISPATCHED) {
+            vm.snackbarEvents.collect { nudges.add(it) }
+        }
+        val toastCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.toastEvents.collect { thanks.add(it) } }
+
+        vm.goGithubSponsors()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { repo.persistUpgrade() }
+        thanks.shouldBeEmpty()
+        nudges.shouldBeEmpty()
+        // Consumed: the visit was evaluated, there is nothing left to retry.
+        vm.hasPendingSponsorLaunch() shouldBe false
+
+        snackbarCollector.cancel()
+        toastCollector.cancel()
+    }
+
+    @Test
+    fun `a failed persist restores the pending sponsor launch`() = runTest2(context = testDispatcher) {
+        // The marker is consumed before the write. If the write then fails, dropping it would eat a
+        // valid sponsor visit for good — the next return/resume has to be able to retry the unlock.
+        val repo = mockRepo()
+        coEvery { repo.persistUpgrade() } throws IOException("write failed")
+        val vm = buildVm(repo = repo)
+
+        val thanks = mutableListOf<Int>()
+        val errors = mutableListOf<Throwable>()
+        val toastCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.toastEvents.collect { thanks.add(it) } }
+        val errorCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.errorEvents.collect { errors.add(it) } }
+
+        vm.goGithubSponsors()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        vm.hasPendingSponsorLaunch() shouldBe true
+        thanks.shouldBeEmpty()
+        // Rethrown, not swallowed: the failure still travels the normal error path.
+        errors.single().shouldBeInstanceOf<IOException>()
+
+        toastCollector.cancel()
+        errorCollector.cancel()
+    }
+
+    @Test
+    fun `a thrown entitlement read restores the pending sponsor launch`() = runTest2(context = testDispatcher) {
+        // The guard's entitlement read happens after the marker was consumed, so it can eat the
+        // sponsor visit just as a failed write can. Installed after arming: the ViewModel's own init
+        // collectors already hold the working flow, so the only failing read is the guard's.
+        // Scope: this covers the THROWN-read path. A production read that HANGS instead of throwing
+        // is a separate, separately filed canonical item.
+        val repo = mockRepo()
+        val vm = buildVm(repo = repo)
+
+        val thanks = mutableListOf<Int>()
+        val errors = mutableListOf<Throwable>()
+        val toastCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.toastEvents.collect { thanks.add(it) } }
+        val errorCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.errorEvents.collect { errors.add(it) } }
+
+        vm.goGithubSponsors()
+        advanceUntilIdle()
+        every { repo.upgradeInfo } returns flow { throw IOException("read failed") }
+
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        vm.hasPendingSponsorLaunch() shouldBe true
+        thanks.shouldBeEmpty()
+        coVerify(exactly = 0) { repo.persistUpgrade() }
+        errors.single().shouldBeInstanceOf<IOException>()
+
+        toastCollector.cancel()
+        errorCollector.cancel()
+    }
+
+    @Test
+    fun `a hung entitlement read releases the visit when the screen dies`() = runTest2(context = testDispatcher) {
+        // A read that never answers holds the check open with the marker already consumed. When the
+        // screen goes away the coroutine is cancelled — the catch's cancellation path has to hand
+        // the sponsor visit back, otherwise it is lost with nothing to retry from.
+        val repo = mockRepo()
+        val vm = buildVm(repo = repo)
+
+        vm.goGithubSponsors()
+        advanceUntilIdle()
+        every { repo.upgradeInfo } returns flow { awaitCancellation() }
+
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+        // Suspended inside the guard's read, marker already consumed.
+        vm.hasPendingSponsorLaunch() shouldBe false
+
+        // The ViewModel going away: vmScope shares viewModelScope's job, so this is the cleared VM.
+        vm.vmScope.cancel()
+        advanceUntilIdle()
+
+        vm.hasPendingSponsorLaunch() shouldBe true
+        coVerify(exactly = 0) { repo.persistUpgrade() }
+    }
+
+    @Test
+    fun `a newer sponsor launch survives a failed older attempt`() = runTest2(context = testDispatcher) {
+        // The restore must not clobber a launch armed while the old attempt was still suspended:
+        // the newer visit is the one the user is actually waiting on.
+        val repo = mockRepo()
+        val gate = CompletableDeferred<Unit>()
+        coEvery { repo.persistUpgrade() } coAnswers {
+            gate.await()
+            throw IOException("write failed")
+        }
+        val handle = SavedStateHandle()
+        val vm = buildVm(repo = repo, handle = handle)
+
+        val errors = mutableListOf<Throwable>()
+        val errorCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.errorEvents.collect { errors.add(it) } }
+
+        vm.goGithubSponsors()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+        // Consumed and parked in the write.
+        vm.hasPendingSponsorLaunch() shouldBe false
+
+        // A second sponsor visit while the first attempt is still hanging.
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(30))
+        val newerPressedAt = SystemClock.elapsedRealtime()
+        vm.goGithubSponsors()
+        advanceUntilIdle()
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+
+        vm.hasPendingSponsorLaunch() shouldBe true
+        // Mirrors the ViewModel's private KEY_SPONSOR_PRESSED_AT: the newer timestamp must still be
+        // the one stored, the failed older attempt must not have written its own back over it.
+        handle.get<Long>("sponsor_pressed_at") shouldBe newerPressedAt
+        errors.single().shouldBeInstanceOf<IOException>()
+
+        errorCollector.cancel()
     }
 
     @Test
@@ -372,7 +541,7 @@ class FossUpgradeViewModelTest : BaseTest() {
         context = testDispatcher,
     ) {
         // The status view's donate button is unarmed on purpose: a supporter browsing the sponsors
-        // page for a while must not run the unlock heuristic again and rewrite their upgrade date.
+        // page for a while must not run the unlock heuristic again — no write attempt, no toast.
         val repo = mockRepo(MutableStateFlow(upgradedInfo()))
         val vm = buildVm(repo = repo)
 

--- a/app/src/testShared/java/testhelpers/datastore/MockDataStoreValue.kt
+++ b/app/src/testShared/java/testhelpers/datastore/MockDataStoreValue.kt
@@ -18,7 +18,10 @@ inline fun <reified T> mockDataStoreValue(
     }
     coEvery { instance.update(any()) } answers {
         val transform = arg<(T) -> T>(0)
-        flow.value = transform(flow.value)
+        val old = flow.value
+        val new = transform(old)
+        flow.value = new
+        DataStoreValue.Updated(old = old, new = new)
     }
     every { instance.valueBlocking } answers { flow.value }
     every { instance.valueBlocking = any() } answers {


### PR DESCRIPTION
## What changed

FOSS version: an existing supporter's "supporter since" date is now protected by the storage layer itself and can no longer be reset by re-visiting the sponsors page. The "thanks for supporting" toast only appears when supporter status was actually newly granted, and if checking or saving the supporter status fails, the pending unlock is no longer lost — the next return to the app retries it (without clobbering a newer visit started in the meantime).

Both versions: the "that debug log looks too short" warning now catches recordings up to 10 seconds (previously 5 — an 8-second log containing nothing but the recorder starting and stopping slipped through in a real support case), and it no longer misjudges the recording length when the device clock changes mid-recording. Also fixed: a rare internal race that could hang state updates (it wedged a CI runner for 6 hours in a sibling project before being caught).

## Technical Context

- The race fix comes first: `DynamicStateFlow.updateBlocking` emitted its update before subscribing to the replay-1 shared flow, so a fast producer plus a reactive collector (exactly `RecorderModule`'s react-to-every-state pattern) could displace the awaited emission before the subscription existed — the caller then suspended forever. Reproduced and thread-dump-verified in capod on 2-core runners; fixed by registering the awaiter with `CoroutineStart.UNDISPATCHED` before emitting, pinned by a contention regression test. The new duration tests would trigger the unfixed race, hence the commit order.
- Root cause (supporter date): `persistUpgrade()` unconditionally overwrote the record; the VM's already-Pro guard reads a `shareIn(replay = 1)` flow whose stale replay can report not-Pro for an upgraded user. The persist is now a create-only-if-absent transaction returning whether a record was created. Prerequisite: `DataStoreValue.update()` now returns `Updated(old, new)` (previously `Unit`) — source-compatible, and aligns the helper with its siblings in the other apps.
- The pending-return marker restore wraps everything after the marker consume and is conditional — a newer launch armed while a failed attempt was suspended survives. A caveat is documented in the KDoc: the kotlinx `createValue` default (`fallbackToDefault = true`) means an undecodable stored record reads as null and counts as absent (matching pre-existing read behavior; re-creating on the next visit is the recovery path).
- Recording duration previously used `currentTimeMillis()` end to end: a backward clock jump trapped long recordings in the warning, a forward jump let short ones skip it. Live sessions now measure via `elapsedRealtime()` (nullable monotonic base in state — 0 is a legal value near boot); sessions resumed from the trigger file keep the persisted wall time and fail open on negative deltas. The wall-clock seam also governs trigger-file validation so the duration tests control every clock read.
- Review guidance: the new persist tests run on `FossCache`'s constructor seam against per-test temp-file stores (including a two-coroutine race electing exactly one creator); `FossCacheLegacyRecordTest` continues to cover the real-file delegate + migration. The duration-test harness stops recorders in nested finally and fails on any newly installed `FileLogger` — cancelling the scope alone would leak it into later tests.
