### PR TITLE
Watcher: Show last known permissions on uninstall reports

### DIFF
--- a/app/src/main/java/eu/darken/myperm/watcher/ui/detail/PermissionCards.kt
+++ b/app/src/main/java/eu/darken/myperm/watcher/ui/detail/PermissionCards.kt
@@ -98,7 +98,7 @@ internal fun PermissionCards(
             }
         }
         WatcherEventType.REMOVED -> {
-            val perms = diff.addedPermissions + diff.addedDeclared
+            val perms = diff.removedPermissions + diff.removedDeclared
             if (perms.isNotEmpty()) {
                 PermissionCategoryCard(
                     title = pluralStringResource(R.plurals.watcher_detail_last_permissions_header, perms.size, perms.size),

--- a/app/src/test/java/eu/darken/myperm/watcher/ui/detail/PermissionCardsTest.kt
+++ b/app/src/test/java/eu/darken/myperm/watcher/ui/detail/PermissionCardsTest.kt
@@ -1,0 +1,54 @@
+package eu.darken.myperm.watcher.ui.detail
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import eu.darken.myperm.watcher.core.PermissionDiff
+import eu.darken.myperm.watcher.core.WatcherEventType
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+class PermissionCardsTest : BaseComposeRobolectricTest() {
+
+    @Test
+    fun `removed event shows removed permissions`() {
+        val diff = PermissionDiff(
+            removedPermissions = listOf("android.permission.CAMERA"),
+            removedDeclared = listOf("android.permission.INTERNET"),
+        )
+
+        composeRule.setContent {
+            MaterialTheme {
+                PermissionCards(
+                    diff = diff,
+                    eventType = WatcherEventType.REMOVED,
+                    enrichedMap = emptyMap(),
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("android.permission.CAMERA").assertIsDisplayed()
+        composeRule.onNodeWithText("android.permission.INTERNET").assertIsDisplayed()
+    }
+
+    @Test
+    fun `removed event ignores added permissions`() {
+        val diff = PermissionDiff(
+            addedPermissions = listOf("android.permission.CAMERA"),
+            addedDeclared = listOf("android.permission.INTERNET"),
+        )
+
+        composeRule.setContent {
+            MaterialTheme {
+                PermissionCards(
+                    diff = diff,
+                    eventType = WatcherEventType.REMOVED,
+                    enrichedMap = emptyMap(),
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("android.permission.CAMERA").assertDoesNotExist()
+        composeRule.onNodeWithText("android.permission.INTERNET").assertDoesNotExist()
+    }
+}


### PR DESCRIPTION
## What changed

When an app is uninstalled, its change report now shows the permissions that app had. Previously an uninstall
report displayed only the header and event details — the "Last known permissions" section never appeared, no
matter how many permissions the removed app held.

## Technical Context

- Root cause: `WatcherDiffRunner` writes an uninstall's permissions into `PermissionDiff.removedPermissions` /
  `removedDeclared`, but the `REMOVED` branch of the report UI read `addedPermissions` / `addedDeclared`. Those are
  always empty for that event type, so the `isNotEmpty()` guard never passed and the card was skipped entirely.
- The other three event types were unaffected — `INSTALL` legitimately reads the `added*` lists, and `UPDATE` reads
  both pairs.
- The new test is the first user of `testhelpers/compose/BaseComposeRobolectricTest`, which existed but had no
  subclasses. It works as-is; no harness changes were needed.
- The test asserts both directions: `removed*` renders, and a `REMOVED` diff carrying only `added*` renders nothing.
  The second case is what stops the two list pairs from being silently swapped back. Both cases were confirmed to
  fail against the pre-fix source.
