### PR TITLE
General: Make package names and permission IDs copyable

### DIFF
--- a/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/apps/ui/details/AppDetailsScreen.kt
@@ -69,6 +69,7 @@ import eu.darken.myperm.R
 import eu.darken.myperm.apps.core.Pkg
 import eu.darken.myperm.apps.core.features.UsesPermission
 import eu.darken.myperm.common.compose.AppIcon
+import eu.darken.myperm.common.compose.CopyableText
 import eu.darken.myperm.common.compose.LoadingContent
 import eu.darken.myperm.common.compose.GrantStatusPill
 import eu.darken.myperm.common.compose.Pill
@@ -260,13 +261,7 @@ fun AppDetailsScreen(
                                             )
                                         }
                                     }
-                                    Text(
-                                        text = state.packageName.value,
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                        maxLines = 1,
-                                        overflow = TextOverflow.Ellipsis,
-                                    )
+                                    CopyableText(text = state.packageName.value)
                                     if (state.versionName != null || state.versionCode != null) {
                                         Text(
                                             text = listOfNotNull(state.versionName, state.versionCode?.let { "($it)" }).joinToString(" "),

--- a/app/src/main/java/eu/darken/myperm/common/compose/CopyableText.kt
+++ b/app/src/main/java/eu/darken/myperm/common/compose/CopyableText.kt
@@ -1,0 +1,102 @@
+package eu.darken.myperm.common.compose
+
+import android.content.ClipData
+import android.os.Build
+import android.widget.Toast
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import eu.darken.myperm.R
+import eu.darken.myperm.common.debug.logging.Logging.Priority.WARN
+import eu.darken.myperm.common.debug.logging.asLog
+import eu.darken.myperm.common.debug.logging.log
+import eu.darken.myperm.common.debug.logging.logTag
+import kotlinx.coroutines.launch
+
+private val TAG = logTag("Common", "CopyableText")
+
+@Composable
+fun CopyableText(
+    text: String,
+    modifier: Modifier = Modifier,
+    style: TextStyle = MaterialTheme.typography.bodySmall,
+    color: Color = MaterialTheme.colorScheme.onSurfaceVariant,
+    fontFamily: FontFamily? = null,
+) {
+    val context = LocalContext.current
+    val clipboard = LocalClipboard.current
+    val scope = rememberCoroutineScope()
+
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        SelectionContainer(modifier = Modifier.weight(1f, fill = false)) {
+            Text(
+                text = text,
+                style = style,
+                color = color,
+                fontFamily = fontFamily,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        IconButton(
+            onClick = {
+                scope.launch {
+                    val copied = try {
+                        clipboard.setClipEntry(
+                            ClipEntry(ClipData.newPlainText(context.getString(R.string.app_name), text))
+                        )
+                        true
+                    } catch (e: Exception) {
+                        log(TAG, WARN) { "Failed to copy to clipboard: ${e.asLog()}" }
+                        false
+                    }
+                    // Android 13+ shows its own system clipboard confirmation
+                    if (copied && Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+                        Toast.makeText(context, R.string.general_copied_to_clipboard_msg, Toast.LENGTH_SHORT).show()
+                    }
+                }
+            },
+        ) {
+            Icon(
+                imageVector = Icons.Filled.ContentCopy,
+                contentDescription = stringResource(R.string.general_copy_action),
+                modifier = Modifier.size(16.dp),
+                tint = color,
+            )
+        }
+    }
+}
+
+@Preview2
+@Composable
+private fun CopyableTextPreview() = PreviewWrapper {
+    CopyableText(text = "eu.darken.myperm")
+}
+
+@Preview2
+@Composable
+private fun CopyableTextLongPreview() = PreviewWrapper {
+    CopyableText(text = "android.permission.ACCESS_BACKGROUND_LOCATION_AND_MORE_VERY_LONG_IDENTIFIER")
+}

--- a/app/src/main/java/eu/darken/myperm/permissions/ui/details/PermissionDetailsScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/details/PermissionDetailsScreen.kt
@@ -55,6 +55,7 @@ import eu.darken.myperm.R
 import eu.darken.myperm.apps.core.Pkg
 import eu.darken.myperm.apps.core.features.UsesPermission
 import eu.darken.myperm.common.compose.AppIcon
+import eu.darken.myperm.common.compose.CopyableText
 import eu.darken.myperm.common.compose.LabeledOption
 import eu.darken.myperm.common.compose.LoadingContent
 import eu.darken.myperm.common.compose.MultiChoiceFilterDialog
@@ -215,13 +216,7 @@ fun PermissionDetailsScreen(
                                         text = state.description ?: state.label,
                                         style = MaterialTheme.typography.titleMedium,
                                     )
-                                    Text(
-                                        text = state.permissionId,
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                        maxLines = 1,
-                                        overflow = TextOverflow.Ellipsis,
-                                    )
+                                    CopyableText(text = state.permissionId)
                                 }
                                 IconButton(
                                     onClick = onPermissionHelpClicked,

--- a/app/src/main/java/eu/darken/myperm/permissions/ui/details/PermissionDetailsViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/permissions/ui/details/PermissionDetailsViewModel.kt
@@ -95,7 +95,15 @@ class PermissionDetailsViewModel @Inject constructor(
             permissionsRepo.permissions.map { perms -> perms.singleOrNull { it.id == permId } },
             generalSettings.permissionDetailsFilterOptions.flow,
         ) { perm, filterOpts ->
-            if (perm == null) return@combine State(label = initialLabel ?: permId.value, isLoading = true)
+            // The repo skips Loading and maps Error to an empty list, so an unresolved permission here
+            // is terminal (e.g. a custom permission whose declaring app was updated or uninstalled).
+            if (perm == null) {
+                return@combine State(
+                    label = initialLabel ?: permId.value.substringAfterLast('.'),
+                    permissionId = permId.value,
+                    isLoading = false,
+                )
+            }
 
             val declaring = perm.declaringApps.map { ref ->
                 DeclaringAppItem(

--- a/app/src/main/java/eu/darken/myperm/watcher/ui/detail/PermissionCards.kt
+++ b/app/src/main/java/eu/darken/myperm/watcher/ui/detail/PermissionCards.kt
@@ -15,12 +15,14 @@ import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.automirrored.filled.HelpOutline
 import androidx.compose.material.icons.filled.Cancel
 import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -50,6 +52,7 @@ internal fun PermissionCards(
     diff: PermissionDiff,
     eventType: WatcherEventType,
     enrichedMap: Map<String, EnrichedPermission>,
+    onViewPermission: (String) -> Unit,
 ) {
     when (eventType) {
         WatcherEventType.INSTALL -> {
@@ -62,6 +65,7 @@ internal fun PermissionCards(
                     permissions = perms,
                     enrichedMap = enrichedMap,
                     showGrantType = true,
+                    onViewPermission = onViewPermission,
                 )
             }
         }
@@ -75,6 +79,7 @@ internal fun PermissionCards(
                     permissions = added,
                     enrichedMap = enrichedMap,
                     showGrantType = true,
+                    onViewPermission = onViewPermission,
                 )
             }
             val removed = diff.removedPermissions + diff.removedDeclared
@@ -86,6 +91,7 @@ internal fun PermissionCards(
                     permissions = removed,
                     enrichedMap = enrichedMap,
                     showGrantType = false,
+                    onViewPermission = onViewPermission,
                 )
             }
             if (diff.grantChanges.isNotEmpty()) {
@@ -94,6 +100,7 @@ internal fun PermissionCards(
                     subtitle = stringResource(R.string.watcher_detail_grant_changes_subtitle),
                     grantChanges = diff.grantChanges,
                     enrichedMap = enrichedMap,
+                    onViewPermission = onViewPermission,
                 )
             }
         }
@@ -107,6 +114,7 @@ internal fun PermissionCards(
                     permissions = perms,
                     enrichedMap = enrichedMap,
                     showGrantType = false,
+                    onViewPermission = onViewPermission,
                 )
             }
         }
@@ -117,6 +125,7 @@ internal fun PermissionCards(
                     subtitle = stringResource(R.string.watcher_detail_grant_changes_subtitle),
                     grantChanges = diff.grantChanges,
                     enrichedMap = enrichedMap,
+                    onViewPermission = onViewPermission,
                 )
             }
         }
@@ -131,6 +140,7 @@ internal fun PermissionCategoryCard(
     permissions: List<String>,
     enrichedMap: Map<String, EnrichedPermission>,
     showGrantType: Boolean,
+    onViewPermission: (String) -> Unit,
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -155,6 +165,7 @@ internal fun PermissionCategoryCard(
                     permissionId = permId,
                     enriched = enrichedMap[permId],
                     showGrantType = showGrantType,
+                    onViewPermission = onViewPermission,
                 )
                 if (index < permissions.lastIndex) {
                     HorizontalDivider(
@@ -173,6 +184,7 @@ private fun EnrichedPermissionEntry(
     permissionId: String,
     enriched: EnrichedPermission?,
     showGrantType: Boolean,
+    onViewPermission: (String) -> Unit,
 ) {
     var expanded by remember { mutableStateOf(false) }
     val hasDescription = enriched?.description != null
@@ -218,6 +230,17 @@ private fun EnrichedPermissionEntry(
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
+            IconButton(onClick = { onViewPermission(permissionId) }) {
+                Icon(
+                    imageVector = Icons.Filled.Info,
+                    contentDescription = stringResource(
+                        R.string.general_view_details_for_x_action,
+                        enriched?.label ?: permissionId,
+                    ),
+                    modifier = Modifier.size(18.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         }
         AnimatedVisibility(visible = expanded && hasDescription) {
             Text(
@@ -254,6 +277,7 @@ internal fun GrantChangesCategoryCard(
     subtitle: String,
     grantChanges: List<PermissionDiff.GrantChange>,
     enrichedMap: Map<String, EnrichedPermission>,
+    onViewPermission: (String) -> Unit,
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -277,6 +301,7 @@ internal fun GrantChangesCategoryCard(
                 GrantChangeEntry(
                     change = change,
                     enriched = enrichedMap[change.permissionId],
+                    onViewPermission = onViewPermission,
                 )
                 if (index < grantChanges.lastIndex) {
                     HorizontalDivider(
@@ -294,6 +319,7 @@ internal fun GrantChangesCategoryCard(
 private fun GrantChangeEntry(
     change: PermissionDiff.GrantChange,
     enriched: EnrichedPermission?,
+    onViewPermission: (String) -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -320,6 +346,17 @@ private fun GrantChangeEntry(
                     style = MaterialTheme.typography.labelSmall,
                     fontFamily = FontFamily.Monospace,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            IconButton(onClick = { onViewPermission(change.permissionId) }) {
+                Icon(
+                    imageVector = Icons.Filled.Info,
+                    contentDescription = stringResource(
+                        R.string.general_view_details_for_x_action,
+                        enriched?.label ?: change.permissionId,
+                    ),
+                    modifier = Modifier.size(18.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
         }
@@ -411,6 +448,7 @@ private fun PermissionCategoryCardPreview() {
                 ),
             ),
             showGrantType = true,
+            onViewPermission = {},
         )
     }
 }
@@ -442,6 +480,7 @@ private fun GrantChangesCategoryCardPreview() {
                     grantType = GrantType.RUNTIME,
                 ),
             ),
+            onViewPermission = {},
         )
     }
 }

--- a/app/src/main/java/eu/darken/myperm/watcher/ui/detail/ReportDetailScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/watcher/ui/detail/ReportDetailScreen.kt
@@ -40,6 +40,7 @@ import eu.darken.myperm.R
 import eu.darken.myperm.apps.core.Pkg
 import eu.darken.myperm.apps.core.features.UsesPermission
 import eu.darken.myperm.common.compose.AppIcon
+import eu.darken.myperm.common.compose.CopyableText
 import eu.darken.myperm.common.compose.Pill
 import eu.darken.myperm.common.error.ErrorEventHandler
 import eu.darken.myperm.common.navigation.LocalNavigationController
@@ -67,6 +68,7 @@ fun ReportDetailScreenHost(
     ReportDetailScreen(
         state = state,
         onBack = { navCtrl?.up() },
+        onViewPermission = { vm.onViewPermission(it) },
         onViewApp = { vm.onViewApp() },
     )
 }
@@ -75,6 +77,7 @@ fun ReportDetailScreenHost(
 fun ReportDetailScreen(
     state: ReportDetailViewModel.State,
     onBack: () -> Unit,
+    onViewPermission: (String) -> Unit,
     onViewApp: () -> Unit = {},
 ) {
     Scaffold(
@@ -132,7 +135,12 @@ fun ReportDetailScreen(
                 AppHeaderCard(state)
                 EventDetailsCard(state)
                 if (state.diff != null) {
-                    PermissionCards(state.diff, state.eventType, state.permissionInfoMap)
+                    PermissionCards(
+                        diff = state.diff,
+                        eventType = state.eventType,
+                        enrichedMap = state.permissionInfoMap,
+                        onViewPermission = onViewPermission,
+                    )
                 } else {
                     DiffErrorCard()
                 }
@@ -177,11 +185,7 @@ private fun AppHeaderCard(state: ReportDetailViewModel.State) {
                     text = state.appLabel ?: state.packageName.value,
                     style = MaterialTheme.typography.titleLarge,
                 )
-                Text(
-                    text = state.packageName.value,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
+                CopyableText(text = state.packageName.value)
 
                 Spacer(modifier = Modifier.height(6.dp))
 
@@ -354,6 +358,7 @@ private fun ReportDetailUpdatePreview() {
                 ),
             ),
             onBack = {},
+            onViewPermission = {},
         )
     }
 }
@@ -377,6 +382,7 @@ private fun ReportDetailInstallPreview() {
                 ),
             ),
             onBack = {},
+            onViewPermission = {},
         )
     }
 }
@@ -399,6 +405,7 @@ private fun ReportDetailRemovedPreview() {
                 ),
             ),
             onBack = {},
+            onViewPermission = {},
         )
     }
 }
@@ -422,6 +429,7 @@ private fun ReportDetailGrantChangePreview() {
                 ),
             ),
             onBack = {},
+            onViewPermission = {},
         )
     }
 }

--- a/app/src/main/java/eu/darken/myperm/watcher/ui/detail/ReportDetailViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/watcher/ui/detail/ReportDetailViewModel.kt
@@ -163,6 +163,15 @@ class ReportDetailViewModel @AssistedInject constructor(
         navTo(Nav.Details.AppDetails(current.packageName.value, current.userHandleId, current.appLabel))
     }
 
+    fun onViewPermission(permissionId: String) {
+        navTo(
+            Nav.Details.PermissionDetails(
+                permissionId = permissionId,
+                permLabel = _state.value.permissionInfoMap[permissionId]?.label,
+            )
+        )
+    }
+
     companion object {
         private val TAG = logTag("Watcher", "ReportDetail", "VM")
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -603,6 +603,8 @@
     <string name="general_navigate_up_action">Navigate up</string>
     <string name="general_progress_loading">Loading…</string>
     <string name="general_upgrade_action">Upgrade</string>
+    <string name="general_copy_action">Copy</string>
+    <string name="general_copied_to_clipboard_msg">Copied to clipboard</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
 
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -605,6 +605,7 @@
     <string name="general_upgrade_action">Upgrade</string>
     <string name="general_copy_action">Copy</string>
     <string name="general_copied_to_clipboard_msg">Copied to clipboard</string>
+    <string name="general_view_details_for_x_action">View details for %1$s</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
 
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->

--- a/app/src/test/java/eu/darken/myperm/watcher/ui/detail/PermissionCardsTest.kt
+++ b/app/src/test/java/eu/darken/myperm/watcher/ui/detail/PermissionCardsTest.kt
@@ -2,9 +2,12 @@ package eu.darken.myperm.watcher.ui.detail
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import eu.darken.myperm.watcher.core.PermissionDiff
 import eu.darken.myperm.watcher.core.WatcherEventType
+import io.kotest.matchers.shouldBe
 import org.junit.Test
 import testhelpers.compose.BaseComposeRobolectricTest
 
@@ -23,6 +26,7 @@ class PermissionCardsTest : BaseComposeRobolectricTest() {
                     diff = diff,
                     eventType = WatcherEventType.REMOVED,
                     enrichedMap = emptyMap(),
+                    onViewPermission = {},
                 )
             }
         }
@@ -44,11 +48,58 @@ class PermissionCardsTest : BaseComposeRobolectricTest() {
                     diff = diff,
                     eventType = WatcherEventType.REMOVED,
                     enrichedMap = emptyMap(),
+                    onViewPermission = {},
                 )
             }
         }
 
         composeRule.onNodeWithText("android.permission.CAMERA").assertDoesNotExist()
         composeRule.onNodeWithText("android.permission.INTERNET").assertDoesNotExist()
+    }
+
+    private val cameraDescription = "Allows the app to take pictures and videos"
+
+    private val cameraEnrichedMap = mapOf(
+        "android.permission.CAMERA" to EnrichedPermission(
+            id = "android.permission.CAMERA",
+            label = "Camera",
+            description = cameraDescription,
+            grantType = GrantType.RUNTIME,
+        ),
+    )
+
+    private fun setUpdateWithCamera(onViewPermission: (String) -> Unit) {
+        composeRule.setContent {
+            MaterialTheme {
+                PermissionCards(
+                    diff = PermissionDiff(addedPermissions = listOf("android.permission.CAMERA")),
+                    eventType = WatcherEventType.UPDATE,
+                    enrichedMap = cameraEnrichedMap,
+                    onViewPermission = onViewPermission,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `info button navigates and does not toggle the description`() {
+        var viewed: String? = null
+        setUpdateWithCamera { viewed = it }
+
+        composeRule.onNodeWithContentDescription("View details for Camera").performClick()
+
+        viewed shouldBe "android.permission.CAMERA"
+        composeRule.onNodeWithText(cameraDescription).assertDoesNotExist()
+    }
+
+    @Test
+    fun `clicking the row body toggles the description`() {
+        var viewed: String? = null
+        setUpdateWithCamera { viewed = it }
+
+        composeRule.onNodeWithText("android.permission.CAMERA", useUnmergedTree = true).performClick()
+
+        composeRule.onNodeWithText(cameraDescription, useUnmergedTree = true).assertIsDisplayed()
+        viewed shouldBe null
     }
 }

--- a/app/src/test/java/eu/darken/myperm/watcher/ui/detail/ReportDetailViewModelTest.kt
+++ b/app/src/test/java/eu/darken/myperm/watcher/ui/detail/ReportDetailViewModelTest.kt
@@ -1,0 +1,106 @@
+package eu.darken.myperm.watcher.ui.detail
+
+import android.content.Context
+import eu.darken.myperm.R
+import eu.darken.myperm.apps.core.Pkg
+import eu.darken.myperm.common.navigation.Nav
+import eu.darken.myperm.common.navigation.NavEvent
+import eu.darken.myperm.common.room.dao.PermissionChangeDao
+import eu.darken.myperm.common.room.dao.SnapshotPkgDao
+import eu.darken.myperm.common.room.entity.PermissionChangeEntity
+import eu.darken.myperm.watcher.core.PermissionDiff
+import eu.darken.myperm.watcher.core.WatcherEventType
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelper.BaseTest
+import testhelper.coroutine.TestDispatcherProvider
+
+class ReportDetailViewModelTest : BaseTest() {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private val changeDao: PermissionChangeDao = mockk(relaxed = true)
+    private val snapshotPkgDao: SnapshotPkgDao = mockk(relaxed = true)
+    private val context: Context = mockk(relaxed = true)
+    private val json: Json = Json { ignoreUnknownKeys = true }
+
+    private val locationId = "android.permission.ACCESS_FINE_LOCATION"
+
+    @BeforeEach
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        // ACCESS_FINE_LOCATION resolves via the app's own known-permission table, no PackageManager needed.
+        every { context.getString(R.string.permission_access_precise_location_label) } returns "Precise location"
+        coEvery { changeDao.getById(REPORT_ID) } returns PermissionChangeEntity(
+            id = REPORT_ID,
+            packageName = Pkg.Name("com.example.app"),
+            userHandleId = 0,
+            appLabel = "Example App",
+            versionCode = 2L,
+            versionName = "2.0",
+            eventType = WatcherEventType.UPDATE,
+            changesJson = json.encodeToString(PermissionDiff(addedPermissions = listOf(locationId))),
+            detectedAt = 1000L,
+        )
+    }
+
+    @AfterEach
+    fun teardown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createVM() = ReportDetailViewModel(
+        reportId = REPORT_ID,
+        dispatcherProvider = TestDispatcherProvider(testDispatcher),
+        changeDao = changeDao,
+        snapshotPkgDao = snapshotPkgDao,
+        context = context,
+        json = json,
+    )
+
+    @Test
+    fun `viewing a permission carries the enriched label`() = runTest(testDispatcher) {
+        val vm = createVM()
+        val state = vm.state.first { !it.isLoading }
+        state.permissionInfoMap[locationId]?.label shouldBe "Precise location"
+
+        vm.onViewPermission(locationId)
+
+        val event = vm.navEvents.first().shouldBeInstanceOf<NavEvent.GoTo>()
+        event.destination shouldBe Nav.Details.PermissionDetails(
+            permissionId = locationId,
+            permLabel = "Precise location",
+        )
+    }
+
+    @Test
+    fun `viewing an unknown permission has no label`() = runTest(testDispatcher) {
+        val vm = createVM()
+        vm.state.first { !it.isLoading }
+
+        vm.onViewPermission("com.example.permission.CUSTOM")
+
+        val event = vm.navEvents.first().shouldBeInstanceOf<NavEvent.GoTo>()
+        event.destination shouldBe Nav.Details.PermissionDetails(
+            permissionId = "com.example.permission.CUSTOM",
+            permLabel = null,
+        )
+    }
+
+    companion object {
+        private const val REPORT_ID = 42L
+    }
+}


### PR DESCRIPTION
## What changed

Package names and permission IDs can now be copied. In the app details, change report, and permission details
screens, the identifier under the title is selectable text with a copy button beside it. Tapping the button puts
the identifier on the clipboard; on Android 12 and below a "Copied to clipboard" confirmation appears (Android 13+
shows its own).

Each permission row in a change report also gains an info button that opens that permission's details screen —
the same idea as the existing button that opens the app's details from the report header.

Requested in a Play Store review: package names were visible but not copyable, so users had to use a second app to
get them. The reporter's use cases were building Bitwarden `androidapp://<package>` entries and scripting.

## Technical Context

- **Clipboard access uses Compose's `LocalClipboard`, not the existing `ClipboardHelper`.** `ClipboardHelper` is a
  Hilt `@Singleton` (currently unreferenced) designed for ViewModel use; routing copy through it would mean
  injecting it into three ViewModels and threading an `onCopy` callback through three screens plus their previews
  and the screenshot-test entry points. `LocalClipboard` keeps `CopyableText` self-contained. `ClipboardHelper` is
  left untouched — removing dead code was out of scope here.
- **The copy/info buttons deliberately do not set a size on the `IconButton`.** An outer `Modifier.size(32.dp)`
  (the pattern used by the existing help button in permission details) measures the button with fixed constraints,
  so `minimumInteractiveComponentSize()` cannot reserve its 48dp interactive area, leaving a sub-minimum touch
  target. Only the inner icon is sized. Verified on-device: the new buttons measure exactly 48dp.
- **`PermissionDetailsViewModel` previously spun forever for unresolvable permissions.** It returned
  `isLoading = true` when the permission wasn't in the repo. Since `PermissionRepo.permissions` skips `Loading` and
  maps `Error` to an empty list, that state was terminal, not transient — the spinner never ended. It was
  unreachable before because every caller navigated from live data, but the new info button routes *historical
  snapshot* IDs there, so a custom permission whose declaring app was updated or uninstalled would have hung. It
  now renders a not-found state showing the (copyable) permission ID with empty app sections. Side effect worth
  knowing: a repo error now also renders as "no apps" rather than an endless spinner.
- **The new callback parameters are required rather than defaulted to `{}`**, deliberately diverging from the
  neighbouring `onViewApp: () -> Unit = {}`. A default would let a forgotten forwarding call compile silently.
  Previews pass `{}` explicitly.
- **Review guidance:** the subtle bit is the info `IconButton` nested inside `EnrichedPermissionEntry`'s clickable
  row — it must consume its own click so the description expander doesn't toggle. That's covered by a Robolectric
  Compose test in both directions and was confirmed on-device.
- **Play Store screenshot goldens are now stale** for App Details and Permission Details (they don't show the copy
  button). CI doesn't validate them; the screenshot pipeline regenerates all locales before the next release.
