### PR TITLE
General: Size the copy affordance to the text it labels

### DIFF
--- a/app/src/main/java/eu/darken/myperm/common/compose/CopyableText.kt
+++ b/app/src/main/java/eu/darken/myperm/common/compose/CopyableText.kt
@@ -3,27 +3,37 @@ package eu.darken.myperm.common.compose
 import android.content.ClipData
 import android.os.Build
 import android.widget.Toast
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalViewConfiguration
+import androidx.compose.ui.platform.ViewConfiguration
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import eu.darken.myperm.R
 import eu.darken.myperm.common.debug.logging.Logging.Priority.WARN
@@ -46,6 +56,24 @@ fun CopyableText(
     val clipboard = LocalClipboard.current
     val scope = rememberCoroutineScope()
 
+    // Match the icon to the text it labels. Deliberately no IconButton: its
+    // minimumInteractiveComponentSize() would impose a 48dp box, padding the row.
+    // Long-pressing the text to select is the accessible path to copying.
+    val iconSize = with(LocalDensity.current) {
+        if (style.fontSize.isSp) style.fontSize.toDp() else 12.dp
+    }
+    val interactionSource = remember { MutableInteractionSource() }
+
+    // clickable() otherwise expands its hit area to minimumTouchTargetSize (48dp),
+    // which would reach back over the trailing text and swallow taps meant to start
+    // a selection. Scoped to the icon so nothing else loses touch-target expansion.
+    val viewConfiguration = LocalViewConfiguration.current
+    val exactHitArea = remember(viewConfiguration) {
+        object : ViewConfiguration by viewConfiguration {
+            override val minimumTouchTargetSize: DpSize = DpSize.Zero
+        }
+    }
+
     Row(
         modifier = modifier,
         verticalAlignment = Alignment.CenterVertically,
@@ -60,30 +88,35 @@ fun CopyableText(
                 overflow = TextOverflow.Ellipsis,
             )
         }
-        IconButton(
-            onClick = {
-                scope.launch {
-                    val copied = try {
-                        clipboard.setClipEntry(
-                            ClipEntry(ClipData.newPlainText(context.getString(R.string.app_name), text))
-                        )
-                        true
-                    } catch (e: Exception) {
-                        log(TAG, WARN) { "Failed to copy to clipboard: ${e.asLog()}" }
-                        false
-                    }
-                    // Android 13+ shows its own system clipboard confirmation
-                    if (copied && Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-                        Toast.makeText(context, R.string.general_copied_to_clipboard_msg, Toast.LENGTH_SHORT).show()
-                    }
-                }
-            },
-        ) {
+        CompositionLocalProvider(LocalViewConfiguration provides exactHitArea) {
             Icon(
                 imageVector = Icons.Filled.ContentCopy,
                 contentDescription = stringResource(R.string.general_copy_action),
-                modifier = Modifier.size(16.dp),
                 tint = color,
+                modifier = Modifier
+                    .padding(start = 6.dp)
+                    .size(iconSize)
+                    .clickable(
+                        interactionSource = interactionSource,
+                        indication = ripple(bounded = false, radius = iconSize),
+                        role = Role.Button,
+                    ) {
+                        scope.launch {
+                            val copied = try {
+                                clipboard.setClipEntry(
+                                    ClipEntry(ClipData.newPlainText(context.getString(R.string.app_name), text))
+                                )
+                                true
+                            } catch (e: Exception) {
+                                log(TAG, WARN) { "Failed to copy to clipboard: ${e.asLog()}" }
+                                false
+                            }
+                            // Android 13+ shows its own system clipboard confirmation
+                            if (copied && Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+                                Toast.makeText(context, R.string.general_copied_to_clipboard_msg, Toast.LENGTH_SHORT).show()
+                            }
+                        }
+                    },
             )
         }
     }


### PR DESCRIPTION
## What changed

The copy button next to package names and permission IDs is now the same size as the text it sits beside, instead
of a 48dp button. Previously it padded the hero card rows noticeably — the version line was pushed away from the
package name to make room for a tap target much larger than the text.

It also no longer steals taps from the text: the oversized touch area used to extend back over the end of a long
identifier, so tapping there to start a text selection could trigger a copy instead.

## Technical Context

- **Root cause of the padding**: `IconButton` applies `minimumInteractiveComponentSize()` (48dp). In a hero card
  that turned a 16dp identifier line into a 48dp row.
- **Root cause of the stolen taps**: separately from layout, `Modifier.clickable` expands its *hit* bounds to
  `ViewConfiguration.minimumTouchTargetSize`. Removing the `IconButton` fixed the layout but left a 126px hit box
  on a 32px icon — confirmed by measuring the UI hierarchy on-device, not by reading the code. Because the icon is
  hit-tested after the `Text`, that overlap won. A `ViewConfiguration` override scoped to the icon via
  `CompositionLocalProvider` removes the expansion without affecting any other component.
- **Icon size derives from `style.fontSize`** rather than a constant, so the affordance stays proportional if a
  caller passes a different text style. Falls back to 12dp if the style's font size isn't in sp.
- **The 6dp gap is applied before `.size()`/`.clickable()`**, so it is outside the hit area — the clickable region
  is exactly the icon.

### Accessibility tradeoff — deliberate

The tap target is now below the 48dp guideline. This is an intentional product decision: long-pressing the
identifier to select it is the primary way to copy and is unaffected, with the icon acting as the visual cue that
the text is copyable plus a shortcut for power users. The icon keeps `Role.Button` semantics and its content
description, so screen readers still announce and activate it.

Measured on an API 30 emulator at 420dpi: the copy node went from 126x126px (48dp) to 32x32px (12dp), sitting
entirely within the 42px text row. Copy-to-clipboard and the pre-33 confirmation toast were re-verified working.
