### PR TITLE
Fix: Stop failed debug-log starts from crashing or losing data

### DIFF
--- a/app/src/main/java/eu/darken/myperm/common/debug/logging/FileLogger.kt
+++ b/app/src/main/java/eu/darken/myperm/common/debug/logging/FileLogger.kt
@@ -25,7 +25,11 @@ class FileLogger(private val logFile: File) : Logging.Logger {
         if (logWriter != null) return
 
         logFile.parentFile!!.mkdirs()
-        if (logFile.createNewFile()) {
+        // Whether THIS attempt created the file decides what a failure below may delete: a resumed
+        // session appends to a log file that already holds the previous recording, and failing to
+        // open it must not erase it.
+        val createdNow = logFile.createNewFile()
+        if (createdNow) {
             Log.i(TAG, "File logger writing to " + logFile.path)
         }
         if (logFile.setReadable(true, false)) {
@@ -44,7 +48,7 @@ class FileLogger(private val logFile: File) : Logging.Logger {
                 writer?.close()
             } catch (ignore: IOException) {
             }
-            logFile.delete()
+            if (createdNow) logFile.delete()
             throw e
         }
 

--- a/app/src/main/java/eu/darken/myperm/common/debug/logging/FileLogger.kt
+++ b/app/src/main/java/eu/darken/myperm/common/debug/logging/FileLogger.kt
@@ -13,8 +13,14 @@ import java.time.Instant
 class FileLogger(private val logFile: File) : Logging.Logger {
     private var logWriter: OutputStreamWriter? = null
 
+    /**
+     * A failure here used to be swallowed, which left an installed logger writing nowhere: the
+     * recording looked like it had started and produced an empty log. The writer is published only
+     * once it is actually usable, and anything else is the caller's failure to handle.
+     */
     @SuppressLint("SetWorldReadable")
     @Synchronized
+    @Throws(IOException::class)
     fun start() {
         if (logWriter != null) return
 
@@ -26,19 +32,24 @@ class FileLogger(private val logFile: File) : Logging.Logger {
             Log.i(TAG, "Debug run log read permission set")
         }
 
+        var writer: OutputStreamWriter? = null
         try {
-            logWriter = OutputStreamWriter(FileOutputStream(logFile, true))
-            logWriter!!.write("=== BEGIN ===\n")
-            logWriter!!.write("Logfile: $logFile\n")
-            logWriter!!.flush()
-            Log.i(TAG, "File logger started.")
+            writer = OutputStreamWriter(FileOutputStream(logFile, true))
+            writer.write("=== BEGIN ===\n")
+            writer.write("Logfile: $logFile\n")
+            writer.flush()
         } catch (e: IOException) {
-            e.printStackTrace()
-
+            Log.e(TAG, "File logger failed to start.", e)
+            try {
+                writer?.close()
+            } catch (ignore: IOException) {
+            }
             logFile.delete()
-            if (logWriter != null) logWriter!!.close()
+            throw e
         }
 
+        logWriter = writer
+        Log.i(TAG, "File logger started.")
     }
 
     @Synchronized

--- a/app/src/main/java/eu/darken/myperm/common/debug/logging/Logging.kt
+++ b/app/src/main/java/eu/darken/myperm/common/debug/logging/Logging.kt
@@ -54,8 +54,14 @@ object Logging {
     }
 
     fun remove(logger: Logger) {
-        log { "Removing: $logger" }
-        synchronized(internalLoggers) { internalLoggers.remove(logger) }
+        // The removal is unconditional: the announcement below goes through the loggers that are
+        // still installed, and one of those throwing must not be what keeps a dying logger in the
+        // list — that is exactly the situation a failed recording start unwinds from.
+        try {
+            log { "Removing: $logger" }
+        } finally {
+            synchronized(internalLoggers) { internalLoggers.remove(logger) }
+        }
     }
 
     fun logInternal(

--- a/app/src/main/java/eu/darken/myperm/common/debug/recording/core/Recorder.kt
+++ b/app/src/main/java/eu/darken/myperm/common/debug/recording/core/Recorder.kt
@@ -28,10 +28,29 @@ class Recorder @Inject constructor() {
         if (fileLogger != null) return@withLock
         val logger = FileLogger(path)
         logger.start()
-        Logging.install(logger)
-        fileLogger = logger
-        this.path = path
-        log(TAG, INFO) { "Now logging to file!" }
+        try {
+            Logging.install(logger)
+            fileLogger = logger
+            this.path = path
+            log(TAG, INFO) { "Now logging to file!" }
+        } catch (e: Throwable) {
+            // Publication is announced through the loggers that are ALREADY installed, so one of
+            // them throwing lands here with this logger installed and open while nothing references
+            // it: the caller's rollback would find a recorder that never started. Undo it here.
+            try {
+                Logging.remove(logger)
+            } catch (inner: Throwable) {
+                if (inner !== e) e.addSuppressed(inner)
+            }
+            try {
+                logger.stop()
+            } catch (inner: Throwable) {
+                if (inner !== e) e.addSuppressed(inner)
+            }
+            fileLogger = null
+            this.path = null
+            throw e
+        }
     }
 
     /**

--- a/app/src/main/java/eu/darken/myperm/common/debug/recording/core/Recorder.kt
+++ b/app/src/main/java/eu/darken/myperm/common/debug/recording/core/Recorder.kt
@@ -5,8 +5,10 @@ import eu.darken.myperm.common.debug.logging.Logging
 import eu.darken.myperm.common.debug.logging.Logging.Priority.INFO
 import eu.darken.myperm.common.debug.logging.log
 import eu.darken.myperm.common.debug.logging.logTag
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import java.io.File
 import javax.inject.Inject
 
@@ -20,24 +22,40 @@ class Recorder @Inject constructor() {
     var path: File? = null
         private set
 
+    // Nothing is published until the logger actually writes: a failed start leaves neither an
+    // installed logger nor a recorder that claims to be recording.
     suspend fun start(path: File) = mutex.withLock {
         if (fileLogger != null) return@withLock
+        val logger = FileLogger(path)
+        logger.start()
+        Logging.install(logger)
+        fileLogger = logger
         this.path = path
-        fileLogger = FileLogger(path)
-        fileLogger?.let {
-            it.start()
-            Logging.install(it)
-            log(TAG, INFO) { "Now logging to file!" }
-        }
+        log(TAG, INFO) { "Now logging to file!" }
     }
 
+    /**
+     * Teardown has to complete once it starts: this runs on the rollback path of a failed start,
+     * where a skipped step means a globally installed logger writing into a session nobody tracks.
+     * Every step is therefore guaranteed, and none of them may be cancelled halfway.
+     */
     suspend fun stop() = mutex.withLock {
-        fileLogger?.let {
-            log(TAG, INFO) { "Stopping file-logger-tree: $it" }
-            Logging.remove(it)
-            it.stop()
-            fileLogger = null
-            this.path = null
+        withContext(NonCancellable) {
+            val logger = fileLogger ?: return@withContext
+            try {
+                log(TAG, INFO) { "Stopping file-logger-tree: $logger" }
+            } finally {
+                try {
+                    Logging.remove(logger)
+                } finally {
+                    try {
+                        logger.stop()
+                    } finally {
+                        fileLogger = null
+                        this@Recorder.path = null
+                    }
+                }
+            }
         }
     }
 

--- a/app/src/main/java/eu/darken/myperm/common/debug/recording/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/myperm/common/debug/recording/core/RecorderModule.kt
@@ -143,7 +143,7 @@ class RecorderModule @Inject constructor(
                             // caller can surface, and the next start attempt re-arms cleanly.
                             copy(
                                 shouldRecord = false,
-                                startFailure = e,
+                                startFailure = asStartFailure(e),
                                 recorder = null,
                                 persistedLogDir = null,
                                 recordingStartedAt = 0L,
@@ -228,6 +228,20 @@ class RecorderModule @Inject constructor(
         } catch (_: Throwable) {
             // Bookkeeping only: nothing about the report may replace the failure being reported.
         }
+    }
+
+    /**
+     * A start failure that arrived as a [CancellationException] while this module's own scope was
+     * still alive — a bounded read inside the start work timing out, for example. Storing and
+     * rethrowing that unchanged makes every caller treat it as their OWN cancellation: the launch
+     * that requested the start ends "normally", and the error handler that would have surfaced the
+     * failure never runs.
+     */
+    class RecordingStartFailedException(cause: Throwable) : IllegalStateException("Failed to start recording", cause)
+
+    private fun asStartFailure(error: Exception): Throwable = when (error) {
+        is CancellationException -> RecordingStartFailedException(error)
+        else -> error
     }
 
     private fun deleteTriggerFile() {

--- a/app/src/main/java/eu/darken/myperm/common/debug/recording/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/myperm/common/debug/recording/core/RecorderModule.kt
@@ -187,7 +187,7 @@ class RecorderModule @Inject constructor(
             try {
                 recorder?.stop()
             } catch (e: Exception) {
-                cause.addSuppressed(e)
+                cause.recordSuppressed(e)
             }
 
             currentLogDir = null
@@ -196,7 +196,7 @@ class RecorderModule @Inject constructor(
                 // A trigger that survives the failure crash-loops every process start.
                 deleteTriggerFile()
             } catch (e: Exception) {
-                cause.addSuppressed(e)
+                cause.recordSuppressed(e)
             }
 
             try {
@@ -204,7 +204,7 @@ class RecorderModule @Inject constructor(
                     log(TAG, WARN) { "Failed to delete the session dir of a failed start: $createdSessionDir" }
                 }
             } catch (e: Exception) {
-                cause.addSuppressed(e)
+                cause.recordSuppressed(e)
             }
 
             try {
@@ -212,6 +212,21 @@ class RecorderModule @Inject constructor(
             } catch (_: Exception) {
                 // A logger that throws while we report the failure must not become the failure.
             }
+        }
+    }
+
+    /**
+     * Attaching a rollback failure to the failure being reported. The very same throwable can come
+     * back out of the rollback — a logger that fails the start rethrows on the teardown line too —
+     * and [Throwable.addSuppressed] rejects self-suppression with an [IllegalArgumentException],
+     * which would abort the rollback before the failure state is ever committed.
+     */
+    private fun Throwable.recordSuppressed(other: Throwable) {
+        if (other === this) return
+        try {
+            addSuppressed(other)
+        } catch (_: Throwable) {
+            // Bookkeeping only: nothing about the report may replace the failure being reported.
         }
     }
 
@@ -259,7 +274,7 @@ class RecorderModule @Inject constructor(
     private fun createSessionDir(): File {
         val sdf = SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'", Locale.US)
         sdf.timeZone = TimeZone.getTimeZone("UTC")
-        val timestamp = sdf.format(Date())
+        val timestamp = sdf.format(Date(wallClock()))
         val installIdPrefix = installId.id.take(8)
         val dirName = "myperm_${BuildConfigWrap.VERSION_NAME}_${timestamp}_$installIdPrefix"
 
@@ -278,13 +293,26 @@ class RecorderModule @Inject constructor(
         }
 
         val parent = primaryParent ?: File(context.cacheDir, "debug/logs").also { it.mkdirs() }
-        val sessionDir = File(parent, dirName)
-        if (!sessionDir.mkdirs() && !sessionDir.exists()) {
-            throw java.io.IOException("Failed to create session directory: $sessionDir")
-        }
 
-        log(TAG) { "Created session dir: $sessionDir" }
-        return sessionDir
+        // Only a directory this call actually created is returned: mkdirs() reports true exactly
+        // when the creation happened, so a name that is already taken (a second recording within
+        // the same second) moves on to the next suffix instead of adopting the earlier session's
+        // directory — which the rollback of a failed start would then delete.
+        var attempt = 1
+        while (true) {
+            val candidate = File(parent, if (attempt == 1) dirName else "$dirName-$attempt")
+            if (candidate.mkdirs()) {
+                log(TAG) { "Created session dir: $candidate" }
+                return candidate
+            }
+            if (!candidate.exists()) {
+                throw java.io.IOException("Failed to create session directory: $candidate")
+            }
+            attempt++
+            if (attempt > MAX_SESSION_DIR_ATTEMPTS) {
+                throw java.io.IOException("Failed to create a unique session directory in: $parent")
+            }
+        }
     }
 
     internal val externalLogDir: File? by lazy {
@@ -408,6 +436,11 @@ class RecorderModule @Inject constructor(
 
         // Budget for the header's diagnostics read.
         private const val HEADER_READ_TIMEOUT_MS = 5_000L
+
+        // Suffix attempts for a session directory name that is already taken. The name carries a
+        // second-resolution timestamp, so collisions only come from repeated starts within one
+        // second; a bound keeps a permanently unwritable parent from spinning here.
+        private const val MAX_SESSION_DIR_ATTEMPTS = 10
 
         // The trigger file stores wall-clock timestamps: it has to survive reboots, which monotonic
         // time does not. [now] is the module's wall clock, defaulted for direct test calls.

--- a/app/src/main/java/eu/darken/myperm/common/debug/recording/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/myperm/common/debug/recording/core/RecorderModule.kt
@@ -19,14 +19,17 @@ import eu.darken.myperm.common.upgrade.UpgradeDiagnostics
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import java.io.File
@@ -73,6 +76,10 @@ class RecorderModule @Inject constructor(
     internal var currentLogDir: File? = null
         private set
 
+    // Serializes the public start/stop requests: each one publishes its request and then waits for a
+    // terminal state, and two overlapping requests would observe each other's outcome.
+    private val requestMutex = Mutex()
+
     private val internalState = DynamicStateFlow(TAG, appScope + dispatcherProvider.IO) {
         val triggerFileExists = triggerFile.exists()
         val persistedInfo = if (triggerFileExists) readTriggerFile() else null
@@ -93,52 +100,61 @@ class RecorderModule @Inject constructor(
 
                 internalState.updateBlocking {
                     if (shouldRecord && !isRecording) {
-                        val resumed = persistedLogDir?.takeIf { it.exists() && it.isDirectory }
-                        val sessionDir = resumed ?: createSessionDir()
-                        val startTime = if (resumed != null) {
-                            log(TAG, INFO) { "Resuming recording in existing session: ${resumed.name}" }
-                            recordingStartedAt
-                        } else {
-                            wallClock()
-                        }
-
-                        val logFile = File(sessionDir, "core.log")
-                        val newRecorder = Recorder()
-                        newRecorder.start(logFile)
-                        writeTriggerFile(sessionDir, startTime)
-
+                        // The whole start is one attempt: anything between creating the session and
+                        // committing it can fail, and every one of those failures used to abandon a
+                        // running recorder, kill this collector and take the process with it.
+                        var newRecorder: Recorder? = null
+                        var createdSessionDir: File? = null
                         try {
-                            logRecordingHeader()
-                        } catch (e: Exception) {
-                            // The recorder is already live but not yet committed to the state: an
-                            // exception escaping the header would abandon it where stopRecorder()
-                            // can't reach it.
-                            withContext(NonCancellable) {
-                                try {
-                                    newRecorder.stop()
-                                } catch (stopError: Exception) {
-                                    e.addSuppressed(stopError)
-                                }
-                                currentLogDir = null
+                            val resumed = persistedLogDir?.takeIf { it.exists() && it.isDirectory }
+                            val sessionDir = resumed ?: createSessionDir().also { createdSessionDir = it }
+                            val startTime = if (resumed != null) {
+                                log(TAG, INFO) { "Resuming recording in existing session: ${resumed.name}" }
+                                recordingStartedAt
+                            } else {
+                                wallClock()
                             }
-                            throw e
+
+                            val logFile = File(sessionDir, "core.log")
+                            val recorder = Recorder()
+                            newRecorder = recorder
+                            recorder.start(logFile)
+                            writeTriggerFile(sessionDir, startTime)
+                            logRecordingHeader()
+
+                            currentLogDir = sessionDir
+
+                            copy(
+                                recorder = recorder,
+                                startFailure = null,
+                                persistedLogDir = null,
+                                recordingStartedAt = startTime,
+                                recordingStartedAtMonotonic = if (resumed != null) null else monotonicClock(),
+                                logDir = sessionDir,
+                            )
+                        } catch (e: Exception) {
+                            rollbackFailedStart(e, newRecorder, createdSessionDir)
+                            // A cancelled scope still cancels; a CancellationException that merely
+                            // escaped a dependency is committed as a failure instead, because
+                            // rethrowing it here is what leaves the module wedged.
+                            currentCoroutineContext().ensureActive()
+
+                            // Final, non-throwing step: the request is answered with a failure the
+                            // caller can surface, and the next start attempt re-arms cleanly.
+                            copy(
+                                shouldRecord = false,
+                                startFailure = e,
+                                recorder = null,
+                                persistedLogDir = null,
+                                recordingStartedAt = 0L,
+                                recordingStartedAtMonotonic = null,
+                                logDir = null,
+                            )
                         }
-
-                        currentLogDir = sessionDir
-
-                        copy(
-                            recorder = newRecorder,
-                            persistedLogDir = null,
-                            recordingStartedAt = startTime,
-                            recordingStartedAtMonotonic = if (resumed != null) null else monotonicClock(),
-                            logDir = sessionDir,
-                        )
                     } else if (!shouldRecord && isRecording) {
                         recorder?.stop()
 
-                        if (triggerFile.exists() && !triggerFile.delete()) {
-                            log(TAG, ERROR) { "Failed to delete trigger file" }
-                        }
+                        deleteTriggerFile()
 
                         currentLogDir = null
 
@@ -157,9 +173,58 @@ class RecorderModule @Inject constructor(
             .launchIn(appScope)
     }
 
-    // Header lines written into a freshly started recording. Runs AFTER the recorder is live, so
-    // every read here is diagnostics-only and must never propagate: a failure would abort the state
-    // update and leave a RUNNING recorder that the module no longer knows about.
+    /**
+     * Undoes a half-finished start. Every step runs even if an earlier one failed, and none of them
+     * may replace [cause]: the failure being committed is what the caller gets to see.
+     *
+     * [createdSessionDir] is only set when THIS attempt created the directory. A resumed session's
+     * directory holds an earlier recording and is never deleted; a directory this attempt created is
+     * a dead session that the session manager would otherwise list and auto-zip, and that a retry
+     * within the same second would collide with.
+     */
+    private suspend fun rollbackFailedStart(cause: Exception, recorder: Recorder?, createdSessionDir: File?) {
+        withContext(NonCancellable) {
+            try {
+                recorder?.stop()
+            } catch (e: Exception) {
+                cause.addSuppressed(e)
+            }
+
+            currentLogDir = null
+
+            try {
+                // A trigger that survives the failure crash-loops every process start.
+                deleteTriggerFile()
+            } catch (e: Exception) {
+                cause.addSuppressed(e)
+            }
+
+            try {
+                if (createdSessionDir != null && !createdSessionDir.deleteRecursively()) {
+                    log(TAG, WARN) { "Failed to delete the session dir of a failed start: $createdSessionDir" }
+                }
+            } catch (e: Exception) {
+                cause.addSuppressed(e)
+            }
+
+            try {
+                log(TAG, ERROR) { "Failed to start recording: ${cause.asLog()}" }
+            } catch (_: Exception) {
+                // A logger that throws while we report the failure must not become the failure.
+            }
+        }
+    }
+
+    private fun deleteTriggerFile() {
+        if (triggerFile.exists() && !triggerFile.delete()) {
+            log(TAG, ERROR) { "Failed to delete trigger file" }
+        }
+    }
+
+    // Header lines written into a freshly started recording. Runs AFTER the recorder is live, and
+    // every read here is diagnostics-only: an injected source that fails must not deny the user the
+    // recording. A failure that DOES escape (the unguarded reads above) aborts the start, which the
+    // start branch rolls back and reports.
     private suspend fun logRecordingHeader() {
         log(TAG, INFO) { "Build.Fingerprint: ${Build.FINGERPRINT}" }
         log(TAG, INFO) { "BuildConfig.Versions: ${BuildConfigWrap.VERSION_DESCRIPTION}" }
@@ -234,11 +299,20 @@ class RecorderModule @Inject constructor(
 
     internal fun getLogDirectories(): List<File> = listOfNotNull(externalLogDir, cacheLogDir)
 
-    suspend fun startRecorder(): File {
+    /**
+     * Publishes the request and waits for a terminal answer: either the recording is live, or the
+     * attempt failed and the failure is thrown here. Waiting for [State.isRecording] alone leaves
+     * every caller of a failed start suspended forever.
+     */
+    suspend fun startRecorder(): File = requestMutex.withLock {
         internalState.updateBlocking {
-            copy(shouldRecord = true)
+            // Clearing the previous failure is what re-arms the wait: a stale one would answer this
+            // request with the error of an attempt that is already over.
+            copy(shouldRecord = true, startFailure = null)
         }
-        return internalState.flow.filter { it.isRecording }.first().logDir!!
+        val settled = internalState.flow.first { it.isRecording || it.startFailure != null }
+        settled.startFailure?.let { throw it }
+        settled.logDir!!
     }
 
     sealed class StopResult {
@@ -263,13 +337,13 @@ class RecorderModule @Inject constructor(
         return StopResult.Stopped(logDir, sessionId)
     }
 
-    suspend fun stopRecorder(): File? {
-        val dir = currentLogDir ?: return null
+    suspend fun stopRecorder(): File? = requestMutex.withLock {
+        val dir = currentLogDir ?: return@withLock null
         internalState.updateBlocking {
             copy(shouldRecord = false)
         }
-        internalState.flow.filter { !it.isRecording }.first()
-        return dir
+        internalState.flow.first { !it.isRecording }
+        dir
     }
 
     data class State(
@@ -281,6 +355,10 @@ class RecorderModule @Inject constructor(
         // or boot is meaningless. Nullable rather than 0L — 0 is a legal elapsedRealtime near boot.
         val recordingStartedAtMonotonic: Long? = null,
         val logDir: File? = null,
+        // The failure of the LAST start attempt, cleared by the next one. A Throwable reference is
+        // deliberate: two identical failures are still two distinct values, so a repeated failure
+        // is not swallowed by the state flow's distinctUntilChanged.
+        val startFailure: Throwable? = null,
         internal val persistedLogDir: File? = null,
     ) {
         val isRecording: Boolean

--- a/app/src/test/java/eu/darken/myperm/common/debug/logging/FileLoggerTest.kt
+++ b/app/src/test/java/eu/darken/myperm/common/debug/logging/FileLoggerTest.kt
@@ -1,7 +1,9 @@
 package eu.darken.myperm.common.debug.logging
 
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
@@ -45,5 +47,31 @@ class FileLoggerTest {
         logger.stop()
 
         logFile.readText() shouldContain "recorded"
+    }
+
+    /**
+     * A resumed session appends to the log file of the recording it continues. Cleaning up after a
+     * failed open deleted that file unconditionally, so a resume that could not append (a full disk)
+     * destroyed the recording the user was about to send.
+     */
+    @Test
+    fun `a failed start keeps a log file it did not create`() {
+        val logFile = File(sessionDir, "core.log")
+        logFile.writeText("=== BEGIN ===\nprevious recording\n")
+        // Read-only: the append cannot be opened, but the file itself is perfectly deletable.
+        logFile.setWritable(false, false)
+        assumeTrue(!logFile.canWrite(), "The read-only bit is not enforced for this user")
+
+        try {
+            val logger = FileLogger(logFile)
+
+            shouldThrow<IOException> { logger.start() }
+
+            // Only a file THIS attempt created may be cleaned up.
+            logFile.exists() shouldBe true
+            logFile.readText() shouldContain "previous recording"
+        } finally {
+            logFile.setWritable(true, true)
+        }
     }
 }

--- a/app/src/test/java/eu/darken/myperm/common/debug/logging/FileLoggerTest.kt
+++ b/app/src/test/java/eu/darken/myperm/common/debug/logging/FileLoggerTest.kt
@@ -1,0 +1,49 @@
+package eu.darken.myperm.common.debug.logging
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.string.shouldContain
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.io.IOException
+
+/**
+ * A file logger that cannot open its writer used to swallow the failure, which left it installed
+ * and silently writing nowhere: the recording looked like it had started and produced an empty log.
+ */
+class FileLoggerTest {
+
+    @TempDir
+    lateinit var sessionDir: File
+
+    @Test
+    fun `a log file that cannot be opened fails the start`() {
+        // core.log occupied by a directory: the writer cannot be opened.
+        val logFile = File(sessionDir, "core.log").also { it.mkdirs() }
+
+        val logger = FileLogger(logFile)
+
+        shouldThrow<IOException> { logger.start() }
+
+        // Inert rather than half-started: nothing was published, so neither writing nor stopping
+        // does anything.
+        logger.log(Logging.Priority.INFO, "tag", "dropped", null)
+        logger.stop()
+    }
+
+    @Test
+    fun `a failed start leaves the logger startable`() {
+        val logFile = File(sessionDir, "core.log").also { it.mkdirs() }
+        val logger = FileLogger(logFile)
+        shouldThrow<IOException> { logger.start() }
+
+        // With the obstruction gone the same logger has to start for real: the failed attempt must
+        // not have left a writer reference behind that makes the retry a no-op.
+        logFile.deleteRecursively()
+        logger.start()
+        logger.log(Logging.Priority.INFO, "tag", "recorded", null)
+        logger.stop()
+
+        logFile.readText() shouldContain "recorded"
+    }
+}

--- a/app/src/test/java/eu/darken/myperm/common/debug/recording/core/RecorderModuleDiagnosticsTest.kt
+++ b/app/src/test/java/eu/darken/myperm/common/debug/recording/core/RecorderModuleDiagnosticsTest.kt
@@ -10,6 +10,7 @@ import eu.darken.myperm.common.debug.logging.Logging
 import eu.darken.myperm.common.upgrade.UpgradeDiagnostics
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -182,8 +183,16 @@ class RecorderModuleDiagnosticsTest : BaseTest() {
         delay(1_000)
 
         coVerify { diagnostics.debugInfo() }
-        // The foreign cancellation became this attempt's failure instead of a wedged caller.
-        start.await().exceptionOrNull().shouldBeInstanceOf<CancellationException>()
+        // The foreign cancellation became this attempt's failure instead of a wedged caller, and it
+        // arrives as an ordinary exception: handed back as a cancellation, the caller's launch would
+        // end "normally" and never surface the failure. The original is kept as the cause, looked up
+        // along the chain because stack-trace recovery may hand back a copy that wraps the wrapper.
+        val error = start.await().exceptionOrNull()
+            .shouldBeInstanceOf<RecorderModule.RecordingStartFailedException>()
+        generateSequence(error.cause) { it.cause }
+            .filterIsInstance<CancellationException>()
+            .map { it.message }
+            .toList() shouldContain "scope died mid-read"
         module.state.first().isRecording shouldBe false
         module.currentLogDir.shouldBeNull()
         // The recorder that was already writing when the header aborted got stopped: its file

--- a/app/src/test/java/eu/darken/myperm/common/debug/recording/core/RecorderModuleDiagnosticsTest.kt
+++ b/app/src/test/java/eu/darken/myperm/common/debug/recording/core/RecorderModuleDiagnosticsTest.kt
@@ -1,5 +1,6 @@
 package eu.darken.myperm.common.debug.recording.core
 
+import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.myperm.common.BuildConfigWrap
 import eu.darken.myperm.common.InstallId
@@ -7,10 +8,13 @@ import eu.darken.myperm.common.coroutine.DispatcherProvider
 import eu.darken.myperm.common.debug.logging.FileLogger
 import eu.darken.myperm.common.debug.logging.Logging
 import eu.darken.myperm.common.upgrade.UpgradeDiagnostics
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -22,11 +26,11 @@ import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
@@ -40,6 +44,7 @@ import org.robolectric.annotation.Config
 import testhelper.BaseTest
 import testhelper.coroutine.TestDispatcherProvider
 import testhelpers.TestApplication
+import java.io.File
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.system.measureTimeMillis
 
@@ -47,8 +52,12 @@ import kotlin.system.measureTimeMillis
  * The recording header reads diagnostics that live outside the recorder. Those reads happen AFTER
  * the recorder is already writing, so a guarded failure must never abort the state update — that
  * would leave a running recorder the module no longer knows about, i.e. a debug recording that
- * can't be stopped or collected. Failures that DO escape the header have to take the uncommitted
- * recorder down with them.
+ * can't be stopped or collected.
+ *
+ * Failures that DO escape the header take the uncommitted recorder down with them and are then
+ * reported: the attempt is rolled back, the failure is committed to the state, and the caller gets
+ * it thrown. What must NOT happen is the old behaviour — the exception escaping the shared
+ * collector, which killed it, wedged every later start and crashed the process.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33], application = TestApplication::class)
@@ -69,6 +78,26 @@ class RecorderModuleDiagnosticsTest : BaseTest() {
     @After
     fun removeLogCapture() {
         Logging.remove(logCapture)
+    }
+
+    // The trigger file lives next to the log dirs in the (shared) external files dir: a stale one
+    // would make the next module in this process resume-start during construction.
+    private val triggerFile: File
+        get() = File(
+            ApplicationProvider.getApplicationContext<Context>().getExternalFilesDir(null),
+            "myperm_force_debug_run",
+        )
+
+    @Before
+    fun clearTriggerFile() {
+        triggerFile.delete()
+    }
+
+    // Runs after the per-test leak assertions: a test that fails halfway must not hand its recorder's
+    // globally installed logger to the next one.
+    @After
+    fun removeStragglingFileLoggers() {
+        Logging.loggers.filterIsInstance<FileLogger>().forEach { Logging.remove(it) }
     }
 
     private fun buildModule(
@@ -132,13 +161,14 @@ class RecorderModuleDiagnosticsTest : BaseTest() {
     }
 
     /**
-     * Cancellation is one of the failures that escape the header, so it is one of the failures that
-     * can abort the state update. The recorder is already live at that point: it has to be stopped
-     * on the way out, or it keeps writing into a session the module no longer tracks.
+     * A cancellation escaping the header is not necessarily OUR cancellation — a dependency can let
+     * one out while the module's scope is perfectly alive. The recorder is already live at that
+     * point: it has to be stopped on the way out, or it keeps writing into a session the module no
+     * longer tracks, and the caller has to be answered instead of left waiting on a start that will
+     * never arrive.
      *
-     * The start is launched, not awaited: an aborted update never flips isRecording, so
-     * startRecorder() stays suspended. The virtual-time delay is what lets the module's own
-     * background collectors run to completion.
+     * The start is launched, not awaited inline: the virtual-time delay is what lets the module's
+     * own background collectors run to completion before the assertions read the outcome.
      */
     @Test
     fun `a cancelled upgrade-diagnostics read stops the recorder instead of leaking it`() = runTest {
@@ -148,10 +178,12 @@ class RecorderModuleDiagnosticsTest : BaseTest() {
 
         val module = buildModule(backgroundScope, diagnostics)
 
-        backgroundScope.launch { module.startRecorder() }
+        val start = backgroundScope.async { runCatching { module.startRecorder() } }
         delay(1_000)
 
         coVerify { diagnostics.debugInfo() }
+        // The foreign cancellation became this attempt's failure instead of a wedged caller.
+        start.await().exceptionOrNull().shouldBeInstanceOf<CancellationException>()
         module.state.first().isRecording shouldBe false
         module.currentLogDir.shouldBeNull()
         // The recorder that was already writing when the header aborted got stopped: its file
@@ -163,9 +195,13 @@ class RecorderModuleDiagnosticsTest : BaseTest() {
      * Same window as above, but for an ordinary failure instead of a cancellation. The header's
      * injected sources are individually guarded, so the escape path is one of the unguarded first
      * log lines — here the build description read.
+     *
+     * Awaited, not launched: a start that cannot finish has to come back to its caller as a thrown
+     * error. This used to be a caller suspended forever behind a collector the same exception had
+     * already killed.
      */
     @Test
-    fun `a failing header read stops the uncommitted recorder`() = runTest {
+    fun `a failed start surfaces the error instead of hanging`() = runTest {
         val fileLoggersBefore = Logging.loggers.filterIsInstance<FileLogger>()
         val diagnostics = mockk<UpgradeDiagnostics>()
         coEvery { diagnostics.debugInfo() } returns "BillingCache(...)"
@@ -173,23 +209,108 @@ class RecorderModuleDiagnosticsTest : BaseTest() {
         mockkObject(BuildConfigWrap)
         every { BuildConfigWrap.VERSION_DESCRIPTION } throws IllegalStateException("build info unreadable")
 
-        // Own scope: the escaping exception fails the collector, which must not fail the test's own
-        // scope. SupervisorJob keeps the module's state flow alive so it can be inspected after.
-        val moduleScope = CoroutineScope(coroutineContext + SupervisorJob() + CoroutineExceptionHandler { _, _ -> })
+        // Own scope: nothing may reach it, but a module scope that is not the test's own keeps a
+        // regression from being reported as an unrelated test-scope failure.
+        val moduleScope = CoroutineScope(coroutineContext + SupervisorJob())
         try {
             val module = buildModule(moduleScope, diagnostics)
 
-            moduleScope.launch { module.startRecorder() }
-            delay(1_000)
+            val error = shouldThrow<IllegalStateException> { module.startRecorder() }
+            error.message shouldBe "build info unreadable"
 
-            module.state.first().isRecording shouldBe false
+            val settled = module.state.first()
+            settled.isRecording shouldBe false
+            // The request is retracted, so the next start is a fresh edge rather than a no-op.
+            settled.shouldRecord shouldBe false
             module.currentLogDir.shouldBeNull()
-            // Non-vacuity: without the guard's cleanup the started recorder's file logger would
-            // still be installed here.
+            // A trigger left behind would re-run this failing start on every process start.
+            triggerFile.exists() shouldBe false
+            // Non-vacuity: without the rollback the started recorder's file logger would still be
+            // installed here.
             Logging.loggers.filterIsInstance<FileLogger>() shouldBe fileLoggersBefore
         } finally {
             moduleScope.cancel()
             unmockkObject(BuildConfigWrap)
+        }
+    }
+
+    /**
+     * The collector that processes a failed start has to survive it: it is the single shared
+     * collector behind every later start and stop request.
+     */
+    @Test
+    fun `the recorder recovers after a failed start`() = runTest {
+        val fileLoggersBefore = Logging.loggers.filterIsInstance<FileLogger>()
+        val diagnostics = mockk<UpgradeDiagnostics>()
+        coEvery { diagnostics.debugInfo() } returns null
+
+        mockkObject(BuildConfigWrap)
+        every { BuildConfigWrap.VERSION_DESCRIPTION } throws IllegalStateException("build info unreadable")
+
+        val moduleScope = CoroutineScope(coroutineContext + SupervisorJob())
+        try {
+            val module = buildModule(moduleScope, diagnostics)
+
+            shouldThrow<IllegalStateException> { module.startRecorder() }
+
+            every { BuildConfigWrap.VERSION_DESCRIPTION } returns "v1.2.3 (4) ~ deadbeef/foss/DEV"
+
+            val logDir = module.startRecorder()
+            module.state.first { it.isRecording }.logDir shouldBe logDir
+            module.currentLogDir shouldBe logDir
+            // The previous attempt's failure was cleared, not carried into the live recording.
+            module.state.first().startFailure.shouldBeNull()
+
+            module.stopRecorder().shouldNotBeNull()
+            module.state.first().isRecording shouldBe false
+            Logging.loggers.filterIsInstance<FileLogger>() shouldBe fileLoggersBefore
+        } finally {
+            moduleScope.cancel()
+            unmockkObject(BuildConfigWrap)
+        }
+    }
+
+    /**
+     * A trigger file makes the module start recording during construction, i.e. during App.onCreate.
+     * A failure there used to be rethrown onto the app scope — a crash — while the trigger stayed on
+     * disk, so the next process start crashed the same way. The module has to settle instead.
+     */
+    @Test
+    fun `a boot trigger that cannot start settles instead of crash-looping`() = runTest {
+        val fileLoggersBefore = Logging.loggers.filterIsInstance<FileLogger>()
+        val diagnostics = mockk<UpgradeDiagnostics>()
+        coEvery { diagnostics.debugInfo() } returns null
+
+        val externalDir = ApplicationProvider.getApplicationContext<Context>().getExternalFilesDir(null)!!
+        val resumedDir = File(externalDir, "debug/logs/myperm_resumed_session").also { it.mkdirs() }
+        triggerFile.writeText("${resumedDir.absolutePath}\n${System.currentTimeMillis() - 5_000L}")
+
+        mockkObject(BuildConfigWrap)
+        every { BuildConfigWrap.VERSION_DESCRIPTION } throws IllegalStateException("build info unreadable")
+
+        // Inverted from the usual pattern: this handler stands in for the process default handler
+        // that an escaping exception would reach, and it has to stay empty.
+        val escaped = CopyOnWriteArrayList<Throwable>()
+        val moduleScope = CoroutineScope(
+            coroutineContext + SupervisorJob() + CoroutineExceptionHandler { _, e -> escaped.add(e) }
+        )
+        try {
+            val module = buildModule(moduleScope, diagnostics)
+
+            val settled = module.state.first { it.startFailure != null }
+            settled.isRecording shouldBe false
+            settled.shouldRecord shouldBe false
+            module.currentLogDir.shouldBeNull()
+            // The trigger is gone: this is what stops the failure from repeating every process start.
+            triggerFile.exists() shouldBe false
+            // The resumed session predates this attempt, so its directory stays.
+            resumedDir.exists() shouldBe true
+            escaped.shouldBeEmpty()
+            Logging.loggers.filterIsInstance<FileLogger>() shouldBe fileLoggersBefore
+        } finally {
+            moduleScope.cancel()
+            unmockkObject(BuildConfigWrap)
+            resumedDir.deleteRecursively()
         }
     }
 

--- a/app/src/test/java/eu/darken/myperm/common/debug/recording/core/RecorderModuleStartFailureTest.kt
+++ b/app/src/test/java/eu/darken/myperm/common/debug/recording/core/RecorderModuleStartFailureTest.kt
@@ -184,11 +184,15 @@ class RecorderModuleStartFailureTest {
             val error = shouldThrow<IllegalStateException> {
                 runBlocking { withTimeout(TEST_ENVELOPE_MS) { recorder.start(logFile) } }
             }
-            error shouldBeSameInstanceAs saboteur.failure
-
+            // Cleanup is what this test is about, so it is asserted before anything about the
+            // exception: an assertion on the throw itself must not be what hides a leaked logger.
             recorder.isRecording shouldBe false
             recorder.path.shouldBeNull()
             Logging.loggers.filterIsInstance<FileLogger>() shouldBe fileLoggersBefore
+
+            // By message, not by reference: the throw crosses the withTimeout coroutine above, and
+            // stack-trace recovery hands back a copy rather than the saboteur's own instance.
+            error.message shouldBe saboteur.failure.message
         } finally {
             saboteur.armed = false
             Logging.remove(saboteur)

--- a/app/src/test/java/eu/darken/myperm/common/debug/recording/core/RecorderModuleStartFailureTest.kt
+++ b/app/src/test/java/eu/darken/myperm/common/debug/recording/core/RecorderModuleStartFailureTest.kt
@@ -8,9 +8,11 @@ import eu.darken.myperm.common.debug.logging.Logging
 import eu.darken.myperm.common.upgrade.UpgradeDiagnostics
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
@@ -160,9 +162,129 @@ class RecorderModuleStartFailureTest {
         }
     }
 
+    /**
+     * A logger that fails while it is being installed: [Logging.install] announces the new logger
+     * through the loggers that are already installed, so the throw arrives with the new logger
+     * already in the list. It used to stay there, open and unreferenced, because the recorder had
+     * not published it yet and its own teardown therefore had nothing to stop.
+     */
+    @Test
+    fun `a logger that fails during installation is not left installed`() {
+        val fileLoggersBefore = Logging.loggers.filterIsInstance<FileLogger>()
+        val logFile = File(externalDir, "debug/logs/install_failure/core.log")
+
+        // Armed only after its own installation announcement has gone through.
+        val saboteur = SaboteurLogger { it.contains("Was installed") }.apply { armed = false }
+        Logging.install(saboteur)
+        saboteur.armed = true
+
+        try {
+            val recorder = Recorder()
+
+            val error = shouldThrow<IllegalStateException> {
+                runBlocking { withTimeout(TEST_ENVELOPE_MS) { recorder.start(logFile) } }
+            }
+            error shouldBeSameInstanceAs saboteur.failure
+
+            recorder.isRecording shouldBe false
+            recorder.path.shouldBeNull()
+            Logging.loggers.filterIsInstance<FileLogger>() shouldBe fileLoggersBefore
+        } finally {
+            saboteur.armed = false
+            Logging.remove(saboteur)
+        }
+    }
+
+    /**
+     * Two recordings within the same second want the same session directory name. Reusing the
+     * earlier one made it count as created-by-this-attempt, so rolling back the second start
+     * deleted the first, completed recording.
+     */
+    @Test
+    fun `a failed start does not delete an earlier session from the same second`() {
+        withModule { module ->
+            // Fixed wall clock: the directory name carries a second-resolution timestamp, so this
+            // is what makes the collision certain rather than a matter of timing.
+            module.wallClock = { FIXED_WALL }
+
+            val earlier = module.startRecorder()
+            module.stopRecorder()
+            File(earlier, "evidence.txt").writeText("earlier session")
+
+            val saboteur = SaboteurLogger { it.contains("Build.Fingerprint") }
+            Logging.install(saboteur)
+            try {
+                shouldThrow<IllegalStateException> { module.startRecorder() } shouldBeSameInstanceAs saboteur.failure
+            } finally {
+                saboteur.armed = false
+                Logging.remove(saboteur)
+            }
+
+            val settled = module.state.first()
+            settled.isRecording shouldBe false
+            settled.shouldRecord shouldBe false
+
+            // The earlier session is untouched, and the directory the failed attempt created for
+            // itself is the only one that got cleaned up.
+            earlier.exists() shouldBe true
+            File(earlier, "evidence.txt").readText() shouldBe "earlier session"
+            File(earlier.parentFile, "${earlier.name}-2").exists() shouldBe false
+        }
+    }
+
+    /**
+     * The rollback can fail with the very same throwable that failed the start — one broken logger
+     * throws on the start's header line and again on the teardown line. Recording that as a
+     * suppressed exception of itself throws [IllegalArgumentException], which used to abort the
+     * rollback before the failure was ever committed: the collector died and every later start hung.
+     */
+    @Test
+    fun `a rollback failing with the start's own exception still commits the failure`() {
+        withModule { module ->
+            val saboteur = SaboteurLogger {
+                it.contains("Build.Fingerprint") || it.contains("Stopping file-logger-tree")
+            }
+            Logging.install(saboteur)
+            try {
+                shouldThrow<IllegalStateException> { module.startRecorder() } shouldBeSameInstanceAs saboteur.failure
+
+                val settled = module.state.first()
+                settled.startFailure shouldBeSameInstanceAs saboteur.failure
+                settled.isRecording shouldBe false
+                settled.shouldRecord shouldBe false
+                module.currentLogDir.shouldBeNull()
+                triggerFile.exists() shouldBe false
+            } finally {
+                saboteur.armed = false
+                Logging.remove(saboteur)
+            }
+
+            // The shared collector survived the rollback: it is what every later request runs on.
+            val logDir = module.startRecorder()
+            module.state.first { it.isRecording }.logDir shouldBe logDir
+            module.stopRecorder().shouldNotBeNull()
+        }
+    }
+
+    /**
+     * A logger that throws for the log lines the test picks, so a start fails at a chosen step. The
+     * failure is a single instance on purpose: the same one can come back out of the rollback.
+     */
+    private class SaboteurLogger(
+        val failure: IllegalStateException = IllegalStateException("logger sabotage"),
+        private val triggers: (String) -> Boolean,
+    ) : Logging.Logger {
+        var armed = true
+
+        override fun log(priority: Logging.Priority, tag: String, message: String, metaData: Map<String, Any>?) {
+            if (armed && triggers(message)) throw failure
+        }
+    }
+
     companion object {
         // Independent of any production bound: a wedged wait has to fail the test, not hang the
         // gradle worker.
         private const val TEST_ENVELOPE_MS = 10_000L
+        private const val FIXED_WALL = 1_800_000_000_000L
     }
 }

--- a/app/src/test/java/eu/darken/myperm/common/debug/recording/core/RecorderModuleStartFailureTest.kt
+++ b/app/src/test/java/eu/darken/myperm/common/debug/recording/core/RecorderModuleStartFailureTest.kt
@@ -1,0 +1,168 @@
+package eu.darken.myperm.common.debug.recording.core
+
+import android.content.Context
+import eu.darken.myperm.common.InstallId
+import eu.darken.myperm.common.coroutine.DispatcherProvider
+import eu.darken.myperm.common.debug.logging.FileLogger
+import eu.darken.myperm.common.debug.logging.Logging
+import eu.darken.myperm.common.upgrade.UpgradeDiagnostics
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import testhelper.coroutine.TestDispatcherProvider
+import java.io.File
+import java.io.IOException
+
+/**
+ * The storage legs of starting a recording: the session directory that cannot be created, and the
+ * log file that cannot be opened. Both used to abandon the attempt mid-way — the module kept
+ * "should record" set while nothing was recording, and the caller waited for a recording that was
+ * never going to arrive.
+ */
+class RecorderModuleStartFailureTest {
+
+    @TempDir
+    lateinit var externalDir: File
+
+    @TempDir
+    lateinit var cacheDir: File
+
+    private lateinit var context: Context
+    private lateinit var installId: InstallId
+    private lateinit var dispatcherProvider: DispatcherProvider
+    private lateinit var appScope: CoroutineScope
+    private lateinit var upgradeDiagnostics: UpgradeDiagnostics
+
+    private val triggerFile: File
+        get() = File(externalDir, "myperm_force_debug_run")
+
+    @BeforeEach
+    fun setup() {
+        File(externalDir, "debug/logs").mkdirs()
+        File(cacheDir, "debug/logs").mkdirs()
+
+        context = mockk(relaxed = true)
+        every { context.getExternalFilesDir(null) } returns externalDir
+        every { context.cacheDir } returns cacheDir
+
+        installId = mockk()
+        every { installId.id } returns "abcdef12-0000-0000-0000-000000000000"
+
+        dispatcherProvider = TestDispatcherProvider()
+        appScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher())
+
+        // Inert diagnostics: the header reads are covered by RecorderModuleDiagnosticsTest, these
+        // fixtures only need them to not touch storage.
+        upgradeDiagnostics = mockk(relaxed = true)
+    }
+
+    @AfterEach
+    fun teardown() {
+        appScope.cancel()
+    }
+
+    /**
+     * Same shape as RecorderModuleDurationTest.withModule: the recorder is stopped in a nested
+     * finally before the scope goes, because cancelling the scope alone does not uninstall a
+     * running recorder's globally installed [FileLogger]. A leaked logger must fail THIS test
+     * rather than write into every later one.
+     *
+     * The module is constructed inside the harness: a seeded trigger file has to be written before
+     * construction, since the init collector resumes the session on the unconfined dispatcher while
+     * the constructor is still running.
+     */
+    private fun withModule(block: suspend (RecorderModule) -> Unit) {
+        val fileLoggersBefore = Logging.loggers.filterIsInstance<FileLogger>()
+        var module: RecorderModule? = null
+        try {
+            try {
+                val created = RecorderModule(
+                    context = context,
+                    appScope = appScope,
+                    dispatcherProvider = dispatcherProvider,
+                    installId = installId,
+                    upgradeDiagnostics = upgradeDiagnostics,
+                )
+                module = created
+                // Envelope: a wedged start or stop must fail in seconds, not hold the gradle worker.
+                runBlocking { withTimeout(TEST_ENVELOPE_MS) { block(created) } }
+            } finally {
+                module?.let { runBlocking { withTimeoutOrNull(TEST_ENVELOPE_MS) { it.stopRecorder() } } }
+            }
+        } finally {
+            appScope.cancel()
+            if (triggerFile.exists()) triggerFile.delete()
+            // Remove stragglers after asserting so one failure can't cascade into later tests.
+            val leaked = Logging.loggers.filterIsInstance<FileLogger>() - fileLoggersBefore.toSet()
+            leaked.forEach { Logging.remove(it) }
+            leaked shouldBe emptyList<FileLogger>()
+        }
+    }
+
+    @Test
+    fun `a session directory that cannot be created surfaces as a start failure`() {
+        // The logs parent is a FILE, so no session directory can be made below it. This is
+        // createSessionDir's explicit IOException, the earliest failure a start can hit.
+        File(externalDir, "debug/logs").deleteRecursively()
+        File(externalDir, "debug/logs").createNewFile()
+
+        withModule { module ->
+            val error = shouldThrow<IOException> { module.startRecorder() }
+            error.message!! shouldContain "Failed to create session directory"
+
+            val settled = module.state.first()
+            settled.startFailure shouldBe error
+            settled.isRecording shouldBe false
+            settled.shouldRecord shouldBe false
+            settled.logDir.shouldBeNull()
+            module.currentLogDir.shouldBeNull()
+            // Nothing got as far as arming a trigger, and nothing may leave one behind either.
+            triggerFile.exists() shouldBe false
+        }
+    }
+
+    @Test
+    fun `a recorder that cannot open its log file surfaces as a start failure`() {
+        // A session resumed from a previous process, with core.log occupied by a DIRECTORY: the
+        // file logger cannot open its writer. That used to be swallowed, which installed a logger
+        // that wrote nowhere and reported a running recording.
+        val resumedDir = File(externalDir, "debug/logs/myperm_resumed_session").also { it.mkdirs() }
+        File(resumedDir, "core.log").mkdirs()
+        triggerFile.writeText("${resumedDir.absolutePath}\n${System.currentTimeMillis() - 5_000L}")
+
+        withModule { module ->
+            val settled = module.state.first { it.startFailure != null }
+            settled.startFailure.shouldBeInstanceOf<IOException>()
+            settled.isRecording shouldBe false
+            settled.shouldRecord shouldBe false
+            module.currentLogDir.shouldBeNull()
+            // The trigger is gone, so the failing start is not repeated on every process start.
+            triggerFile.exists() shouldBe false
+            // The resumed directory predates this attempt and holds an earlier recording: only a
+            // directory the attempt created itself is cleaned up.
+            resumedDir.exists() shouldBe true
+        }
+    }
+
+    companion object {
+        // Independent of any production bound: a wedged wait has to fail the test, not hang the
+        // gradle worker.
+        private const val TEST_ENVELOPE_MS = 10_000L
+    }
+}

--- a/app/src/test/java/eu/darken/myperm/settings/ui/support/SupportViewModelDebugLogTest.kt
+++ b/app/src/test/java/eu/darken/myperm/settings/ui/support/SupportViewModelDebugLogTest.kt
@@ -1,0 +1,68 @@
+package eu.darken.myperm.settings.ui.support
+
+import eu.darken.myperm.common.WebpageTool
+import eu.darken.myperm.common.debug.recording.core.DebugSession
+import eu.darken.myperm.common.debug.recording.core.DebugSessionManager
+import eu.darken.myperm.common.debug.recording.core.RecorderModule
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelper.BaseTest
+import testhelper.coroutine.TestDispatcherProvider
+import java.io.IOException
+
+/**
+ * A debug recording that cannot start is the user's own next problem: the toggle has to come back
+ * with the error dialog instead of leaving the screen waiting on a recording that never starts.
+ */
+class SupportViewModelDebugLogTest : BaseTest() {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private val debugSessionManager: DebugSessionManager = mockk()
+    private val webpageTool: WebpageTool = mockk(relaxed = true)
+
+    @BeforeEach
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+
+        every { debugSessionManager.recorderState } returns MutableStateFlow(RecorderModule.State())
+        every { debugSessionManager.sessions } returns MutableStateFlow(emptyList<DebugSession>())
+    }
+
+    @AfterEach
+    fun teardown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createVM() = SupportViewModel(
+        dispatcherProvider = TestDispatcherProvider(testDispatcher),
+        webpageTool = webpageTool,
+        debugSessionManager = debugSessionManager,
+    )
+
+    @Test
+    fun `a failed recording start reaches the error events`() = runTest(testDispatcher) {
+        val failure = IOException("Failed to create session directory")
+        coEvery { debugSessionManager.startRecording() } throws failure
+
+        val vm = createVM()
+        val forwardedError = async { vm.errorEvents.first() }
+
+        vm.startDebugLog()
+
+        forwardedError.await() shouldBe failure
+    }
+}


### PR DESCRIPTION
## What changed

A failed debug-log start no longer crashes the app — and no longer turns into a crash loop on every launch via the leftover trigger file. The failure now shows as a normal error dialog and the next attempt works. Two data-loss edges are closed: a failed restart can no longer delete the recording you already made, and a failed start can no longer delete an earlier session that happened to share its folder name.

## Technical Context

- A throw in the start branch rethrew out of the reactive collector onto the handler-less app scope — through the app's uncaught-handler chain that is a process crash; where the process survived, the collector was dead and `startRecorder()` hung forever with `shouldRecord` stuck true. The persisted trigger file re-entered the same failing start at every launch.
- Fix shape (shared with the sibling apps): whole-branch guard, failures committed to state (`startFailure`), `shouldRecord` reset, rollback under `NonCancellable` (attempt-created trigger/dir deleted, resumed preserved), and `ensureActive()` after rollback — real scope cancellation propagates while a dependency's `CancellationException` is wrapped in `RecordingStartFailedException` so ViewModel error handlers fire instead of treating it as normal cancellation.
- `FileLogger.start()` surfaces failures, publishes its writer only after successful init, and deletes only files it created (a failed resume previously deleted the existing `core.log`). `Recorder.start()` is failure-atomic around `Logging.install` (a throwing announcement could leave the logger installed but invisible to rollback).
- Session dirs are created atomically-unique (suffix on collision) and "created this attempt" comes from the actual creation — a same-second collision previously let rollback recursively delete a prior completed session.
- Suppression is identity-guarded (`addSuppressed(self)` threw and aborted the rollback). Start/stop APIs are mutex-serialized. New consumer-level test proves a failed start reaches the error events.
