### PR TITLE
General: Fix rare crashes from the error dialog's Google Play button

### DIFF
--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/billing/GplayServiceUnavailableException.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/billing/GplayServiceUnavailableException.kt
@@ -1,5 +1,6 @@
 package eu.darken.myperm.common.upgrade.core.billing
 
+import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
@@ -25,20 +26,27 @@ class GplayServiceUnavailableException(cause: Throwable) :
         // action is a GENERIC troubleshooting affordance (open Play's app info), not a diagnosis of
         // the cause. Harmless for a transient blip, and it matches the fleet's dialog.
         fixAction = { activity ->
-            try {
-                val intent = Intent().apply {
-                    action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
-                    data = Uri.fromParts("package", GPLAY_PKG, null)
-                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                }
+            val intent = Intent().apply {
+                action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
+                data = Uri.fromParts("package", GPLAY_PKG, null)
+            }
 
+            try {
                 activity.startActivity(intent)
             } catch (e: ActivityNotFoundException) {
-                log(ERROR) { "Can't launch settings intent for Google Play: $e" }
-                Toast.makeText(activity, "Google Play is not installed", Toast.LENGTH_SHORT).show()
+                onLaunchFailed(activity, e)
+            } catch (e: SecurityException) {
+                // Play can be installed but unreachable: disabled app, work/restricted profile or a
+                // ROM that guards the settings screen. The launch is denied, not unresolvable.
+                onLaunchFailed(activity, e)
             }
         },
     )
+
+    private fun onLaunchFailed(activity: Activity, e: Exception) {
+        log(ERROR) { "Can't launch settings intent for Google Play: $e" }
+        Toast.makeText(activity, R.string.upgrades_gplay_not_installed_message, Toast.LENGTH_SHORT).show()
+    }
 
     companion object {
         private const val GPLAY_PKG = "com.android.vending"

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -84,6 +84,8 @@
 
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot can\'t connect to Google Play. Is Google Play installed and up to date? Is your Google Account logged in? Try clearing the cache of the Google Play app and rebooting your device.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play is not installed.</string>
     <string name="upgrades_gplay_billing_error_label">Google Play Issue</string>
     <string name="upgrades_gplay_billing_error_description">There was a problem with Google Play. Please try again later or restart your device.\n\nDetails: %s</string>
     <string name="upgrades_gplay_internal_error_title">Google Play error</string>

--- a/app/src/main/java/eu/darken/myperm/common/error/ErrorEventHandler.kt
+++ b/app/src/main/java/eu/darken/myperm/common/error/ErrorEventHandler.kt
@@ -13,6 +13,10 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import eu.darken.myperm.R
 import eu.darken.myperm.common.compose.findActivity
+import eu.darken.myperm.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.myperm.common.debug.logging.asLog
+import eu.darken.myperm.common.debug.logging.log
+import eu.darken.myperm.common.debug.logging.logTag
 
 @Composable
 fun ErrorEventHandler(source: ErrorEventSource2) {
@@ -54,8 +58,16 @@ private fun ComposeErrorDialog(
             if (hasFix) {
                 TextButton(
                     onClick = {
-                        localizedError.fixAction!!.invoke(activity!!)
-                        onDismiss()
+                        // Fix actions are arbitrary code (e.g. intent launches): a throw here would
+                        // crash the UI thread from inside a click handler, and skipping onDismiss()
+                        // would leave the dialog latched on the current error with no way out.
+                        try {
+                            localizedError.fixAction!!.invoke(activity!!)
+                        } catch (e: Exception) {
+                            log(TAG, ERROR) { "Error action failed: ${e.asLog()}" }
+                        } finally {
+                            onDismiss()
+                        }
                     },
                 ) {
                     Text(text = localizedError.fixActionLabel ?: stringResource(android.R.string.ok))
@@ -78,3 +90,5 @@ private fun ComposeErrorDialog(
         },
     )
 }
+
+private val TAG = logTag("Error", "Dialog")

--- a/app/src/test/java/eu/darken/myperm/common/error/ComposeErrorDialogGuardTest.kt
+++ b/app/src/test/java/eu/darken/myperm/common/error/ComposeErrorDialogGuardTest.kt
@@ -1,0 +1,71 @@
+package eu.darken.myperm.common.error
+
+import android.content.Context
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import eu.darken.myperm.common.compose.PreviewWrapper
+import eu.darken.myperm.common.flow.SingleEventFlow
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+/**
+ * The shared error dialog's fix action is arbitrary code: a fix that blows up must never take the
+ * UI — or the dialog's own exit — down with it. [ErrorEventHandler] backs every screen, so a latched
+ * dialog would leave the user stuck on the current error.
+ */
+class ComposeErrorDialogGuardTest : BaseComposeRobolectricTest() {
+
+    private class FakeErrorSource : ErrorEventSource2 {
+        override val errorEvents = SingleEventFlow<Throwable>()
+    }
+
+    private class ThrowingFixError(private val onFixDispatched: () -> Unit) :
+        Exception(ERROR_BODY), HasLocalizedError {
+
+        override fun getLocalizedError(context: Context): LocalizedError = LocalizedError(
+            throwable = this,
+            label = ERROR_TITLE,
+            description = ERROR_BODY,
+            fixActionLabel = FIX_LABEL,
+            fixAction = {
+                // Flag first: the assertion has to distinguish "action ran and threw" from
+                // "action was never dispatched".
+                onFixDispatched()
+                throw IllegalStateException("fix action exploded")
+            },
+        )
+    }
+
+    private fun showError(error: Throwable) {
+        val source = FakeErrorSource()
+        composeRule.setContent {
+            PreviewWrapper {
+                ErrorEventHandler(source)
+            }
+        }
+        // Buffered channel: the event survives until the handler's collector attaches.
+        source.errorEvents.tryEmit(error)
+        composeRule.waitForIdle()
+    }
+
+    @Test
+    fun `a throwing fix action still dismisses the dialog`() {
+        var invoked = false
+        showError(ThrowingFixError { invoked = true })
+
+        composeRule.onNodeWithText(FIX_LABEL).performClick()
+        composeRule.waitForIdle()
+
+        invoked shouldBe true
+        // The fix button is gone: the throw neither crashed the click handler nor swallowed the
+        // dismissal that closes the dialog.
+        composeRule.onAllNodesWithText(FIX_LABEL).assertCountEquals(0)
+    }
+}
+
+private const val ERROR_TITLE = "Test error title"
+private const val ERROR_BODY = "Test error description"
+private const val FIX_LABEL = "Fix it"

--- a/app/src/testGplay/java/eu/darken/myperm/common/error/ComposeErrorDialogTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/error/ComposeErrorDialogTest.kt
@@ -1,6 +1,7 @@
 package eu.darken.myperm.common.error
 
 import android.content.Context
+import android.content.Intent
 import android.provider.Settings
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertCountEquals
@@ -85,6 +86,9 @@ class ComposeErrorDialogTest : BaseTest() {
         val started = shadowOf(composeRule.activity).nextStartedActivity.shouldNotBeNull()
         started.action shouldBe Settings.ACTION_APPLICATION_DETAILS_SETTINGS
         started.data.toString() shouldBe "package:com.android.vending"
+        // NEW_TASK on an activity context detaches Play's app info from our task: the user loses the
+        // back path to the screen they came from and the settings screen lingers in recents.
+        (started.flags and Intent.FLAG_ACTIVITY_NEW_TASK) shouldBe 0
         // The user acted: leaving the dialog up would greet them again on the way back.
         composeRule.onAllNodesWithText("Google Play").assertCountEquals(0)
     }

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/billing/GplayFixActionTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/billing/GplayFixActionTest.kt
@@ -1,0 +1,60 @@
+package eu.darken.myperm.common.upgrade.core.billing
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import eu.darken.myperm.R
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowToast
+import testhelper.BaseTest
+import testhelpers.TestApplication
+
+/**
+ * The error dialog's "Google Play" button runs on an activity context: a device where the launch is
+ * refused must get a toast, not a crash. The intent shape of a successful launch is pinned by
+ * ComposeErrorDialogTest, which drives the same action through the dialog.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class GplayFixActionTest : BaseTest() {
+
+    /** Play is installed but unreachable: disabled app, restricted profile or a guarding ROM. */
+    class DeniedLaunchActivity : Activity() {
+        override fun startActivity(intent: Intent): Unit = throw SecurityException("Permission Denial")
+    }
+
+    /** No component resolves the app-info screen for Play, e.g. Play isn't installed at all. */
+    class MissingPlayActivity : Activity() {
+        override fun startActivity(intent: Intent): Unit = throw ActivityNotFoundException("No Activity found")
+    }
+
+    private fun fixActionOf(context: Context): (Activity) -> Unit =
+        GplayServiceUnavailableException(RuntimeException("Play hiccup"))
+            .getLocalizedError(context).fixAction.shouldNotBeNull()
+
+    private fun <T : Activity> activityOf(clazz: Class<T>): T = Robolectric.buildActivity(clazz).setup().get()
+
+    private fun assertToastInsteadOfCrash(activity: Activity) {
+        fixActionOf(activity).invoke(activity)
+
+        ShadowToast.getTextOfLatestToast() shouldBe
+            activity.getString(R.string.upgrades_gplay_not_installed_message)
+    }
+
+    @Test
+    fun `a denied launch shows the not-installed toast instead of crashing`() {
+        assertToastInsteadOfCrash(activityOf(DeniedLaunchActivity::class.java))
+    }
+
+    @Test
+    fun `an unresolvable launch shows the not-installed toast instead of crashing`() {
+        assertToastInsteadOfCrash(activityOf(MissingPlayActivity::class.java))
+    }
+}


### PR DESCRIPTION
## What changed

The error dialog's "Google Play" button can no longer crash the app. On devices where Google Play is missing, disabled, or blocked (work/restricted profiles, some ROMs), tapping it now shows a short notice — in the user's language — instead of crashing, and the dialog closes properly. Google Play's app-info screen also opens inside the app's own task, so pressing Back returns to the screen you came from.

## Technical Context

- The fix action launched its settings intent with `FLAG_ACTIVITY_NEW_TASK` from an activity context — that detaches the settings screen from our task (Back loses the way home, the screen lingers in recents). Dropped; a test pins its absence.
- The launch was only guarded against `ActivityNotFoundException`; a `SecurityException` (disabled Play, restricted profile, guarding ROM) crashed the app. Both now route to one fallback: an error log plus a toast that is now a translatable string resource (previously hardcoded English).
- The dialog's fix-button dispatch is wrapped in try/catch/finally: fix actions run arbitrary code, and a throw from a click handler would crash the UI thread and leave the dialog latched on the error it was supposed to resolve. Failures are logged, the dialog always dismisses.
- The guard test lives in `app/src/test` (the dialog is shared code, so both flavor test legs exercise it); the new billing-side test covers both exception paths through the shared toast fallback.
