### PR TITLE
General: Update app translations from Crowdin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,6 +22,7 @@
     "frontend-design@claude-plugins-official": true,
     "kotlin-lsp@claude-plugins-official": true,
     "support-investigator@claude-code-cafe": true,
-    "google-play@claude-code-cafe": true
+    "google-play@claude-code-cafe": true,
+    "devtools@claude-code-cafe": true
   }
 }

--- a/app/src/foss/res/values-af-rZA/strings.xml
+++ b/app/src/foss/res/values-af-rZA/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">Ondersteun weer</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot word in die openheid ontwikkel. Oorweeg \'n herhalende borgskap om dit te help volhou.</string>
     <string name="upgrade_screen_recurring_action">Maak GitHub Sponsors oop</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Ondersteun Permission Pilot</string>
+    <string name="upgrade_screen_why_title">Opgraadvoordele</string>
+    <string name="upgrade_screen_how_title">Hoe om te help</string>
+    <string name="upgrade_screen_how_body">Word \'n beskermheer en borg ontwikkeling! Tik die knoppie hieronder om alle ekstra funksies te aktiveer en my GitHub Sponsors profiel oop te maak.</string>
+    <string name="upgrade_screen_thanks_toast">Dankie dat jy oopbron ontwikkeling ondersteun ❤️</string>
 </resources>

--- a/app/src/foss/res/values-am/strings.xml
+++ b/app/src/foss/res/values-am/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">ደግመው ድጋፍ ስጥ</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot በክፍት ተሰራ። ሚስክ ለመርዳት ተደጋጋሚ ስፖንሰርሺፕ ያስቡ።</string>
     <string name="upgrade_screen_recurring_action">GitHub Sponsors ይክፈቱ</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Permission Pilot ን ደግፉ</string>
+    <string name="upgrade_screen_why_title">የማሻሻያ ጥቅሞች</string>
+    <string name="upgrade_screen_how_title">እንዴት መርዳት እንደሚችሉ</string>
+    <string name="upgrade_screen_how_body">ደጋፊ ይሁኑ እና ልማትን ይደግፉ! ሁሉንም ተጨማሪ ባህሪያት ለማንቃት እና የእኔን GitHub Sponsors መገለጫ ለመክፈት ከታች ያለውን ቁልፍ ይንኩ።</string>
+    <string name="upgrade_screen_thanks_toast">ክፍት ምንጭ ልማትን ስለደገፉ እናመሰግናለን ❤️</string>
 </resources>

--- a/app/src/foss/res/values-ar/strings.xml
+++ b/app/src/foss/res/values-ar/strings.xml
@@ -17,4 +17,9 @@
     <string name="upgrade_screen_recurring_title">ادعم مرة أخرى</string>
     <string name="upgrade_screen_recurring_body">يتم تطوير Permission Pilot بشكل علني. فكر في رعاية متكررة للمساعدة على استدامته.</string>
     <string name="upgrade_screen_recurring_action">افتح GitHub Sponsors</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">دعم Permission Pilot</string>
+    <string name="upgrade_screen_why_title">فوائد الترقية</string>
+    <string name="upgrade_screen_how_body">كن داعما وراعيا للتطوير! انقر على الزر أدناه لتفعيل جميع الميزات الإضافية وفتح ملفي الخاص برعاة GitHub.</string>
+    <string name="upgrade_screen_thanks_toast">شكراً على دعمك لتطوير المصادر المفتوحة ❤️</string>
 </resources>

--- a/app/src/foss/res/values-az/strings.xml
+++ b/app/src/foss/res/values-az/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">Yenidən dəstəkləyin</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot açıq şəkildə inkişaf etdirilir. Onu dəstəkləmək üçün dövri sponsorluğu nəzərdən keçirin.</string>
     <string name="upgrade_screen_recurring_action">GitHub Sponsors-u açın</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Permission Pilot-u dəstəkləyin</string>
+    <string name="upgrade_screen_why_title">Yüksəltmə üstünlükləri</string>
+    <string name="upgrade_screen_how_title">Necə kömək etmək</string>
+    <string name="upgrade_screen_how_body">Himayədar olun və inkişafı sponsor edin! Bütün əlavə xüsusiyyətləri aktivləşdirmək və mənim GitHub Sponsors profilimi açmaq üçün aşağıdakı düyməni toxunun.</string>
+    <string name="upgrade_screen_thanks_toast">Açıq mənbə inkişafını dəstəklədiyiniz üçün təşəkkür edirik ❤️</string>
 </resources>

--- a/app/src/foss/res/values-be/strings.xml
+++ b/app/src/foss/res/values-be/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">Падтрымаць яшчэ раз</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot распрацоўваецца адкрыта. Разгледзьце рэгулярнае спонсарства, каб дапамагчы яго падтрымаць.</string>
     <string name="upgrade_screen_recurring_action">Адкрыць GitHub Sponsors</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Падтрымаць Permission Pilot</string>
+    <string name="upgrade_screen_why_title">Перавагі абнаўлення</string>
+    <string name="upgrade_screen_how_title">Як дапамагчы</string>
+    <string name="upgrade_screen_how_body">Станьце спонсарам распрацоўкі! Націсніце кнопку ніжэй, каб актывіраваць усе дадатковыя функцыі і адкрыць мой профіль на GitHub Sponsors.</string>
+    <string name="upgrade_screen_thanks_toast">Дзякуй за падтрымку распрацоўкі з адкрытым зыходным кодам ❤️</string>
 </resources>

--- a/app/src/foss/res/values-bg/strings.xml
+++ b/app/src/foss/res/values-bg/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">Подкрепете отново</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot е разработен открито. Помислете за периодична спонсорска подкрепа, за да помогнете за неговото развитие.</string>
     <string name="upgrade_screen_recurring_action">Отворете GitHub Sponsors</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Подкрепете Permission Pilot</string>
+    <string name="upgrade_screen_why_title">Предимства на надстройката</string>
+    <string name="upgrade_screen_how_title">Как да помогнете</string>
+    <string name="upgrade_screen_how_body">Станете покровител и спонсорирайте разработката! Докоснете бутона по-долу, за да активирате всички допълнителни функции и да отворите моя GitHub Sponsors профил.</string>
+    <string name="upgrade_screen_thanks_toast">Благодаря ви, че подкрепяте разработката с отворен код ❤️</string>
 </resources>

--- a/app/src/foss/res/values-bn-rBD/strings.xml
+++ b/app/src/foss/res/values-bn-rBD/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">আবার সমর্থন করুন</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot খোলামেলাভাবে তৈরি করা হয়েছে। এটি টিকিয়ে রাখতে সাহায্য করার জন্য নিয়মিত স্পন্সরশিপ বিবেচনা করুন।</string>
     <string name="upgrade_screen_recurring_action">GitHub Sponsors খুলুন</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Permission Pilot সমর্থন করুন</string>
+    <string name="upgrade_screen_why_title">আপগ্রেড সুবিধা</string>
+    <string name="upgrade_screen_how_title">কিভাবে সাহায্য করতে পারি</string>
+    <string name="upgrade_screen_how_body">একটি পৃষ্ঠপোষক এবং স্পনসর উন্নয়ন হয়ে! সমস্ত অতিরিক্ত বৈশিষ্ট্য সক্রিয় করতে নীচের বোতামটি আলতো চাপুন এবং আমার GitHub স্পনসর প্রোফাইল খুলুন।</string>
+    <string name="upgrade_screen_thanks_toast">ওপেন সোর্স ডেভেলপমেন্ট সমর্থন করার জন্য আপনাকে ধন্যবাদ ❤️</string>
 </resources>

--- a/app/src/foss/res/values-ca/strings.xml
+++ b/app/src/foss/res/values-ca/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">Torneu a donar suport</string>
     <string name="upgrade_screen_recurring_body">El Permission Pilot es desenvolupa en obert. Considereu un patrocini recurrent per ajudar a mantenir-lo.</string>
     <string name="upgrade_screen_recurring_action">Obre els patrocinadors del GitHub</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Doneu suport al Permission Pilot</string>
+    <string name="upgrade_screen_why_title">Beneficis de la millora</string>
+    <string name="upgrade_screen_how_title">Com ajudar</string>
+    <string name="upgrade_screen_how_body">Convertiu-vos en mecenes i patrocinadors del desenvolupament! Toqueu el botó següent per activar totes les funcions addicionals i obrir el meu perfil de patrocinadors del GitHub.</string>
+    <string name="upgrade_screen_thanks_toast">Gràcies per donar suport al desenvolupament de codi obert \ufe0f</string>
 </resources>

--- a/app/src/foss/res/values-cs/strings.xml
+++ b/app/src/foss/res/values-cs/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">Podpořit znovu</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot je vyvíjen otevřeně. Zvažte pravidelný sponzoring, který jej pomáhá udržovat.</string>
     <string name="upgrade_screen_recurring_action">Otevřít GitHub Sponsors</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Podpořit Permission Pilot</string>
+    <string name="upgrade_screen_why_title">Výhody upgradu</string>
+    <string name="upgrade_screen_how_title">Jak pomoci</string>
+    <string name="upgrade_screen_how_body">Staňte se patronem a sponzorem vývoje! Klepnutím na tlačítko níže aktivujete všechny další funkce a otevřete můj profil sponzora na GitHubu.</string>
+    <string name="upgrade_screen_thanks_toast">Děkujeme vám za podporu vývoje open-source ❤️</string>
 </resources>

--- a/app/src/foss/res/values-da/strings.xml
+++ b/app/src/foss/res/values-da/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">Støt igen</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot udvikles åbent. Overvej et tilbagevendende sponsorat for at hjælpe med at opretholde det.</string>
     <string name="upgrade_screen_recurring_action">Åbn GitHub Sponsors</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Støt Permission Pilot</string>
+    <string name="upgrade_screen_why_title">Opgraderingsfordele</string>
+    <string name="upgrade_screen_how_title">Sådan hjælper du</string>
+    <string name="upgrade_screen_how_body">Bliv patron og sponsorér udvikling! Tryk på knappen nedenfor for at aktivere alle ekstra funktioner og åbne min GitHub-sponsorprofil.</string>
+    <string name="upgrade_screen_thanks_toast">Tak, fordi du støtter open source-udvikling ❤️</string>
 </resources>

--- a/app/src/foss/res/values-de/strings.xml
+++ b/app/src/foss/res/values-de/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">Erneut unterstützen</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot wird offen entwickelt. Ziehen Sie ein wiederkehrendes Sponsoring in Betracht, um es zu unterstützen.</string>
     <string name="upgrade_screen_recurring_action">GitHub Sponsors öffnen</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Permission Pilot unterstützen</string>
+    <string name="upgrade_screen_why_title">Vorteile des Upgrades</string>
+    <string name="upgrade_screen_how_title">Wie man hilft</string>
+    <string name="upgrade_screen_how_body">Werde Unterstützer und fördere die Entwicklung! Tippe auf den Button unten, um alle Zusatzfunktionen zu aktivieren und mein GitHub-Sponsors-Profil zu öffnen.</string>
+    <string name="upgrade_screen_thanks_toast">Vielen Dank, dass du Open-Source-Entwicklung unterstützt ❤️</string>
 </resources>

--- a/app/src/foss/res/values-el/strings.xml
+++ b/app/src/foss/res/values-el/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">Υποστηρίξτε ξανά</string>
     <string name="upgrade_screen_recurring_body">Το Permission Pilot αναπτύσσεται δημοσίως. Σκέψου μια τακτική χορηγία για να βοηθήσεις στη διατήρησή του.</string>
     <string name="upgrade_screen_recurring_action">Άνοιξε GitHub Sponsors</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Υποστηρίξτε Permission Pilot</string>
+    <string name="upgrade_screen_why_title">Πλεονεκτήματα αναβάθμισης</string>
+    <string name="upgrade_screen_how_title">Πώς να βοηθήσετε</string>
+    <string name="upgrade_screen_how_body">Γίνετε patron και χορηγήστε την ανάπτυξη! Πατήστε το κουμπί παρακάτω για να ενεργοποιήσετε όλα τα επιπλέον χαρακτηριστικά και ανοίξτε το προφίλ μου GitHub Sponsors.</string>
+    <string name="upgrade_screen_thanks_toast">Σας ευχαριστούμε που υποστηρίζετε την ανάπτυξη ανοιχτού κώδικα ❤️</string>
 </resources>

--- a/app/src/foss/res/values-es/strings.xml
+++ b/app/src/foss/res/values-es/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">Apoya de nuevo</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot se desarrolla de forma abierta. Considera un patrocinio recurrente para ayudar a sostenerlo.</string>
     <string name="upgrade_screen_recurring_action">Abrir Patrocinadores de GitHub</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Apoyar Permission Pilot</string>
+    <string name="upgrade_screen_why_title">Beneficios de la mejora</string>
+    <string name="upgrade_screen_how_title">Como ayudar</string>
+    <string name="upgrade_screen_how_body">¡Conviértete en patrocinador y patrocina el desarrollo! Toque el botón de abajo para activar todas las funciones adicionales y abrir mi perfil de Patrocinadores de GitHub.</string>
+    <string name="upgrade_screen_thanks_toast">Gracias por apoyar el desarrollo del código abierto ❤️</string>
 </resources>

--- a/app/src/foss/res/values-fi/strings.xml
+++ b/app/src/foss/res/values-fi/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">Tue uudelleen</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot kehitetään avoimesti. Harkitse toistuvaa tukea sen jatkuvuuden turvaamiseksi.</string>
     <string name="upgrade_screen_recurring_action">Avaa GitHub Sponsors</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Tue Permission Pilotia</string>
+    <string name="upgrade_screen_why_title">Päivityksen edut</string>
+    <string name="upgrade_screen_how_title">Kuinka auttaa</string>
+    <string name="upgrade_screen_how_body">Ryhdy tukijaksi ja sponsoroi kehitystä! Napauta alla olevaa painiketta aktivoidaksesi kaikki lisäominaisuudet ja avataksesi GitHub Sponsors -profiilini.</string>
+    <string name="upgrade_screen_thanks_toast">Kiitos avoimen lähdekoodin kehityksen tukemisesta ❤️</string>
 </resources>

--- a/app/src/foss/res/values-fr/strings.xml
+++ b/app/src/foss/res/values-fr/strings.xml
@@ -17,4 +17,9 @@
     <string name="upgrade_screen_recurring_title">Soutenir à nouveau</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot est développé en open source. Envisagez un parrainage récurrent pour aider à le maintenir.</string>
     <string name="upgrade_screen_recurring_action">Ouvrir GitHub Sponsors</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Soutenir Permission Pilot</string>
+    <string name="upgrade_screen_why_title">Avantages de la mise à niveau</string>
+    <string name="upgrade_screen_how_title">Comment aider</string>
+    <string name="upgrade_screen_thanks_toast">Merci de soutenir le développement des logiciels libres ❤️</string>
 </resources>

--- a/app/src/foss/res/values-hi-rIN/strings.xml
+++ b/app/src/foss/res/values-hi-rIN/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">फिर से समर्थन करें</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot को खुले तरीके से विकसित किया गया है। इसे जारी रखने में मदद के लिए आवर्ती प्रायोजन पर विचार करें।</string>
     <string name="upgrade_screen_recurring_action">GitHub Sponsors खोलें</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Permission Pilot का समर्थन करें</string>
+    <string name="upgrade_screen_why_title">अपग्रेड लाभ</string>
+    <string name="upgrade_screen_how_title">कैसे सहायता करें</string>
+    <string name="upgrade_screen_how_body">संरक्षक बनें और विकास को प्रायोजित करें! सभी अतिरिक्त सुविधाओं को सक्रिय करने और मेरी GitHub Sponsors प्रोफ़ाइल खोलने के लिए नीचे दिए गए बटन को टैप करें।</string>
+    <string name="upgrade_screen_thanks_toast">ओपन-सोर्स विकास ❤️ का समर्थन करने के लिए धन्यवाद</string>
 </resources>

--- a/app/src/foss/res/values-hr/strings.xml
+++ b/app/src/foss/res/values-hr/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">Podržite ponovno</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot razvija se otvoreno. Razmotrite ponavljajuće sponzorstvo kako biste pomogli održati ga.</string>
     <string name="upgrade_screen_recurring_action">Otvori GitHub Sponsors</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Podržite Permission Pilot</string>
+    <string name="upgrade_screen_why_title">Prednosti nadogradnje</string>
+    <string name="upgrade_screen_how_title">Kako pomoći</string>
+    <string name="upgrade_screen_how_body">Postanite pokrovitelj i sponzorirajte razvoj! Dodirnite gumb ispod da biste aktivirali sve dodatne značajke i otvorili moj GitHub sponzorski profil.</string>
+    <string name="upgrade_screen_thanks_toast">Hvala vam što podržavate razvoj otvorenog koda ❤️</string>
 </resources>

--- a/app/src/foss/res/values-hu/strings.xml
+++ b/app/src/foss/res/values-hu/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">Támogass újra</string>
     <string name="upgrade_screen_recurring_body">A Permission Pilot nyílt forráskódban fejlesztik. Fontold meg az ismétlődő szponzorálást a fenntartásának segítésére.</string>
     <string name="upgrade_screen_recurring_action">GitHub Sponsors megnyitása</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Támogasd a Permission Pilot-ot</string>
+    <string name="upgrade_screen_why_title">Frissítés előnyei</string>
+    <string name="upgrade_screen_how_title">Hogyan lehet segíteni</string>
+    <string name="upgrade_screen_how_body">Legyen patron támogató és szponzorálja a fejlesztést! Kattintson az alábbi gombra az összes extra funkció aktiválásához és a GitHub Sponsors profilom megnyitásához.</string>
+    <string name="upgrade_screen_thanks_toast">Köszönjük, hogy támogatod a nyílt forráskódú fejlesztést ❤️</string>
 </resources>

--- a/app/src/foss/res/values-it/strings.xml
+++ b/app/src/foss/res/values-it/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">Sostieni di nuovo</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot è sviluppato in modo aperto. Considera un contributo ricorrente per aiutare a sostenerlo.</string>
     <string name="upgrade_screen_recurring_action">Apri GitHub Sponsors</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Supporta Permission Pilot</string>
+    <string name="upgrade_screen_why_title">Vantaggi dell\'upgrade</string>
+    <string name="upgrade_screen_how_title">Come aiutare</string>
+    <string name="upgrade_screen_how_body">Diventa un sostenitore e sponsorizza lo sviluppo! Clicca il pulsante qui sotto per attivare tutte le funzioni extra e apri il mio profilo Sponsor Github.</string>
+    <string name="upgrade_screen_thanks_toast">Grazie per aver supportato lo sviluppo open-source ❤️</string>
 </resources>

--- a/app/src/foss/res/values-iw/strings.xml
+++ b/app/src/foss/res/values-iw/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">תמוך שוב</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot מפותח בצורה פתוחה. שקול חסות חוזרת כדי לעזור בשמירה עליו.</string>
     <string name="upgrade_screen_recurring_action">פתח את GitHub Sponsors</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">תמוך ב-Permission Pilot</string>
+    <string name="upgrade_screen_why_title">יתרונות השדרוג</string>
+    <string name="upgrade_screen_how_title">איך לעזור</string>
+    <string name="upgrade_screen_how_body">הפוך לפטרון ונותן חסות לפיתוח! הקש על הכפתור למטה כדי להפעיל את כל התכונות הנוספות ולפתוח את פרופיל הספונסרים בגיטהאב שלי.</string>
+    <string name="upgrade_screen_thanks_toast">תודה שתמכת בפיתוח קוד פתוח ❤️</string>
 </resources>

--- a/app/src/foss/res/values-ja/strings.xml
+++ b/app/src/foss/res/values-ja/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">もう一度サポートする</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot はオープンな形で開発されています。継続的なスポンサーシップをご検討ください。</string>
     <string name="upgrade_screen_recurring_action">GitHub スポンサーを開く</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Permission Pilot をサポート</string>
+    <string name="upgrade_screen_why_title">アップグレードの利点</string>
+    <string name="upgrade_screen_how_title">協力するには</string>
+    <string name="upgrade_screen_how_body">パトロンとスポンサーの開発になりましょう！下のボタンをタップすると、すべての追加機能が有効になり、GitHub Sponsors プロファイルを開きます。</string>
+    <string name="upgrade_screen_thanks_toast">オープンソースでの開発に協力してくれてありがとうございます ❤️</string>
 </resources>

--- a/app/src/foss/res/values-ko/strings.xml
+++ b/app/src/foss/res/values-ko/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">다시 후원하기</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot는 공개적으로 개발되고 있습니다. 지속을 위해 정기 후원을 고려해주세요.</string>
     <string name="upgrade_screen_recurring_action">GitHub Sponsors 열기</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Permission Pilot 지원</string>
+    <string name="upgrade_screen_why_title">업그레이드 혜택</string>
+    <string name="upgrade_screen_how_title">도움 주기</string>
+    <string name="upgrade_screen_how_body">후원자가 되어 개발을 지원하세요! 아래 버튼을 눌러 Github Sponsors 프로필을 열고 추가 기능을 잠금해제하세요.</string>
+    <string name="upgrade_screen_thanks_toast">오픈소스 개발을 지원해 주셔서 감사합니다 ❤️</string>
 </resources>

--- a/app/src/foss/res/values-ku-rTR/strings.xml
+++ b/app/src/foss/res/values-ku-rTR/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">Dîsa piştgirî bike</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot di demildestî de pêşve tê xistin. Mêvandarê dubarekirî bîr bike da ku ew berdewam bimîne.</string>
     <string name="upgrade_screen_recurring_action">GitHub Sponsors Vekir</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Permission Pilotan desteki bike</string>
+    <string name="upgrade_screen_why_title">Sûdên pêşbirkî</string>
+    <string name="upgrade_screen_how_title">Çawa desteki bike</string>
+    <string name="upgrade_screen_how_body">Bibe patronê û pişteva peşveçûnê bike! Bişkoja jêr bikirte da ku hemû taybetmendiyên zêde çalak bikin û profila GitHub Sponsors veki bibin.</string>
+    <string name="upgrade_screen_thanks_toast">Sipasî ji bo destekkirina peşveçûna kodên vekirî ❤️</string>
 </resources>

--- a/app/src/foss/res/values-nb/strings.xml
+++ b/app/src/foss/res/values-nb/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">Støtt igjen</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot er utviklet åpent. Vurder et gjentakende sponsorskap for å hjelpe til med å opprettholde det.</string>
     <string name="upgrade_screen_recurring_action">Åpne GitHub Sponsors</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Støtt Permission Pilot</string>
+    <string name="upgrade_screen_why_title">Oppgraderingsfordeler</string>
+    <string name="upgrade_screen_how_title">Hvordan hjelpe</string>
+    <string name="upgrade_screen_how_body">Bli en patron og støtt utviklingen! Trykk på knappen under for å aktivere alle ekstra funksjoner og åpne sponsorprofilen min på GitHub.</string>
+    <string name="upgrade_screen_thanks_toast">Takk for at du støtter åpen kildekodeutvikling ❤️</string>
 </resources>

--- a/app/src/foss/res/values-nl/strings.xml
+++ b/app/src/foss/res/values-nl/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">Opnieuw ondersteunen</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot wordt open source ontwikkeld. Overweeg een terugkerende sponsoring om het in stand te houden.</string>
     <string name="upgrade_screen_recurring_action">GitHub Sponsors openen</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Ondersteun Permission Pilot</string>
+    <string name="upgrade_screen_why_title">Voordelen van de upgrade</string>
+    <string name="upgrade_screen_how_title">Hoe kun je helpen</string>
+    <string name="upgrade_screen_how_body">Word mecenas en sponsor ontwikkelaar! Tik op de onderstaande knop om alle extra functies te activeren en mijn GitHub Sponsors-profiel te openen.</string>
+    <string name="upgrade_screen_thanks_toast">Bedankt voor het ondersteunen van open-sourceontwikkeling ❤️</string>
 </resources>

--- a/app/src/foss/res/values-pl/strings.xml
+++ b/app/src/foss/res/values-pl/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">Ponowne wsparcie</string>
     <string name="upgrade_screen_recurring_body">Pilot Uprawnień jest rozwijany w sposób otwarty. Rozważ stałe wspieranie, aby go utrzymać.</string>
     <string name="upgrade_screen_recurring_action">Otwórz GitHub Sponsors</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Wesprzyj Pilot Uprawnień</string>
+    <string name="upgrade_screen_why_title">Korzyści z uaktualnienia</string>
+    <string name="upgrade_screen_how_title">Jak pomóc</string>
+    <string name="upgrade_screen_how_body">Zostań patronem i wspieraj rozwój! Dotknij przycisku poniżej, aby aktywować wszystkie dodatkowe funkcje i otworzyć mój profil GitHub Sponsors.</string>
+    <string name="upgrade_screen_thanks_toast">Dziękuję za wsparcie rozwoju oprogramowania otwartego źródłowego ❤️</string>
 </resources>

--- a/app/src/foss/res/values-pt-rBR/strings.xml
+++ b/app/src/foss/res/values-pt-rBR/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">Apoiar novamente</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot é desenvolvido de forma aberta. Considere um patrocínio recorrente para ajudar a sustentá-lo.</string>
     <string name="upgrade_screen_recurring_action">Abrir GitHub Sponsors</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Apoie o Permission Pilot</string>
+    <string name="upgrade_screen_why_title">Benefícios da atualização</string>
+    <string name="upgrade_screen_how_title">Como ajudar</string>
+    <string name="upgrade_screen_how_body">Torne-se um patrocinador e financie o desenvolvimento! Clique no botão abaixo para ativar todos os recursos extras e abrir meu perfil Github Sponsors.</string>
+    <string name="upgrade_screen_thanks_toast">Obrigado por apoiar o desenvolvimento de código aberto ❤️</string>
 </resources>

--- a/app/src/foss/res/values-pt/strings.xml
+++ b/app/src/foss/res/values-pt/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">Apoie novamente</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot é desenvolvido de forma aberta. Considere um patrocínio recorrente para ajudar a sustentá-lo.</string>
     <string name="upgrade_screen_recurring_action">Abrir GitHub Sponsors</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Apoiar Permission Pilot</string>
+    <string name="upgrade_screen_why_title">Benefícios da atualização</string>
+    <string name="upgrade_screen_how_title">Como ajudar</string>
+    <string name="upgrade_screen_how_body">Torne-se patrono e apoie o desenvolvimento! Toque no botão abaixo para ativar todas as funcionalidades adicionais e abrir o meu perfil no GitHub Sponsors.</string>
+    <string name="upgrade_screen_thanks_toast">Obrigado por apoiar o desenvolvimento de código aberto ❤️</string>
 </resources>

--- a/app/src/foss/res/values-ro/strings.xml
+++ b/app/src/foss/res/values-ro/strings.xml
@@ -17,4 +17,9 @@
     <string name="upgrade_screen_recurring_title">Sprijină din nou</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot este dezvoltat deschis. Ia în considerare o sponsorizare recurentă pentru a-l susține.</string>
     <string name="upgrade_screen_recurring_action">Deschide GitHub Sponsors</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Susțineți Permission Pilot</string>
+    <string name="upgrade_screen_why_title">Beneficiile upgrade-ului</string>
+    <string name="upgrade_screen_how_title">Cum să ajuți</string>
+    <string name="upgrade_screen_thanks_toast">Mulțumim pentru susținerea dezvoltării open-source ❤️</string>
 </resources>

--- a/app/src/foss/res/values-ru/strings.xml
+++ b/app/src/foss/res/values-ru/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">Поддержать снова</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot разрабатывается открыто. Подумайте о регулярной поддержке, чтобы помочь нам развиваться.</string>
     <string name="upgrade_screen_recurring_action">Открыть GitHub Sponsors</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Поддержать Permission Pilot</string>
+    <string name="upgrade_screen_why_title">Преимущества обновления</string>
+    <string name="upgrade_screen_how_title">Как помочь</string>
+    <string name="upgrade_screen_how_body">Станьте спонсором и поддержите разработку! Нажмите кнопку ниже, чтобы активировать все дополнительные функции и открыть мой профиль GitHub Sponsors.</string>
+    <string name="upgrade_screen_thanks_toast">Благодарим Вас за поддержку разработки с открытым исходным кодом ❤️</string>
 </resources>

--- a/app/src/foss/res/values-sk/strings.xml
+++ b/app/src/foss/res/values-sk/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">Podporte znova</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot sa vyvíja otvorene. Zvážte opakovaný sponzorský príspevok, aby ste pomohli ho udržať.</string>
     <string name="upgrade_screen_recurring_action">Otvoriť GitHub Sponsors</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Podporiť Permission Pilot</string>
+    <string name="upgrade_screen_why_title">Výhody upgradu</string>
+    <string name="upgrade_screen_how_title">Ako pomôcť</string>
+    <string name="upgrade_screen_how_body">Staňte sa patrónom a sponzorujte rozvoj! Klepnutím na tlačidlo nižšie aktivujete všetky ďalšie funkcie a otvoríte môj profil sponzorov GitHub.</string>
+    <string name="upgrade_screen_thanks_toast">Ďakujem za podporu vývoja open-source ❤️</string>
 </resources>

--- a/app/src/foss/res/values-sr/strings.xml
+++ b/app/src/foss/res/values-sr/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">Поново подржи</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot се развија отворено. Размотри редовно спонзорство да помогнеш у његовом одржавању.</string>
     <string name="upgrade_screen_recurring_action">Отвори GitHub Sponsors</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Подржите Permission Pilot</string>
+    <string name="upgrade_screen_why_title">Предности надградње</string>
+    <string name="upgrade_screen_how_title">Како помоћи</string>
+    <string name="upgrade_screen_how_body">Постаните покровитељ и спонзоришите развој! Додирните дугме испод да активирате све додатне функције и отворите мој GitHub Sponsors профил.</string>
+    <string name="upgrade_screen_thanks_toast">Хвала вам што подржавате развој отвореног кода ❤️</string>
 </resources>

--- a/app/src/foss/res/values-sv/strings.xml
+++ b/app/src/foss/res/values-sv/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">Stödja igen</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot utvecklas öppet. Överväg ett återkommande sponsorskap för att hjälpa till att upprätthålla det.</string>
     <string name="upgrade_screen_recurring_action">Öppna GitHub Sponsors</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Stöd Permission Pilot</string>
+    <string name="upgrade_screen_why_title">Uppgraderingsfördelar</string>
+    <string name="upgrade_screen_how_title">Hur du kan hjälpa</string>
+    <string name="upgrade_screen_how_body">Bli en beskyddare och sponsra utvecklingen! Tryck på knappen nedan för att aktivera alla extra funktioner och öppna min GitHub Sponsors-profil.</string>
+    <string name="upgrade_screen_thanks_toast">Tack för att du stöder utveckling med öppen källkod ❤️</string>
 </resources>

--- a/app/src/foss/res/values-th/strings.xml
+++ b/app/src/foss/res/values-th/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">สนับสนุนอีกครั้ง</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot ได้รับการพัฒนาแบบเปิด ลองพิจารณาการสนับสนุนแบบประจำเพื่อช่วยรักษาแอปไว้</string>
     <string name="upgrade_screen_recurring_action">เปิด GitHub Sponsors</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">สนับสนุน Permission Pilot</string>
+    <string name="upgrade_screen_why_title">ประโยชน์ของการอัปเกรด</string>
+    <string name="upgrade_screen_how_title">วิธีการช่วยเหลือ</string>
+    <string name="upgrade_screen_how_body">เป็นผู้อุปถัมภ์และสปอนเซอร์การพัฒนา! แตะปุ่มด้านล่างเพื่อเปิดใช้ฟีเจอร์เพิ่มเติมทั้งหมดและเปิดโปรไฟล์ GitHub Sponsors ของฉัน</string>
+    <string name="upgrade_screen_thanks_toast">ขอบคุณสำหรับการสนับสนุนการพัฒนาโอเพ่นซอร์ส ❤️</string>
 </resources>

--- a/app/src/foss/res/values-tr/strings.xml
+++ b/app/src/foss/res/values-tr/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">Tekrar Destekle</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot açık olarak geliştirilmektedir. Bunu sürdürmeye yardımcı olmak için yinelenen bir sponsorluk düşünün.</string>
     <string name="upgrade_screen_recurring_action">GitHub Sponsors\'ı Aç</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Permission Pilot\'u Destekle</string>
+    <string name="upgrade_screen_why_title">Yükseltme Faydaları</string>
+    <string name="upgrade_screen_how_title">Nasıl yardım edilir</string>
+    <string name="upgrade_screen_how_body">Haminiz olun ve gelişime sponsor olun! Tüm ekstra özellikleri etkinleştirmek ve GitHub Sponsorları profilimi açmak için aşağıdaki düğmeye dokunun.</string>
+    <string name="upgrade_screen_thanks_toast">Açık kaynak geliştirmeyi desteklediğiniz için teşekkür ederiz ❤️</string>
 </resources>

--- a/app/src/foss/res/values-uk/strings.xml
+++ b/app/src/foss/res/values-uk/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">Підтримати знову</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot розробляється відкрито. Розгляньте регулярне спонсорство, щоб підтримати його розвиток.</string>
     <string name="upgrade_screen_recurring_action">Відкрити GitHub Sponsors</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Підтримайте Permission Pilot</string>
+    <string name="upgrade_screen_why_title">Переваги оновлення</string>
+    <string name="upgrade_screen_how_title">Як допомогти</string>
+    <string name="upgrade_screen_how_body">Стань меценатом і спонсором розробки! Торкніться кнопки нижче, щоб активувати всі додаткові функції та відкрити мій профіль спонсорів GitHub.</string>
+    <string name="upgrade_screen_thanks_toast">Дякуємо за підтримку розробки з відкритим кодом ❤️</string>
 </resources>

--- a/app/src/foss/res/values-vi/strings.xml
+++ b/app/src/foss/res/values-vi/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">Ủng hộ lại</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot được phát triển công khai. Hãy xem xét một chương trình tài trợ định kỳ để giúp duy trì nó.</string>
     <string name="upgrade_screen_recurring_action">Mở GitHub Sponsors</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">Hỗ trợ Permission Pilot</string>
+    <string name="upgrade_screen_why_title">Lợi ích nâng cấp</string>
+    <string name="upgrade_screen_how_title">Làm thế nào để giúp đỡ</string>
+    <string name="upgrade_screen_how_body">Trở thành người bảo trợ và tài trợ phát triển! Nhấp vào nút bên dưới để kích hoạt tất cả các tính năng bổ sung và mở hồ sơ Nhà tài trợ GitHub của tôi.</string>
+    <string name="upgrade_screen_thanks_toast">Cảm ơn bạn đã hỗ trợ phát triển mã nguồn mở ❤️</string>
 </resources>

--- a/app/src/foss/res/values-zh-rCN/strings.xml
+++ b/app/src/foss/res/values-zh-rCN/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">再次支持</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot 是公开开发的。请考虑定期赞助以帮助维持其运营。</string>
     <string name="upgrade_screen_recurring_action">打开 GitHub Sponsors</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">支持 Permission Pilot</string>
+    <string name="upgrade_screen_why_title">升级权益</string>
+    <string name="upgrade_screen_how_title">如何帮助我们</string>
+    <string name="upgrade_screen_how_body">成为赞助者并支持我们的开发！点击下面的按钮激活所有额外功能并打开我的 GitHub 赞助者资料。</string>
+    <string name="upgrade_screen_thanks_toast">感谢您支持开源开发 ❤️</string>
 </resources>

--- a/app/src/foss/res/values-zh-rTW/strings.xml
+++ b/app/src/foss/res/values-zh-rTW/strings.xml
@@ -17,4 +17,10 @@
     <string name="upgrade_screen_recurring_title">再次支持</string>
     <string name="upgrade_screen_recurring_body">Permission Pilot 是以開源方式開發的。請考慮定期贊助以幫助維持它的發展。</string>
     <string name="upgrade_screen_recurring_action">開啟 GitHub Sponsors</string>
+    <!-- Support pitch -->
+    <string name="upgrade_screen_title">支持 Permission Pilot</string>
+    <string name="upgrade_screen_why_title">升級權益</string>
+    <string name="upgrade_screen_how_title">如何協助</string>
+    <string name="upgrade_screen_how_body">成為贊助者並贊助開發！輕觸下面的按鈕，啟用所有額外功能，並開啟我的 Github 贊助者設定檔。</string>
+    <string name="upgrade_screen_thanks_toast">感謝您對開放原始碼開發的支持 ❤️</string>
 </resources>

--- a/app/src/gplay/res/values-af-rZA/strings.xml
+++ b/app/src/gplay/res/values-af-rZA/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">Reeds gekoop</string>
     <string name="upgrades_gplay_already_owned_error">Google Play rapporteer dat u reeds hierdie opgradering besit, maar dit kon nie herstel word nie. Kyk dat u aangemeld is met die Google-rekening wat vir die oorspronklike aankoop gebruik is, en probeer dan \"Aankoop herstel\".</string>
     <string name="upgrade_screen_preamble">Permission Pilot is sonder advertensies en respekteer jou privaatheid. Opgradering ondersteun voortgesette ontwikkeling.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Pryse nie beskikbaar nie</string>
+    <string name="upgrade_screen_offers_unavailable_message">Pryse kon nou nie gelaai word nie. Kontroleer Google Play en probeer oor \'n oomblik weer.</string>
     <string name="upgrade_screen_subscription_trial_action">Begin gratis proeftydperk</string>
     <string name="upgrade_screen_subscription_action">Teken in</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/jaar, kanselleer enige tyd</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Veelvuldige rekeninge kan Google Play verwar. Die installering van die toepassing deur die Google Play-webwerf dwing dit om met \'n spesifieke rekening geassosieer te word.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Google Play-sinkronisasie kan tyd neem. Probeer herlaai, maak die Google Play Store-kas skoon of wag net.</string>
     <string name="upgrade_screen_restore_contact_hint">Steeds vasgevang? Kontak ondersteuning vanaf die e-posadres waarmee die aankoop gemaak is, en sluit u Google Play-ordernommer in.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Kry %1$s</string>
+    <string name="upgrade_screen_benefits_title">Opgraadvoordele</string>
+    <string name="upgrade_screen_thanks_toast">Jy is die beste! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro is nog steeds aktief. Wag vir Google Play om jou aankoop te herbevestig, al die Pro-funksies bly intussen ontgrendel.</string>
+    <string name="upgrade_screen_restore_body">Herstel vra Google Play om hierdie toepassing se aankope vir die huidige rekening te herkontroleer. Dit begin nie \'n nuwe aankoop nie.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Die kontrole met Google Play het nie betyds voltooi nie, dus is jou aankoupstatus nog steeds onbekend. Niks het op jou rekening verander nie.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot kan nie aan Google Play koppel nie. Is Google Play geïnstalleer en opgedateer? Is jou Google-rekening aangemeld? Probeer om die kas van die Google Play-toepassing skoon te maak en jou toestel herlaai.</string>
+    <string name="upgrades_gplay_billing_error_label">Google Play-probleem</string>
+    <string name="upgrades_gplay_billing_error_description">Daar was \'n probleem met Google Play. Probeer asseblief later weer of herstart jou toestel.\n\nBesonderhede: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play-fout</string>
+    <string name="upgrades_gplay_internal_error_description">\'n Interne Google Play-fout het voorgekom. Probeer asseblief die volgende:\n\n• Herstart jou toestel\n• Maak Google Play Store-kas skoon\n• Probeer later weer</string>
+    <string name="upgrades_gplay_network_error_title">Verbindingsfout</string>
+    <string name="upgrades_gplay_network_error_description">Kan nie aan Google Play koppel nie. Kontroleer asseblief jou internetverbinding en probeer weer.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Aanbod nie beskikbaar nie</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play bied hierdie opgraadopsie tans nie aan nie. Probeer asseblief later weer of kontroleer die Google Play Store.</string>
 </resources>

--- a/app/src/gplay/res/values-am/strings.xml
+++ b/app/src/gplay/res/values-am/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">ቀድሞ ተገዛ</string>
     <string name="upgrades_gplay_already_owned_error">Google Play ይህን ማሻሻያ ቀድሞ ይዤተዋል ይላል፣ ነገር ግን ሊመለስ አልተቻለም። ዋናውን ግዢ ለያዙ Google መለያ ገብተዋል መሆኑን ያረጋግጡ፣ ከዚያ \"ግዢ ወደ ነበር ሆኑ\" ሞክሩ።</string>
     <string name="upgrade_screen_preamble">Permission Pilot አዶዘቕ ዘርዘር እና ስሴያወን ይካባተኻላለ። ደርጉን ወደፈርም ብጅት ይደግፋለ።</string>
+    <string name="upgrade_screen_offers_unavailable_title">ዋጋዎች አይገኙም</string>
+    <string name="upgrade_screen_offers_unavailable_message">ዋጋዎች አሁን ሊጫኑ አልቻሉም። Google Play ይመልከቱ እና ከጥቂት ደቂቃዎች በኋላ እንደገና ሞክሩ።</string>
     <string name="upgrade_screen_subscription_trial_action">የ፣የ ንብስት ይጀምሩ</string>
     <string name="upgrade_screen_subscription_action">ይመዝገቡ</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/ዓመት፣ በማንኛውም ጊዜ ይሰርዙ</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">ብዙ መለያዎች Google Play ማምታታት ይችላሉ። መተግበሪያውን በGoogle Play ድርጣቢያ በኩል መጫን ከተወሰነ መለያ ጋር ግንኙነትን ያስገድዳል።</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Google Play ሲምሪዝሽን ጊዜ ሊወስድ ይችላል። እንደገና ማስጀመር፣ Google Play Store መሸጎጫ ማጥራት ወይም ብቻ መጠበቅ ይሞክሩ።</string>
     <string name="upgrade_screen_restore_contact_hint">አሁንም ተጣበቀ? ግዢውን ያደረገውን ኢሜይል በመጠቀም ድጋፋን ያገናኙ እና የGoogle Play ትዕዛዝ ቁጥር ያካትቱ።</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">%1$s ያግኙ</string>
+    <string name="upgrade_screen_benefits_title">የማሻሻያ ጥቅሞች</string>
+    <string name="upgrade_screen_thanks_toast">እርስዎ ምርጥ ነዎት! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro አሁንም ንቁ ነው። Google Play ለእርስዎ ግዥ እንደገና ለማረጋገጥ ጠብቁ፣ ሁሉም Pro ባህሪዎች ለወቅቱ ተከፍተው ይሆናሉ።</string>
+    <string name="upgrade_screen_restore_body">ወደ ልክ መመለስ Google Play ይህን መተግባሪያ ግዥዎችን ለአሁኑ መለያ እንደገና ይመልከታል። አዲስ ግዥ አይጀምርም።</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Google Play ጋር ያለው ማረጋገጫ በጊዜ አልተጠናቀቀም፣ ስለሆነም የእርስዎ የግዥ ሁኔታ አሁንም ያልታወቀ ነው። በእርስዎ መለያ ላይ ምንም ነገር አልተወለጠም።</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot ከGoogle Play ጋር መገናኘት አይችልም። Google Play ተጭኖ እና ወቅታዊ ነው? የGoogle መለያዎ ገብቷል? የGoogle Play መተግበሪያ መሸጎጫ ማጥራት እና መሳሪያዎን እንደገና ማስጀመር ይሞክሩ።</string>
+    <string name="upgrades_gplay_billing_error_label">Google Play ችግር</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play ጋር ችግር ተፈጠረ። ከጥቂት ደቂቃዎች በኋላ እንደገና ይሞክሩ ወይም መሳሪያዎን እንደገና ያስጀምሩ።\n\nዝርዝር: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play ስህተት</string>
+    <string name="upgrades_gplay_internal_error_description">ውስጣዊ Google Play ስህተት ተፈጠረ። እባክዎ የሚከተለውን ይሞክሩ:\n\n• መሳሪያዎን እንደገና ያስጀምሩ\n• Google Play Store ካሽ ያጽዳ\n• ከጥቂት ደቂቃዎች በኋላ እንደገና ሞክር</string>
+    <string name="upgrades_gplay_network_error_title">ትስስር ስህተት</string>
+    <string name="upgrades_gplay_network_error_description">Google Play ጋር መገናኘት ያልተቻለ። እባክዎ Internet ግንኙነቶን ይመልከቱ እና እንደገና ሞክሩ።</string>
+    <string name="upgrades_gplay_offer_unavailable_title">ታሪፍ አይገኝም</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play አሁን ይህ ማሳሻያ አማራጭ አያቀርብም። እባክዎ ከጥቂት ደቂቃዎች በኋላ ወይም Google Play Store ይመልከቱ።</string>
 </resources>

--- a/app/src/gplay/res/values-ar/strings.xml
+++ b/app/src/gplay/res/values-ar/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">تم شراؤه بالفعل</string>
     <string name="upgrades_gplay_already_owned_error">يفيد Google Play بأنك تمتلك هذه الترقية بالفعل، لكن لم يتمكن من استعادتها. تحقق من أنك مسجل الدخول بحساب Google الذي استخدمته في الشراء الأصلي، ثم جرّب \"استعادة الشراء\".</string>
     <string name="upgrade_screen_preamble">Permission Pilot خالي من الإعلانات ويحترم خصوصيتك. الترقية تدعم استمرار التطوير.</string>
+    <string name="upgrade_screen_offers_unavailable_title">الأسعار غير متاحة</string>
+    <string name="upgrade_screen_offers_unavailable_message">لم يتمكن من تحميل الأسعار حالياً. تحقق من Google Play وحاول مرة أخرى لاحقاً.</string>
     <string name="upgrade_screen_subscription_trial_action">ابدأ الإصدار التجريبي المجاني</string>
     <string name="upgrade_screen_subscription_action">اشتراك</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/سنة، إلغاء في أي وقت</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">قد تسبب حسابات متعددة التباسًا في Google Play. يؤدي تثبيت التطبيق من موقع Google Play على الويب إلى ربطه بحساب معين.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">قد تستغرق مزامنة Google Play بعض الوقت. جرب إعادة تشغيل الجهاز أو مسح ذاكرة التخزين المؤقتة لمتجر Google Play أو ببساطة الانتظار.</string>
     <string name="upgrade_screen_restore_contact_hint">لا تزال عالقًا؟ تواصل مع الدعم من البريد الإلكتروني الذي استخدمته للشراء وأرفق رقم طلب Google Play.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">احصل على %1$s</string>
+    <string name="upgrade_screen_benefits_title">فوائد الترقية</string>
+    <string name="upgrade_screen_thanks_toast">أنت الأفضل! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">الإصدار Pro لا يزال نشطاً. جاري انتظار Google Play لإعادة تأكيد شرائك، تظل جميع ميزات Pro مفتوحة في غضون ذلك.</string>
+    <string name="upgrade_screen_restore_body">تطلب الاستعادة من Google Play إعادة فحص عمليات شراء هذا التطبيق للحساب الحالي. لا تبدأ عملية شراء جديدة.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">لم ينتهِ الفحص مع Google Play في الوقت المحدد، لذلك حالة شرائك لا تزال غير معروفة. لم يتغير شيء على حسابك.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">يتعذر على Permission Pilot الاتصال بـ Google Play. هل تم تثبيت Google Play وتحديثه؟ هل تم تسجيل الدخول إلى حسابك في Google؟ حاول مسح ذاكرة التخزين المؤقت لتطبيق Google Play وإعادة تشغيل جهازك.</string>
+    <string name="upgrades_gplay_billing_error_label">هناك مشكلة مع المتجر التطبيقات Google Play</string>
+    <string name="upgrades_gplay_billing_error_description">واجهنا مشكلة مع Google Play، المرجو المحاولة ثانية لاحقا أو إعادة تشغيل جهازك. \n\nالتفاصيل: %s</string>
+    <string name="upgrades_gplay_internal_error_title">خطأ في Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">حدث خطأ داخلي في Google Play. يرجى تجربة ما يلي:\n\n• أعد تشغيل جهازك\n• امسح ذاكرة التخزين المؤقت لمتجر Google Play\n• حاول لاحقاً</string>
+    <string name="upgrades_gplay_network_error_title">خطأ في الاتصال</string>
+    <string name="upgrades_gplay_network_error_description">غير قادر على الاتصال بـ Google Play. يرجى التحقق من اتصالك بالإنترنت وحاول مرة أخرى.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">العرض غير متاح</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play حالياً لا يقدم خيار الترقية هذا. يرجى محاولة لاحقاً أو التحقق من متجر Google Play.</string>
 </resources>

--- a/app/src/gplay/res/values-az/strings.xml
+++ b/app/src/gplay/res/values-az/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">Artıq satın alındı</string>
     <string name="upgrades_gplay_already_owned_error">Google Play bildirir ki, siz artıq bu yüksəltməyə sahibsiniz, lakin o bərpa olunmadı. Orijinal alış üçün istifadə etdiyiniz Google hesabına daxil olduğunuzu yoxlayın, sonra \"Satın almağı bərpa et\"-i cəhd edin.</string>
     <string name="upgrade_screen_preamble">Permission Pilot rəkləmsüzdür və məxfiliyinizə hörmət edir. Yüksəltmək davamlı gelişdirməni dəstəkləyir.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Qiymətlər əlçatan deyil</string>
+    <string name="upgrade_screen_offers_unavailable_message">Qiymətlər indi yükləniləsi olmadı. Google Play-ə baxın və bir az sonra yenidən cəhd edin.</string>
     <string name="upgrade_screen_subscription_trial_action">Pülsüz sınaq başladın</string>
     <string name="upgrade_screen_subscription_action">Abunə olun</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/il, istənilən vaxt ləğv edin</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Çoxlu hesablar Google Play-i çaşdıra bilər. Tətbiqini Google Play veb saytı vasitəsilə quraşdırmaq onu müəyyən hesabla əlaqələndirməyi məcbur edir.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Google Play sinxronlaşdırması vaxt ala bilər. Yenidən başlatmağı, Google Play Store keşini təmizləməyi və ya sadəcə gözləməyi sınayın.</string>
     <string name="upgrade_screen_restore_contact_hint">Hələ də problem yaşayırsınız? Satınalmaq üçün istifadə olunan e-poçt ünvanından dəstəyə müraciət edin və Google Play sifariş nömrənizi əlavə edin.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">%1$s-i əldə edin</string>
+    <string name="upgrade_screen_benefits_title">Yüksəltmə üstünlükləri</string>
+    <string name="upgrade_screen_thanks_toast">Siz ən yaxşısınız! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro hələ də fəaldir. Google Play alışınızı yenidən təsdiq etməsi üçün gözləyirik. Bu müddətdə bütün Pro xüsusiyyətləri açıq qalır.</string>
+    <string name="upgrade_screen_restore_body">Bərpaya sal Google Play-in bu tətbiqin cari hesab üçün alışlarını yenidən yoxlamasını xahiş edir. Bu yeni alış başlatmır.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Google Play ilə yoxlama vaxtında bitmədi, buna görə də alış statusunuz hələ də naməlumdur. Hesabınızda heç bir şey dəyişməyib.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot Google Play-ə qoşula bilmir. Google Play quraşdırılıb və yenilənib? Google hesabınız daxil olub? Google Play tətbiqinin keşini təmizləməyi və cihazınızı yenidən başlatmagı sınayın.</string>
+    <string name="upgrades_gplay_billing_error_label">Google Play Problemi</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play ilə problem yarandı. Xahiş edirik bir az sonra yenidən cəhd edin və ya cihazınızı yenidən başladın.\n\nDetallar: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play xətası</string>
+    <string name="upgrades_gplay_internal_error_description">Google Play-də daxili xəta baş verdi. Xahiş edirik aşağıdakıları sınayın:\n\n• Cihazınızı yenidən başladın\n• Google Play Store keşini təmizləyin\n• Daha sonra yenidən cəhd edin</string>
+    <string name="upgrades_gplay_network_error_title">Bağlantı xətası</string>
+    <string name="upgrades_gplay_network_error_description">Google Play-ə qoşula bilinmir. Xahiş edirik internet bağlantınızı yoxlayın və yenidən cəhd edin.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Təklif əlçatan deyil</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play hal-hazırda bu yüksəltmə seçənəyini təklif etmir. Xahiş edirik bir az sonra yenidən cəhd edin və ya Google Play Store-u yoxlayın.</string>
 </resources>

--- a/app/src/gplay/res/values-be/strings.xml
+++ b/app/src/gplay/res/values-be/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">Ужо куплена</string>
     <string name="upgrades_gplay_already_owned_error">Google Play паведамляе, што вы ўжо валодаеце гэтым абнаўленнем, але яго не ўдалося аднавіць. Праверце, што вы ўвайшлі ў акаўнт Google, выкарыстаны для арыгінальнай пакупкі, а затым паспрабуйце «Аднавіць пакупку».</string>
     <string name="upgrade_screen_preamble">Permission Pilot не мае рэкламы і паважае вашу прыватнасць. Абнаўленне падтрымлівае далейшую распрацоўку.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Цаны недаступныя</string>
+    <string name="upgrade_screen_offers_unavailable_message">Цаны не змаглі загрузіцца зараз. Праверце Google Play і паспрабуйце пазней.</string>
     <string name="upgrade_screen_subscription_trial_action">Пачаць бясплатны пробны перыяд</string>
     <string name="upgrade_screen_subscription_action">Падпісацца</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/год, можна скасаваць у любы час</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Некалькі акаўнтаў могуць заблытаць Google Play. Усталяванне праграмы праз вэб-сайт Google Play прывязвае яе да пэўнага акаўнта.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Сінхранізацыя Google Play можа заняць пэўны час. Паспрабуйце перазагрузіцца, ачысціць кэш Google Play Store або проста пачакаць.</string>
     <string name="upgrade_screen_restore_contact_hint">Усё яшчэ не атрымліваецца? Звяжыцеся з падтрымкай з электроннай пошты, якую выкарыстоўвалі для пакупкі, і ўкажыце нумар замовы Google Play.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Атрымаць %1$s</string>
+    <string name="upgrade_screen_benefits_title">Перавагі абнаўлення</string>
+    <string name="upgrade_screen_thanks_toast">Вы найлепшы! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro па-ранейшаму актыўны. Чакаем пацвярджэння Google Play вашай пакупкі, усе функцыі Pro застаюцца разблакіраванымі.</string>
+    <string name="upgrade_screen_restore_body">Аднаўленне просіць Google Play яшчэ раз праверыць пакупкі гэтай праграмы для цяперашняга ўліковага запісу. Гэта не пачынае новую пакупку.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Праверка Google Play не паспела завершыцца, таму статус вашай пакупкі ўсё яшчэ невядомы. Нічога не змянілася ў вашым уліковым запісе.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot не можа падключыцца да Google Play. Ці ўсталяваны і абноўлены Google Play? Вы ўвайшлі ў свой уліковы запіс Google? Паспрабуйце ачысціць кэш праграмы Google Play і перазагрузіць прыладу.</string>
+    <string name="upgrades_gplay_billing_error_label">Праблема з Google Play</string>
+    <string name="upgrades_gplay_billing_error_description">Узнікла праблема з Google Play. Паўтарыце спробу пазней або перазагрузіце прыладу.\n\nПадрабязнасці: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Памылка Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Адбылася ўнутраная памылка Google Play. Паспрабуйце наступнае:\n\n• Перазагрузіце вашу прыладу\n• Ачысціце кэш Google Play Store\n• Паспрабуйце пазней</string>
+    <string name="upgrades_gplay_network_error_title">Памылка падключэння</string>
+    <string name="upgrades_gplay_network_error_description">Не атрымалася падключыцца да Google Play. Праверце ваша інтэрнэт-злучэнне і паспрабуйце яшчэ раз.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Прапанова недаступна</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play зараз не прапаноўвае гэты варыянт абнаўлення. Паспрабуйце яшчэ раз пазней ці праверце Google Play Store.</string>
 </resources>

--- a/app/src/gplay/res/values-bg/strings.xml
+++ b/app/src/gplay/res/values-bg/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">Вече закупено</string>
     <string name="upgrades_gplay_already_owned_error">Google Play съобщава, че вече притежавате това обновление, но то не можа да бъде възстановено. Проверете дали сте влезли с Google акаунта, използван за първоначалната покупка, след което опитайте „Възстановяване на покупката“.</string>
     <string name="upgrade_screen_preamble">Permission Pilot е без реклами и защитава поверителността ви. Надградата подкрепя понататашното развитие.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Цените не са налични</string>
+    <string name="upgrade_screen_offers_unavailable_message">Цените не могат да бъдат заредени сега. Проверете Google Play и опитайте отново след малко.</string>
     <string name="upgrade_screen_subscription_trial_action">Стартирайте безплатен пробен период</string>
     <string name="upgrade_screen_subscription_action">Абонирайте се</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/година, анулиране по всяко време</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Множествените акаунти могат да объркат Google Play. Инсталирането на приложението чрез уебсайта на Google Play го принуждава да се асоциира с конкретен акаунт.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Синхронизацията на Google Play може да отнеме време. Опитайте рестартиране, изчистване на кеша на Google Play Store или просто изчакане.</string>
     <string name="upgrade_screen_restore_contact_hint">Все още закъсали? Свържете се с поддръжката от имейла, с който е направена покупката, и посочете номера на поръчката си в Google Play.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Вземи %1$s</string>
+    <string name="upgrade_screen_benefits_title">Предимства на надстройката</string>
+    <string name="upgrade_screen_thanks_toast">Вие сте най-добрите! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro е все още активен. Чакаме Google Play да потвърди отново вашата покупка, всички Pro функции остават отключени дотогава.</string>
+    <string name="upgrade_screen_restore_body">Възстановяването моли Google Play да провери отново покупките на това приложение за текущия акаунт. Не стартира нова покупка.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Проверката с Google Play не завърши навреме, затова състоянието на вашата покупка остава неизвестно. Нищо не се е променило по вашия акаунт.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot не може да се свърже с Google Play. Инсталиран ли е Google Play и актуален ли е? Влязъл ли е вашият Google акаунт? Опитайте да изчистите кеша на приложението Google Play и да рестартирате устройството си.</string>
+    <string name="upgrades_gplay_billing_error_label">Проблем с Google Play</string>
+    <string name="upgrades_gplay_billing_error_description">Възникна проблем с Google Play. Опитайте отново по-късно или рестартирайте устройството си.\n\nПодробности: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Грешка на Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Възникна вътрешна грешка на Google Play. Моля, опитайте следното:\n\n• Рестартирайте устройството си\n• Изчистете кеша на Google Play Store\n• Опитайте отново по-късно</string>
+    <string name="upgrades_gplay_network_error_title">Грешка при свързване</string>
+    <string name="upgrades_gplay_network_error_description">Невъзможно е да се свържете с Google Play. Проверете вашата интернет връзка и опитайте отново.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Офертата не е налична</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play в момента не предлага тази опция за надстройка. Опитайте отново по-късно или проверете Google Play Store.</string>
 </resources>

--- a/app/src/gplay/res/values-bn-rBD/strings.xml
+++ b/app/src/gplay/res/values-bn-rBD/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">ইতিমধ্যে ক্রয় করা হয়েছে</string>
     <string name="upgrades_gplay_already_owned_error">গুগল প্লে রিপোর্ট করে যে আপনি ইতিমধ্যে এই আপগ্রেডের মালিক, কিন্তু এটি পুনরুদ্ধার করা যায়নি। যাচাই করুন যে আপনি মূল ক্রয়ের জন্য ব্যবহৃত গুগল অ্যাকাউন্টে সাইন ইন করেছেন, তারপর \"ক্রয় পুনরুদ্ধার করুন\" চেষ্টা করুন।</string>
     <string name="upgrade_screen_preamble">Permission Pilot বিজ্ঞাপনমুক্ত এবং আপনার গোপনীয়তাকে সম্মান করে। আপগ্রেড করা চলমান ডিভেলপমেন্টকে সমর্থন করে।</string>
+    <string name="upgrade_screen_offers_unavailable_title">মূল্য উপলব্ধ নয়</string>
+    <string name="upgrade_screen_offers_unavailable_message">মূল্য এখন লোড করা যায়নি। Google Play চেক করুন এবং একটু পরে আবার চেষ্টা করুন।</string>
     <string name="upgrade_screen_subscription_trial_action">বিনামূল্যের ট্রায়াল শুরু করুন</string>
     <string name="upgrade_screen_subscription_action">সাবস্ক্রাইব করুন</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/বছর, যেকোনো সময় বাতিল করুন</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">একাধিক অ্যাকাউন্ট গুগল প্লেকে বিভ্রান্ত করতে পারে। গুগল প্লে ওয়েবসাইটের মাধ্যমে অ্যাপটি ইনস্টল করা এটিকে একটি নির্দিষ্ট অ্যাকাউন্টের সাথে যুক্ত করতে বাধ্য করে।</string>
     <string name="upgrade_screen_restore_sync_patience_hint">গুগল প্লে সিঙ্ক্রোনাইজেশন কিছু সময় লাগতে পারে। পুনরায় বুট করার চেষ্টা করুন, গুগল প্লে স্টোর ক্যাশ পরিষ্কার করুন, অথবা শুধুমাত্র অপেক্ষা করুন।</string>
     <string name="upgrade_screen_restore_contact_hint">এখনও আটকে আছেন? ক্রয় করা ইমেল থেকে সহায়তার যোগাযোগ করুন এবং আপনার গুগল প্লে অর্ডার নম্বর অন্তর্ভুক্ত করুন।</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">%1$s পান</string>
+    <string name="upgrade_screen_benefits_title">আপগ্রেড সুবিধা</string>
+    <string name="upgrade_screen_thanks_toast">আপনি সেরা! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro এখনও সক্রিয়। Google Play আপনার ক্রয় পুনরায় নিশ্চিত করার জন্য অপেক্ষা করছে, এই মধ্যে সমস্ত Pro বৈশিষ্ট্য আনলক থাকবে।</string>
+    <string name="upgrade_screen_restore_body">পুনরুদ্ধার করলে Google Play কে বর্তমান অ্যাকাউন্টের জন্য এই অ্যাপের ক্রয় পুনরায় পরীক্ষা করার জন্য অনুরোধ করা হয়। এটি নতুন ক্রয় শুরু করে না।</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Google Play এর সাথে পরীক্ষা সময়মতো শেষ হয়নি, তাই আপনার ক্রয় স্থিতি এখনও অজানা। আপনার অ্যাকাউন্টে কিছুই পরিবর্তন হয়নি।</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot Google Play এর সাথে সংযোগ করতে পারছে না। Google Play কি ইনস্টল এবং আপ টু ডেট? আপনার Google অ্যাকাউন্ট লগ ইন আছে? Google Play অ্যাপের ক্যাশ সাফ করে এবং আপনার ডিভাইস রিবুট করে চেষ্টা করুন।</string>
+    <string name="upgrades_gplay_billing_error_label">গুগল প্লে সমস্যা</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play তে সমস্যা হয়েছে। অনুগ্রহ করে পরে আবার চেষ্টা করুন অথবা আপনার ডিভাইসটি পুনরায় চালু করুন।\n\nবিস্তারিত: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play ত্রুটি</string>
+    <string name="upgrades_gplay_internal_error_description">একটি অভ্যন্তরীণ Google Play ত্রুটি ঘটেছে। অনুগ্রহ করে নিম্নলিখিত চেষ্টা করুন:\n\n• আপনার ডিভাইস পুনরায় চালু করুন\n• Google Play Store ক্যাশ সাফ করুন\n• পরে আবার চেষ্টা করুন</string>
+    <string name="upgrades_gplay_network_error_title">সংযোগ ত্রুটি</string>
+    <string name="upgrades_gplay_network_error_description">Google Play এ সংযোগ করতে অক্ষম। অনুগ্রহ করে আপনার ইন্টারনেট সংযোগ পরীক্ষা করুন এবং আবার চেষ্টা করুন।</string>
+    <string name="upgrades_gplay_offer_unavailable_title">অফার উপলব্ধ নয়</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play বর্তমানে এই আপগ্রেড বিকল্প অফার করছে না। অনুগ্রহ করে পরে আবার চেষ্টা করুন বা Google Play Store পরীক্ষা করুন।</string>
 </resources>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">Ja ho heu comprat</string>
     <string name="upgrades_gplay_already_owned_error">El Google Play indica que ja teniu aquesta actualització, però no s\'ha pogut restaurar. Comproveu que heu iniciat sessió amb el compte de Google que vau utilitzar per a la compra original i proveu «Restaura la compra».</string>
     <string name="upgrade_screen_preamble">El Permission Pilot no té anuncis i respecta la teva privadesa. L\'actualització permet el desenvolupament continu.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Preus no disponibles</string>
+    <string name="upgrade_screen_offers_unavailable_message">No s\'han pogut carregar els preus ara mateix. Consulteu el Google Play i torneu-ho a provar en uns moments.</string>
     <string name="upgrade_screen_subscription_trial_action">Inicia la prova gratuïta</string>
     <string name="upgrade_screen_subscription_action">Subscripció</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/any, cancel·leu en qualsevol moment</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Tenir diversos comptes pot generar confusió al Google Play. La instal·lació de l\'aplicació a través del lloc web del Google Play obliga a associar-lo amb un compte específic.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">La sincronització del Google Play pot trigar una estona. Proveu de reiniciar, esborreu la memòria cau del Google Play o simplement espereu.</string>
     <string name="upgrade_screen_restore_contact_hint">Encara teniu problemes? Contacteu amb l\'assistència des del correu amb què heu fet la compra i incloeu el número de comanda del Google Play.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Obtingueu %1$s</string>
+    <string name="upgrade_screen_benefits_title">Beneficis de la millora</string>
+    <string name="upgrade_screen_thanks_toast">Sou el millor! \ufe0f</string>
+    <string name="upgrade_screen_grace_body_short">El Pro encara està actiu. Mentrestant, estem esperant que el Google Play torni a confirmar la compra; totes les funcions Pro romandran desbloquejades.</string>
+    <string name="upgrade_screen_restore_body">La restauració sol·licita al Google Play que comprovi de nou les compres d\'aquesta aplicació per al compte actual. No inicia cap compra nova.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">La comprovació amb el Google Play no ha acabat a temps, així que l\'estat de la vostra compra segueix sent desconegut. Res ha canviat al vostre compte.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">El Permission Pilot no es pot connectar al Google Play. El Google Play està instal·lat i actualitzat? Heu iniciat la sessió al vostre compte de Google? Proveu d\'esborrar la memòria cau de l\'aplicació Google Play i reinicieu el dispositiu.</string>
+    <string name="upgrades_gplay_billing_error_label">Problema del Google Play</string>
+    <string name="upgrades_gplay_billing_error_description">S\'ha produït un problema amb el Google Play. Torneu-ho a provar més tard o reinicieu el dispositiu.\n\nDetalls: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Error del Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">S\'ha produït un error intern del Google Play. Proveu el següent:\n\n\u2022 Reinicieu el dispositiu\n\u2022 Esborreu la memòria cau del Google Play Store\n\u2022 Torneu-ho a provar més tard</string>
+    <string name="upgrades_gplay_network_error_title">Error de connexió</string>
+    <string name="upgrades_gplay_network_error_description">No es pot connectar al Google Play. Comproveu la connexió a Internet i torneu-ho a provar.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Oferta no disponible</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Actualment, el Google Play no ofereix aquesta opció d\'actualització. Torneu-ho a provar més tard o consulteu el Google Play Store.</string>
 </resources>

--- a/app/src/gplay/res/values-cs/strings.xml
+++ b/app/src/gplay/res/values-cs/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">Již zakoupeno</string>
     <string name="upgrades_gplay_already_owned_error">Služba Google Play hlásí, že již máte tento upgrade, ale nelze jej obnovit. Zkontrolujte, zda jste přihlášeni pomocí účtu Google, který jste použili pro původní nákup, a poté zkuste „Obnovit nákup“.</string>
     <string name="upgrade_screen_preamble">Permission Pilot je bez reklam a respektuje vaše soukromí. Upgrade podporuje další vývoj.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Ceny nejsou dostupné</string>
+    <string name="upgrade_screen_offers_unavailable_message">Ceny se momentálně nepodařilo načíst. Podívejte se na Google Play a zkuste to za chvíli znovu.</string>
     <string name="upgrade_screen_subscription_trial_action">Spustit zkušební verzi</string>
     <string name="upgrade_screen_subscription_action">Předplatit</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/rok, zrušit kdykoliv</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Více účtů může zmást Google Play. Instalace aplikace přes webové stránky Google Play vynucuje její přidružení ke konkrétnímu účtu.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Synchronizace Obchodu Play může chvíli trvat. Zkuste restartovat, vymazat mezipaměť Google Play nebo prostě počkat.</string>
     <string name="upgrade_screen_restore_contact_hint">Stále máte problém? Kontaktujte podporu z e-mailu, který provedl nákup, a připojte vaše číslo objednávky Google Play.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Získat %1$s</string>
+    <string name="upgrade_screen_benefits_title">Výhody upgradu</string>
+    <string name="upgrade_screen_thanks_toast">Jste nejlepší! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro je stále aktivní. Čekám na Google Play, aby znovu potvrdil váš nákup, všechny funkce Pro zůstávají mezitím odemčeny.</string>
+    <string name="upgrade_screen_restore_body">Obnovení požádá Google Play, aby znovu zkontroloval nákupy této aplikace pro aktuální účet. Nezačíná nový nákup.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Kontrola s Obchodem Google Play nebyla dokončena včas, takže stav nákupu zůstává neznámý. Na vašem účtu se nic nezměnilo.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot se nemůže připojit k Obchodu Google Play. Je Obchod Google Play nainstalován a aktualizován? Jste přihlášeni k účtu Google? Zkuste vymazat mezipaměť Obchodu Google Play a restartovat zařízení.</string>
+    <string name="upgrades_gplay_billing_error_label">Problém s Google Play</string>
+    <string name="upgrades_gplay_billing_error_description">Došlo k problému s Google Play. Zkuste to prosím znovu později nebo restartujte zařízení.\n\nPodrobnosti: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Chyba Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Došlo k interní chybě Google Play. Zkuste následující kroky:\n\n• Restartujte zařízení\n• Vyčistěte mezipaměť obchodu Google Play\n• Zkuste to znovu později</string>
+    <string name="upgrades_gplay_network_error_title">Chyba připojení</string>
+    <string name="upgrades_gplay_network_error_description">Nelze se připojit k Google Play. Zkontrolujte připojení k internetu a zkuste to znovu.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Nabídka není dostupná</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Obchod Google Play momentálně nenabízí tuto možnost upgradu. Zkuste to prosím později nebo zkontrolujte Obchod Google Play.</string>
 </resources>

--- a/app/src/gplay/res/values-da/strings.xml
+++ b/app/src/gplay/res/values-da/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">Allerede købt</string>
     <string name="upgrades_gplay_already_owned_error">Google Play rapporterer, at du allerede ejer denne opgradering, men den kunne ikke gendannes. Kontroller, at du er logget ind med den Google-konto, der blev brugt til det oprindelige køb, og prøv derefter \"Gendan køb\".</string>
     <string name="upgrade_screen_preamble">Permission Pilot er reklamefri og respekterer dit privatliv. Opgradering støtter fortsat udvikling.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Priser ikke tilgængelige</string>
+    <string name="upgrade_screen_offers_unavailable_message">Priserne kunne ikke indlæses lige nu. Kontroller Google Play og prøv igen om lidt.</string>
     <string name="upgrade_screen_subscription_trial_action">Start gratis prøveperiode</string>
     <string name="upgrade_screen_subscription_action">Abonner</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/år, annuller når som helst</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Flere konti kan forvirre Google Play. Installation af appen via Google Play-hjemmesiden fremtvinger tilknytning til en bestemt konto.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Google Play-synkronisering kan tage tid. Prøv at genstarte, rydde Google Play Store-cachen eller bare vent.</string>
     <string name="upgrade_screen_restore_contact_hint">Stadig fast? Kontakt support fra den e-mail, der foretog købet, og inkluder dit Google Play-ordrenummer.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Få %1$s</string>
+    <string name="upgrade_screen_benefits_title">Opgraderingsfordele</string>
+    <string name="upgrade_screen_thanks_toast">Du er den bedste! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro er stadig aktiv. Venter på, at Google Play bekræfter dit køb igen, alle Pro-funktioner forbliver låst op i mellemtiden.</string>
+    <string name="upgrade_screen_restore_body">Gendannelse beder Google Play om at kontrollere dette apps køb for den aktuelle konto igen. Det starter ikke et nyt køb.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Kontrollen med Google Play blev ikke færdig i tide, så din købsstatus er stadig ukendt. Intet er ændret på din konto.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot kan ikke forbinde til Google Play. Er Google Play installeret og opdateret? Er din Google-konto logget ind? Prøv at rydde cachen i Google Play-appen og genstarte din enhed.</string>
+    <string name="upgrades_gplay_billing_error_label">Google Play Problem</string>
+    <string name="upgrades_gplay_billing_error_description">Der opstod et problem med Google Play. Prøv igen senere eller genstart din enhed.\n\nDetaljer: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play-fejl</string>
+    <string name="upgrades_gplay_internal_error_description">Internt Google Play-fejl opstod. Prøv venligst følgende:\n\n• Genstart din enhed\n• Ryd Google Play Store-cachen\n• Prøv igen senere</string>
+    <string name="upgrades_gplay_network_error_title">Forbindelsesfejl</string>
+    <string name="upgrades_gplay_network_error_description">Kan ikke forbinde til Google Play. Kontroller din internetforbindelse og prøv igen.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Tilbud ikke tilgængeligt</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play tilbyder ikke aktuelt denne opgraderingsmulighed. Prøv igen senere eller kontroller Google Play Store.</string>
 </resources>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">Bereits gekauft</string>
     <string name="upgrades_gplay_already_owned_error">Google Play meldet, dass Sie dieses Upgrade bereits besitzen, es konnte jedoch nicht wiederhergestellt werden. Stellen Sie sicher, dass Sie mit dem Google-Konto angemeldet sind, das für den ursprünglichen Kauf verwendet wurde, und versuchen Sie dann, den Kauf wiederherzustellen.</string>
     <string name="upgrade_screen_preamble">Permission Pilot ist werbefrei und respektiert deine Privatsphäre. Ein Upgrade unterstützt die weitere Entwicklung.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Preise nicht verfügbar</string>
+    <string name="upgrade_screen_offers_unavailable_message">Die Preise konnten gerade nicht geladen werden. Überprüfe Google Play und versuche es gleich noch einmal.</string>
     <string name="upgrade_screen_subscription_trial_action">Kostenlos testen</string>
     <string name="upgrade_screen_subscription_action">Abonnieren</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/Jahr, jederzeit kündbar</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Mehrere Konten können Google Play durcheinanderbringen. Die Installation der App über die Google Play-Website erzwingt die Zuordnung zu einem bestimmten Konto.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Die Google Play-Synchronisierung kann eine Weile dauern. Versuchen Sie, das Gerät neu zu starten, den Google Play Store-Cache zu löschen oder einfach zu warten.</string>
     <string name="upgrade_screen_restore_contact_hint">Immer noch nicht weiter? Kontaktiere den Support von der E-Mail-Adresse aus, mit der der Kauf getätigt wurde, und gib deine Google-Play-Bestellnummer an.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Hol dir %1$s</string>
+    <string name="upgrade_screen_benefits_title">Vorteile des Upgrades</string>
+    <string name="upgrade_screen_thanks_toast">Du bist der Beste! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro ist weiterhin aktiv. Es wird darauf gewartet, dass Google Play deinen Kauf erneut bestätigt. Alle Pro-Funktionen bleiben in der Zwischenzeit freigeschaltet.</string>
+    <string name="upgrade_screen_restore_body">Das Wiederherstellen veranlasst Google Play dazu, die Käufe dieser App für das aktuelle Konto erneut zu überprüfen. Dadurch wird kein neuer Kauf gestartet.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Die Überprüfung mit Google Play wurde nicht rechtzeitig abgeschlossen, daher ist dein Kaufstatus weiterhin unbekannt. An deinem Konto wurde nichts geändert.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot kann keine Verbindung zu Google Play herstellen. Ist Google Play installiert und auf dem neuesten Stand? Bist du mit deinem Google-Konto angemeldet? Versuche, den Cache der Google Play-App zu leeren und dein Gerät neu zu starten.</string>
+    <string name="upgrades_gplay_billing_error_label">Google Play Problem</string>
+    <string name="upgrades_gplay_billing_error_description">Es gab ein Problem mit Google Play. Bitte versuche es später erneut oder starte dein Gerät neu.\n\nDetails: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play Fehler</string>
+    <string name="upgrades_gplay_internal_error_description">Ein interner Fehler bei Google Play ist aufgetreten. Bitte versuche Folgendes:\n\n• Starte dein Gerät neu\n• Leere den Cache des Google Play Stores\n• Versuche es später erneut</string>
+    <string name="upgrades_gplay_network_error_title">Verbindungsfehler</string>
+    <string name="upgrades_gplay_network_error_description">Verbindung zu Google Play nicht möglich. Bitte überprüfe Deine Internetverbindung und versuche es erneut.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Angebot nicht verfügbar</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play bietet diese Upgrade-Option derzeit nicht an. Bitte versuche es später noch einmal oder überprüfe den Google Play Store.</string>
 </resources>

--- a/app/src/gplay/res/values-el/strings.xml
+++ b/app/src/gplay/res/values-el/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">Ήδη αγορασμένο</string>
     <string name="upgrades_gplay_already_owned_error">Το Google Play αναφέρει ότι έχετε ήδη αυτήν την αναβάθμιση, αλλά δεν ήταν δυνατό να επαναφερθεί. Βεβαιωθείτε ότι είστε συνδεδεμένοι με τον λογαριασμό Google που χρησιμοποιήθηκε για την αρχική αγορά, στη συνέχεια δοκιμάστε «Επαναφορά αγοράς».</string>
     <string name="upgrade_screen_preamble">Το Permission Pilot είναι χωρίς διαφημίσεις και σέβεται την ιδιωτικότητά σας. Η αναβάθμιση υποστηρίζει τη συνεχή ανάπτυξη.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Τιμές μη διαθέσιμες</string>
+    <string name="upgrade_screen_offers_unavailable_message">Οι τιμές δεν μπορούσαν να φορτωθούν αυτή τη στιγμή. Ελέγξτε το Google Play και δοκιμάστε ξανά σε λίγο.</string>
     <string name="upgrade_screen_subscription_trial_action">Έναρξη δωρεάν δοκιμής</string>
     <string name="upgrade_screen_subscription_action">Εγγραφή</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/χρόνο, ακύρωση ανά πάσα στιγμή</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Πολλοί λογαριασμοί μπορεί να μπερδέψουν το Google Play. Η εγκατάσταση της εφαρμογής μέσω του ιστοτόπου Google Play την αναγκάζει να συσχετίζεται με έναν συγκεκριμένο λογαριασμό.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Ο συγχρονισμός του Google Play ενδέχεται να πάρει χρόνο. Δοκιμάστε να κάνετε επανεκκίνηση, να καθαρίσετε την προσωρινή μνήμη του Google Play Store ή απλώς να περιμένετε.</string>
     <string name="upgrade_screen_restore_contact_hint">Ακόμα κολλημένοι; Επικοινωνήστε με την υποστήριξη από το email που έκανε την αγορά και συμπεριλάβετε τον αριθμό παραγγελίας του Google Play.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Αποκτήστε %1$s</string>
+    <string name="upgrade_screen_benefits_title">Πλεονεκτήματα αναβάθμισης</string>
+    <string name="upgrade_screen_thanks_toast">Είστε οι καλύτεροι! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Το Pro είναι ακόμα ενεργό. Αναμονή ώστε το Google Play να επιβεβαιώσει ξανά την αγορά σας, όλες οι δυνατότητες Pro παραμένουν ξεκλείδωτες προς το παρόν.</string>
+    <string name="upgrade_screen_restore_body">Η επαναφορά ζητά από το Google Play να ελέγξει ξανά τις αγορές αυτής της εφαρμογής για τον τρέχοντα λογαριασμό. Δεν ξεκινά νέα αγορά.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Ο έλεγχος με το Google Play δεν ολοκληρώθηκε εγκαίρως, οπότε η κατάσταση αγοράς σας είναι ακόμα άγνωστη. Τίποτα δεν έχει αλλάξει στο λογαριασμό σας.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Η εφαρμογή Permission Pilot δεν μπορεί να συνδεθεί με το Google Play. Είναι εγκατεστημένο και ενημερωμένο το Google Play; Είναι συνδεδεμένος ο λογαριασμός σας Google; Δοκιμάστε να καθαρίσετε την προσωρινή μνήμη cache της εφαρμογής Google Play και να επανεκκινήσετε τη συσκευή σας.</string>
+    <string name="upgrades_gplay_billing_error_label">Πρόβλημα Google Play</string>
+    <string name="upgrades_gplay_billing_error_description">Παρουσιάστηκε κάποιο πρόβλημα με το Google Play. Δοκιμάστε ξανά αργότερα ή επανεκκινήστε τη συσκευή σας.\n\nΛεπτομέρειες: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Σφάλμα Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Παρουσιάστηκε εσωτερικό σφάλμα του Google Play. Δοκιμάστε τα εξής:\n\n• Επανεκκινήστε τη συσκευή σας\n• Καθαρίστε την προσωρινή μνήμη του Google Play Store\n• Δοκιμάστε ξανά αργότερα</string>
+    <string name="upgrades_gplay_network_error_title">Σφάλμα σύνδεσης</string>
+    <string name="upgrades_gplay_network_error_description">Αδυναμία σύνδεσης με το Google Play. Ελέγξτε τη σύνδεσή σας στο διαδίκτυο και δοκιμάστε ξανά.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Προσφορά μη διαθέσιμη</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Το Google Play δεν προσφέρει αυτή την επιλογή αναβάθμισης αυτή τη στιγμή. Δοκιμάστε ξανά αργότερα ή ελέγξτε το Google Play Store.</string>
 </resources>

--- a/app/src/gplay/res/values-es/strings.xml
+++ b/app/src/gplay/res/values-es/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">Ya adquirido</string>
     <string name="upgrades_gplay_already_owned_error">Google Play reporta que ya tienes esta actualización, pero no se pudo restaurar. Verifica que hayas iniciado sesión con la cuenta de Google utilizada para la compra original y luego intenta «Restaurar compra».</string>
     <string name="upgrade_screen_preamble">Permission Pilot no tiene anuncios y respeta tu privacidad. Actualizar apoya el desarrollo continuo.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Precios no disponibles</string>
+    <string name="upgrade_screen_offers_unavailable_message">Los precios no se pudieron cargar en este momento. Consulta Google Play e intenta de nuevo en un momento.</string>
     <string name="upgrade_screen_subscription_trial_action">Iniciar el período de prueba gratuita</string>
     <string name="upgrade_screen_subscription_action">Suscríbete</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/año, cancela en cualquier momento</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Múltiples cuentas pueden confundir a Google Play. Instalar la aplicación a través del sitio web de Google Play la obliga a asociarse con una cuenta específica.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">La sincronización con Google Play puede tardar un tiempo. Intenta reiniciar, borrar la caché de Google Play Store o simplemente esperar.</string>
     <string name="upgrade_screen_restore_contact_hint">¿Aún atascado? Contacta con soporte desde el correo electrónico que realizó la compra e incluye tu número de pedido de Google Play.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Obtener %1$s</string>
+    <string name="upgrade_screen_benefits_title">Beneficios de la mejora</string>
+    <string name="upgrade_screen_thanks_toast">¡Eres el mejor! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro sigue activo. Esperando que Google Play reconfirme tu compra; todas las funciones Pro permanecen desbloqueadas mientras tanto.</string>
+    <string name="upgrade_screen_restore_body">Restaurar solicita a Google Play que recompruebe las compras de esta aplicación en la cuenta actual. No inicia una nueva compra.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">La comprobación con Google Play no se completó a tiempo, por lo que tu estado de compra sigue siendo desconocido. Nada ha cambiado en tu cuenta.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot no puede conectarse a Google Play. ¿Está Google Play instalado y actualizado? ¿Has iniciado sesión con tu cuenta de Google? Prueba a borrar la caché de la aplicación Google Play y reinicia tu dispositivo.</string>
+    <string name="upgrades_gplay_billing_error_label">Problema con Google Play</string>
+    <string name="upgrades_gplay_billing_error_description">Hubo un problema con la Google Play. Inténtalo de nuevo más tarde o reinicia tu dispositivo.\n\nDetalles: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Error de Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Se produjo un error interno de Google Play. Intenta lo siguiente:\n\n• Reinicia tu dispositivo\n• Borra la caché de Google Play Store\n• Intenta más tarde</string>
+    <string name="upgrades_gplay_network_error_title">Error de conexión</string>
+    <string name="upgrades_gplay_network_error_description">No se puede conectar a Google Play. Comprueba tu conexión a Internet e intenta de nuevo.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Oferta no disponible</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play actualmente no está ofreciendo esta opción de mejora. Intenta de nuevo más tarde o consulta la Google Play Store.</string>
 </resources>

--- a/app/src/gplay/res/values-fi/strings.xml
+++ b/app/src/gplay/res/values-fi/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">Jo ostettu</string>
     <string name="upgrades_gplay_already_owned_error">Google Play ilmoittaa, että omistit jo tämän päivityksen, mutta sitä ei voitu palauttaa. Varmista, että olet kirjautunut Google-tilillä, jolla teit alkuperäisen ostoksen, ja yritä sitten \"Palauta osto\".</string>
     <string name="upgrade_screen_preamble">Permission Pilot on mainokseton ja kunnioittaa yksityisyyttäsi. Päivittäminen tukee jatkuvaa kehitystä.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Hinnat eivät ole saatavilla</string>
+    <string name="upgrade_screen_offers_unavailable_message">Hintoja ei voitu ladata juuri nyt. Tarkista Google Play ja yritä uudelleen hetken kuluttua.</string>
     <string name="upgrade_screen_subscription_trial_action">Aloita ilmainen kokeilu</string>
     <string name="upgrade_screen_subscription_action">Tilaa</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/vuosi, voit peruuttaa milloin tahansa</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Useat tilit voivat hämmentää Google Playta. Sovelluksen asentaminen Google Play -verkkosivuston kautta pakottaa sen liittymään tiettyyn tiliin.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Google Play -synkronointi voi kestää. Kokeile uudelleenkäynnistystä, Google Play -välimuistin tyhjentämistä tai vain odottamista.</string>
     <string name="upgrade_screen_restore_contact_hint">Oletko vielä jumissa? Ota yhteyttä tukeen sähköpostista, jolla ostoksesi tehtiin, ja sisällytä Google Play -tilausnumerosi.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Hanki %1$s</string>
+    <string name="upgrade_screen_benefits_title">Päivityksen edut</string>
+    <string name="upgrade_screen_thanks_toast">Olet paras! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro on edelleen aktiivinen. Odotetaan Google Playn uudelleenvahvistusta ostoksellesi, kaikki Pro-ominaisuudet pysyvät lukitukselta vapaina väliajalla.</string>
+    <string name="upgrade_screen_restore_body">Palauttaminen pyytää Google Playta tarkistamaan uudelleen tämän sovelluksen ostokset nykyiselle tilille. Se ei aloita uutta ostoa.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Google Play -tarkistus ei valmistunut ajoissa, joten ostotilastasi on edelleen tuntematon. Tilillä ei ole muuttunut mitään.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot ei voi yhdistää Google Playhin. Onko Google Play asennettu ja ajan tasalla? Onko Google-tilisi kirjautunut sisään? Kokeile tyhjentää Google Play -sovelluksen välimuisti ja käynnistä laitteesi uudelleen.</string>
+    <string name="upgrades_gplay_billing_error_label">Google Play -vika</string>
+    <string name="upgrades_gplay_billing_error_description">Google Playssa oli ongelma. Yritäthän myöhemmin uudelleen tai käynnistäthän laite uudelleen.\n\nYksityiskohdat: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play -vika</string>
+    <string name="upgrades_gplay_internal_error_description">Sisäinen Google Play -vika ilmeni. Yritä seuraavaa:\n\n• Käynnistä laitteesi uudelleen\n• Tyhjennä Google Play Store -välimuisti\n• Yritä myöhemmin</string>
+    <string name="upgrades_gplay_network_error_title">Yhteysvirhe</string>
+    <string name="upgrades_gplay_network_error_description">Google Playhin ei voida yhdistää. Tarkista internet-yhteytesi ja yritä uudelleen.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Tarjous ei ole saatavilla</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play ei tällä hetkellä tarjoa tätä päivitysvaihtoehtoa. Yritä myöhemmin uudelleen tai tarkista Google Play Store.</string>
 </resources>

--- a/app/src/gplay/res/values-fr/strings.xml
+++ b/app/src/gplay/res/values-fr/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">Déjà acheté</string>
     <string name="upgrades_gplay_already_owned_error">Google Play indique que vous possédez déjà cette mise à niveau, mais elle n’a pas pu être restaurée. Vérifiez que vous êtes connecté au compte Google utilisé pour l’achat initial, puis essayez « Restaurer l’achat ».</string>
     <string name="upgrade_screen_preamble">Permission Pilot est sans publicité et respecte votre vie privée. La mise à niveau soutient le développement continu.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Prix indisponibles</string>
+    <string name="upgrade_screen_offers_unavailable_message">Les prix n\'ont pas pu être chargés pour le moment. Vérifiez Google Play et réessayez dans un instant.</string>
     <string name="upgrade_screen_subscription_trial_action">Commencer l’essai gratuit</string>
     <string name="upgrade_screen_subscription_action">M’abonner</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/an, annulation à tout moment</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Plusieurs comptes peuvent perturber Google Play. Installer l’appli via le site Web de Google Play force son association avec un compte spécifique.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">La synchronisation Google Play peut prendre du temps. Essayez de redémarrer votre appareil, de vider le cache de Google Play Store ou simplement d’attendre.</string>
     <string name="upgrade_screen_restore_contact_hint">Toujours bloqué ? Contactez le support depuis l’adresse e-mail qui a effectué l’achat et incluez votre numéro de commande Google Play.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Obtenir %1$s</string>
+    <string name="upgrade_screen_benefits_title">Avantages de la mise à niveau</string>
+    <string name="upgrade_screen_thanks_toast">Vous êtes formidable ! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro est toujours actif. En attente de confirmation de Google Play pour votre achat, toutes les fonctionnalités Pro restent déverrouillées en attendant.</string>
+    <string name="upgrade_screen_restore_body">La restauration demande à Google Play de revérifier les achats de cette appli pour le compte actuel. Cela ne démarre pas un nouvel achat.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">La vérification avec Google Play n\'a pas pu se terminer à temps, votre statut d\'achat reste donc inconnu. Rien n\'a changé sur votre compte.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot ne peut pas se connecter à Google Play. L\'appli Google Play est-elle installée et à jour ? Votre compte Google est-il connecté ? Essayez de vider le cache de l\'appli Google Play et de redémarrer votre appareil.</string>
+    <string name="upgrades_gplay_billing_error_label">Problème avec Google Play</string>
+    <string name="upgrades_gplay_billing_error_description">Un problème est survenu avec Google Play. Réessayez ultérieurement ou redémarrer votre appareil.\n\nDétails : %s</string>
+    <string name="upgrades_gplay_internal_error_title">Erreur Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Une erreur interne Google Play est survenue. Essayez de :\n\n• Redémarrer votre appareil\n• Vider le cache du magasin Google Play\n• Réessayer plus tard</string>
+    <string name="upgrades_gplay_network_error_title">Erreur de connexion</string>
+    <string name="upgrades_gplay_network_error_description">Impossible de se connecter à Google Play. Vérifiez votre connexion à Internet et réessayez.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Offre indisponible</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play n\'offre pas actuellement cette option de mise à niveau. Réessayez plus tard ou consultez le Google Play Store.</string>
 </resources>

--- a/app/src/gplay/res/values-hi-rIN/strings.xml
+++ b/app/src/gplay/res/values-hi-rIN/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">पहले से खरीदा गया</string>
     <string name="upgrades_gplay_already_owned_error">Google Play की रिपोर्ट है कि आप पहले से इस अपग्रेड के मालिक हैं, लेकिन इसे पुनः स्थापित नहीं किया जा सका। जांचें कि आप मूल खरीद के लिए उपयोग किए गए Google खाते से साइन इन हैं, फिर \"खरीद को पुनः स्थापित करें\" की कोशिश करें।</string>
     <string name="upgrade_screen_preamble">Permission Pilot विज्ञापन-मुक्त है और आपकी गोपनीयता का सम्मान करता है। अपग्रेड करना निरंतर विकास का समर्थन करता है।</string>
+    <string name="upgrade_screen_offers_unavailable_title">कीमतें उपलब्ध नहीं हैं</string>
+    <string name="upgrade_screen_offers_unavailable_message">कीमतें अभी लोड नहीं हो सकीं। Google Play देखें और कुछ समय में फिर से कोशिश करें।</string>
     <string name="upgrade_screen_subscription_trial_action">निशुल्क प्रयोग प्रारंभ करें</string>
     <string name="upgrade_screen_subscription_action">सदस्यता लें</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/वर्ष, कभी भी रद्द करें</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">कई खाते Google Play को भ्रमित कर सकते हैं। Google Play वेबसाइट के माध्यम से ऐप इंस्टॉल करने से यह एक विशिष्ट खाते के साथ जुड़ने के लिए बाध्य होता है।</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Google Play सिंक्रोनाइजेशन में समय लग सकता है। रीबूट करने, Google Play Store कैश साफ़ करने, या बस प्रतीक्षा करने का प्रयास करें।</string>
     <string name="upgrade_screen_restore_contact_hint">अभी भी फंसे हुए हैं? खरीद करने वाले ईमेल से समर्थन से संपर्क करें और अपनी Google Play ऑर्डर संख्या शामिल करें।</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">%1$s प्राप्त करें</string>
+    <string name="upgrade_screen_benefits_title">अपग्रेड लाभ</string>
+    <string name="upgrade_screen_thanks_toast">आप सर्वश्रेष्ठ हैं! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro अभी भी सक्रिय है। Google Play से आपकी खरीदारी की पुष्टि करने की प्रतीक्षा में, इस बीच सभी Pro सुविधाएं अनलॉक रहती हैं।</string>
+    <string name="upgrade_screen_restore_body">पुनर्स्थापन Google Play को इस ऐप की खरीदारी को वर्तमान खाते के लिए दोबारा जांचने के लिए कहता है। यह कोई नई खरीदारी शुरू नहीं करता है।</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Google Play के साथ जांच समय पर पूरी नहीं हुई, इसलिए आपकी खरीदारी की स्थिति अभी भी अज्ञात है। आपके खाते पर कुछ भी नहीं बदला है।</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot Google Play से कनेक्ट नहीं हो सकता। क्या Google Play इंस्टॉल और अप-टू-डेट है? क्या आपका Google खाता लॉग इन है? Google Play ऐप का कैश साफ़ करने और अपने डिवाइस को रीबूट करने का प्रयास करें।</string>
+    <string name="upgrades_gplay_billing_error_label">Google Play समस्या</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play में समस्या थी। कृपया बाद में फिर से कोशिश करें या अपने डिवाइस को पुनः शुरू करें।\n\nविवरण: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play त्रुटि</string>
+    <string name="upgrades_gplay_internal_error_description">एक आंतरिक Google Play त्रुटि हुई। कृपया निम्नलिखित प्रयास करें:\n\n• अपने डिवाइस को पुनः शुरू करें\n• Google Play Store कैश साफ़ करें\n• बाद में फिर से कोशिश करें</string>
+    <string name="upgrades_gplay_network_error_title">कनेक्शन त्रुटि</string>
+    <string name="upgrades_gplay_network_error_description">Google Play से कनेक्ट करने में असमर्थ। कृपया अपना इंटरनेट कनेक्शन जांचें और फिर से कोशिश करें।</string>
+    <string name="upgrades_gplay_offer_unavailable_title">ऑफ़र उपलब्ध नहीं</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play वर्तमान में यह अपग्रेड विकल्प प्रदान नहीं कर रहा है। कृपया बाद में फिर से कोशिश करें या Google Play Store देखें।</string>
 </resources>

--- a/app/src/gplay/res/values-hr/strings.xml
+++ b/app/src/gplay/res/values-hr/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">Već kupljeno</string>
     <string name="upgrades_gplay_already_owned_error">Google Play izvještava da već posjedujete ovu nadogradnju, ali nije mogla biti vraćena. Provjerite jeste li prijavljeni sa Google računom korištenim za izvornu kupnju, pa pokušajte s opcijom \"Vrati kupnju\".</string>
     <string name="upgrade_screen_preamble">Permission Pilot je bez oglasa i poštuje vašu privatnost. Nadogradnjom podržavate daljnji razvoj.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Cijene nisu dostupne</string>
+    <string name="upgrade_screen_offers_unavailable_message">Cijene se ne mogu učitati. Provjerite Google Play i pokušajte ponovno.</string>
     <string name="upgrade_screen_subscription_trial_action">Započnite besplatnu probu</string>
     <string name="upgrade_screen_subscription_action">Pretplatite se</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/godinu, otkaži bilo kada</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Više računa može zbuniti Google Play. Instaliranje aplikacije putem web-mjesta Google Playa prisiljava je da se poveže s određenim računom.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Sinkronizacija Google Playa može potrajati. Pokušajte ponovno pokrenuti, obrisati predmemoriju Google Play Storea ili samo pričekati.</string>
     <string name="upgrade_screen_restore_contact_hint">Još uvijek zapeli? Kontaktirajte podršku s e-pošte koja je izvršila kupnju i uključite broj narudžbe s Google Playa.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Nabavi %1$s</string>
+    <string name="upgrade_screen_benefits_title">Prednosti nadogradnje</string>
+    <string name="upgrade_screen_thanks_toast">Najbolji ste! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro je i dalje aktivan. Google Play ponovno potvrđuje vašu kupnju, sve Pro značajke ostaju otključane u međuvremenu.</string>
+    <string name="upgrade_screen_restore_body">Vraćanje traži od Google Playa da ponovno provjeri kupnje ove aplikacije za trenutni račun. Nema nove kupnje.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Provjera s Google Playem nije završena na vrijeme, pa je status vaše kupnje i dalje nepoznat. Ništa se nije promijenilo na vašem računu.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot se ne može povezati s Google Playem. Je li Google Play instaliran i ažuriran? Jeste li prijavljeni na svoj Google račun? Pokušajte očistiti predmemoriju Google Play aplikacije i ponovno pokrenuti uređaj.</string>
+    <string name="upgrades_gplay_billing_error_label">Greška Google Playa</string>
+    <string name="upgrades_gplay_billing_error_description">Došlo je do problema s Google Playom. Pokušajte ponovno kasnije ili ponovno pokrenite uređaj.\n\nDetalji: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Greška Google Playa</string>
+    <string name="upgrades_gplay_internal_error_description">Došlo je do interne greške Google Playa. Pokušajte sljedeće:\n\n• Ponovno pokrenite uređaj\n• Očistite predmemoriju Google Play trgovine\n• Pokušajte ponovno kasnije</string>
+    <string name="upgrades_gplay_network_error_title">Greška veze</string>
+    <string name="upgrades_gplay_network_error_description">Nije moguće povezati se s Google Playem. Provjerite internetsku vezu i pokušajte ponovno.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Ponuda nije dostupna</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play trenutno ne nudi tu opciju nadogradnje. Pokušajte ponovno kasnije ili provjerite Google Play trgovinu.</string>
 </resources>

--- a/app/src/gplay/res/values-hu/strings.xml
+++ b/app/src/gplay/res/values-hu/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">Már megvásárolt</string>
     <string name="upgrades_gplay_already_owned_error">A Google Play azt jelenti, hogy már rendelkezel ezzel a frissítéssel, de nem sikerült helyreállítani. Ellenőrizd, hogy bejelentkeztél-e azzal a Google-fiókkal, amelyet az eredeti vásárláshoz használtál, majd próbáld meg a \"Vásárlás helyreállítása\" lehetőséget.</string>
     <string name="upgrade_screen_preamble">A Permission Pilot reklámmentes és tiszteletben tartja az adatvédelmed. A frissítés támogatja a további fejlesztést.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Az árak nem érhetők el</string>
+    <string name="upgrade_screen_offers_unavailable_message">Az árak most nem töltöttek be. Ellenőrizd a Google Play-t, és próbálkozz később.</string>
     <string name="upgrade_screen_subscription_trial_action">Ingyenes próba indítása</string>
     <string name="upgrade_screen_subscription_action">Iratkozz fel</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/év, bármikor lemondható</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Több fiók összezavarhatja a Google Play-t. Az alkalmazás Google Play webhelyről történő telepítése azt kényszeríti, hogy egy adott fiókkal társuljon.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">A Google Play szinkronizálása eltarthat egy ideig. Próbálj meg újraindítani, töröld a Google Play Store gyorsítótárát, vagy egyszerűen csak várakozz.</string>
     <string name="upgrade_screen_restore_contact_hint">Még mindig elakadt? Lépj kapcsolatba a támogatással a vásárlást végzett e-mail címről, és add meg a Google Play megrendelési számot.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Szerezd meg a %1$s</string>
+    <string name="upgrade_screen_benefits_title">Frissítés előnyei</string>
+    <string name="upgrade_screen_thanks_toast">Te vagy a legjobb! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">A Pro még aktív. Várakozunk, amíg a Google Play megerősíti a vásárlásod – addig az összes Pro funkció feloldva marad.</string>
+    <string name="upgrade_screen_restore_body">A visszaállítás felkéri a Google Play-t, hogy ellenőrizze az alkalmazás vásárlásait az aktuális fióknál. Nem indít új vásárlást.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Az ellenőrzés a Google Play-vel nem fejeződött be időben, így a vásárlási állapot még mindig ismeretlen. A fiókod nem változott.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">A Permission Pilot nem tud csatlakozni a Google Playhez. Telepített és naprakész a Google Play? Be vagy jelentkezve Google-fiókkal? Próbáld meg törölni a Google Play alkalmazás gyorsítótárát és indítsd újra az eszközt.</string>
+    <string name="upgrades_gplay_billing_error_label">Google Play probléma</string>
+    <string name="upgrades_gplay_billing_error_description">Hiba lépett fel a Google Play-vel. Próbálkozz később, vagy indítsd újra az eszközt.\n\nRészletek: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play hiba</string>
+    <string name="upgrades_gplay_internal_error_description">A Google Play belső hibája felmerült. Próbáld meg az alábbiak közül:\n\n\u2022 Indítsd újra az eszközt\n\u2022 Töröld a Google Play Store gyorsítótárát\n\u2022 Próbálkozz később</string>
+    <string name="upgrades_gplay_network_error_title">Csatlakozási hiba</string>
+    <string name="upgrades_gplay_network_error_description">Nem sikerült csatlakozni a Google Playhez. Ellenőrizd az internetkapcsolatod, és próbálkozz újra.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Az ajánlat nem érhető el</string>
+    <string name="upgrades_gplay_offer_unavailable_description">A Google Play jelenleg nem kínálja ezt a frissítési lehetőséget. Próbálkozz később, vagy ellenőrizd a Google Play Store-t.</string>
 </resources>

--- a/app/src/gplay/res/values-it/strings.xml
+++ b/app/src/gplay/res/values-it/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">Già acquistato</string>
     <string name="upgrades_gplay_already_owned_error">Google Play segnala che possiedi già questo acquisto, ma non è stato possibile ripristinarlo. Verifica che tu sia acceduto con l’account Google utilizzato per l’acquisto originale, quindi prova a «Ripristina acquisto».</string>
     <string name="upgrade_screen_preamble">Permission Pilot è senza pubblicità e rispetta la tua privacy. Aggiornare supporta lo sviluppo continuo.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Prezzi non disponibili</string>
+    <string name="upgrade_screen_offers_unavailable_message">I prezzi non potevano essere caricati adesso. Controlla Google Play e riprova tra un momento.</string>
     <string name="upgrade_screen_subscription_trial_action">Inizia la prova gratuita</string>
     <string name="upgrade_screen_subscription_action">Abbonati</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/anno, annulla in qualsiasi momento</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Account multipli possono confondere Google Play. Installare l’app dal sito di Google Play la costringe ad associarsi a un account specifico.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">La sincronizzazione di Google Play può richiedere un po’. Prova a riavviare, svuota la cache di Google Play Store o aspetta semplicemente.</string>
     <string name="upgrade_screen_restore_contact_hint">Ancora bloccato? Contatta il supporto dall’email che ha effettuato l’acquisto e includi il tuo numero d’ordine di Google Play.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Ottieni %1$s</string>
+    <string name="upgrade_screen_benefits_title">Vantaggi dell\'upgrade</string>
+    <string name="upgrade_screen_thanks_toast">Sei il migliore! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro è ancora attivo. In attesa che Google Play confermi di nuovo il tuo acquisto, tutte le funzioni Pro rimangono sbloccate nel frattempo.</string>
+    <string name="upgrade_screen_restore_body">Ripristinare chiede a Google Play di controllare nuovamente gli acquisti di questa app per l\'account corrente. Non avvia un nuovo acquisto.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Il controllo con Google Play non è terminato in tempo, quindi lo stato del tuo acquisto è ancora sconosciuto. Nulla è cambiato nel tuo account.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot non può connettersi a Google Play. Google Play è installato e aggiornato? Il tuo account Google è connesso? Prova a svuotare la cache dell\'app Google Play e riavviare il dispositivo.</string>
+    <string name="upgrades_gplay_billing_error_label">Problema con Google Play</string>
+    <string name="upgrades_gplay_billing_error_description">Si è verificato un problema con Google Play. Per favore riprova più tardi o riavvia il dispositivo.\n\nDettagli: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Errore di Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Si è verificato un errore interno di Google Play. Prova quanto segue:\n\n• Riavvia il dispositivo\n• Svuota la cache di Google Play Store\n• Riprova più tardi</string>
+    <string name="upgrades_gplay_network_error_title">Errore di connessione</string>
+    <string name="upgrades_gplay_network_error_description">Impossibile connettersi a Google Play. Verifica la tua connessione a Internet e riprova.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Offerta non disponibile</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play attualmente non offre questa opzione di upgrade. Per favore riprova più tardi o controlla il Google Play Store.</string>
 </resources>

--- a/app/src/gplay/res/values-iw/strings.xml
+++ b/app/src/gplay/res/values-iw/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">כבר נקנה</string>
     <string name="upgrades_gplay_already_owned_error">גוגל פליי דיווח שכבר קנית את השדרוג הזה, אך לא ניתן היה להשחזרו. בדוק שאתה מחובר עם חשבון גוגל שנשמש לרכישה המקורית, ולאחר מכן נסה \"השחזר רכישה\".</string>
     <string name="upgrade_screen_preamble">Permission Pilot היא בללי פרסומות ומכבדת את פרטיותך. שדרוג תומך בפיתוח המשך.</string>
+    <string name="upgrade_screen_offers_unavailable_title">מחירים לא זמינים</string>
+    <string name="upgrade_screen_offers_unavailable_message">לא ניתן היה לטעון מחירים כעת. בדוק ב-Google Play ונסה שוב בעוד רגע.</string>
     <string name="upgrade_screen_subscription_trial_action">התחל ניסיון חינם</string>
     <string name="upgrade_screen_subscription_action">הירשם כמנוי</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/שנה, בטל בכל עת</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">מספר חשבונות יכול לגרום לבעיות בגוגל פליי. התקנת האפליקציה דרך אתר גוגל פליי מחייבת אותה להשתייך לחשבון מסוים.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">סנכרון גוגל פליי יכול לקחת זמן. נסה להפעיל מחדש, לנקות את המטמון של חנות גוגל פליי, או פשוט להמתין.</string>
     <string name="upgrade_screen_restore_contact_hint">עדיין תקוע? צור קשר עם התמיכה מהכתובת דוא\"ל שבה בוצעה הרכישה וכלול את מספר ההזמנה של גוגל פליי שלך.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">קבל %1$s</string>
+    <string name="upgrade_screen_benefits_title">יתרונות השדרוג</string>
+    <string name="upgrade_screen_thanks_toast">אתה הכי טוב! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro עדיין פעיל. ממתין ל-Google Play לאישור מחדש של הרכישה שלך, כל תכונות Pro נשארות פתוחות בינתיים.</string>
+    <string name="upgrade_screen_restore_body">שחזור מבקש מ-Google Play לבדוק מחדש את הרכישות של האפליקציה הזו עבור החשבון הנוכחי. זה לא יוצר רכישה חדשה.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">הבדיקה עם Google Play לא הסתיימה בזמן, ולכן סטטוס הרכישה שלך עדיין לא ידוע. שום דבר לא השתנה בחשבונך.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot לא יכול להתחבר ל-Google Play. האם Google Play מותקן ומעודכן? האם חשבון Google שלך מחובר? נסה לנקות את המטמון של אפליקציית Google Play ולאתחל את המכשיר שלך.</string>
+    <string name="upgrades_gplay_billing_error_label">בעיה ב-Google Play</string>
+    <string name="upgrades_gplay_billing_error_description">היתה בעיה עם Google Play. אנא נסה שוב מאוחר יותר או הפעל את המכשיר שלך מחדש.\n\nפרטים: %s</string>
+    <string name="upgrades_gplay_internal_error_title">שגיאת Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">אירעה שגיאה פנימית ב-Google Play. אנא נסה את הפעולות הבאות:\n\n• הפעל את המכשיר שלך מחדש\n• נקה את מטמון Google Play Store\n• נסה שוב מאוחר יותר</string>
+    <string name="upgrades_gplay_network_error_title">שגיאת חיבור</string>
+    <string name="upgrades_gplay_network_error_description">לא ניתן להתחבר ל-Google Play. אנא בדוק את חיבור האינטרנט שלך ונסה שוב.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">ההצעה לא זמינה</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play אינו מציע כעת את אפשרות השדרוג הזו. אנא נסה שוב מאוחר יותר או בדוק את Google Play Store.</string>
 </resources>

--- a/app/src/gplay/res/values-ja/strings.xml
+++ b/app/src/gplay/res/values-ja/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">既に購入済み</string>
     <string name="upgrades_gplay_already_owned_error">Google Play ではこのアップグレードを所有していると報告されていますが、復元できませんでした。元の購入に使用した Google アカウントでサインインしていることを確認してから、「購入を復元」をお試しください。</string>
     <string name="upgrade_screen_preamble">Permission Pilotは広告なしでプライバシーを尊重しています。アップグレードは継続的な開発をサポートします。</string>
+    <string name="upgrade_screen_offers_unavailable_title">価格が利用できません</string>
+    <string name="upgrade_screen_offers_unavailable_message">価格を今すぐ読み込むことができません。Google Playを確認して、しばらくしてからもう一度お試しください。</string>
     <string name="upgrade_screen_subscription_trial_action">試用を開始する</string>
     <string name="upgrade_screen_subscription_action">登録</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/年、いつでもキャンセルできます</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">複数のアカウントは Google Play を混乱させる可能性があります。Google Play ウェブサイトからアプリをインストールすれば、特定のアカウントに関連付けられます。</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Google Play の同期には時間がかかる場合があります。再起動するか、Google Play ストアのキャッシュをクリアするか、しばらく待ってみてください。</string>
     <string name="upgrade_screen_restore_contact_hint">まだお困りですか？購入に使用したメールアドレスからサポートに連絡し、Google Play の注文番号を含めてください。</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">%1$sを取得する</string>
+    <string name="upgrade_screen_benefits_title">アップグレードの利点</string>
+    <string name="upgrade_screen_thanks_toast">あなたは最高です！ ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Proはまだアクティブです。Google Playがあなたの購入を再確認するのを待っています。その間、すべてのPro機能はロック解除されたままです。</string>
+    <string name="upgrade_screen_restore_body">復元するとGoogle Playに現在のアカウントのこのアプリの購入を再確認するよう求めます。新しい購入は開始しません。</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Google Playとのチェックが時間内に完了しなかったため、購入ステータスはまだ不明です。アカウントには何も変更されていません。</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot は Google Play に接続できません。Google Playはインストールされており、最新の状態ですか？ あなたのGoogleアカウントはログインしていますか？ Google Playアプリのキャッシュをクリアしてデバイスを再起動してみてください。</string>
+    <string name="upgrades_gplay_billing_error_label">アプリ内購入の問題</string>
+    <string name="upgrades_gplay_billing_error_description">Google Playで問題が発生しました。後でもう一度試すか、デバイスを再起動してください。\n\n詳細: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play エラー</string>
+    <string name="upgrades_gplay_internal_error_description">Google Play の内部エラーが発生しました。以下をお試しください:\n\n• デバイスを再起動する\n• Google Play ストアのキャッシュをクリアする\n• 後でもう一度試す</string>
+    <string name="upgrades_gplay_network_error_title">接続エラー</string>
+    <string name="upgrades_gplay_network_error_description">Google Play に接続できません。インターネット接続を確認して、もう一度お試しください。</string>
+    <string name="upgrades_gplay_offer_unavailable_title">オファーが利用できません</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play は現在このアップグレード オプションを提供していません。後でもう一度試すか、Google Play ストアを確認してください。</string>
 </resources>

--- a/app/src/gplay/res/values-ko/strings.xml
+++ b/app/src/gplay/res/values-ko/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">이미 구매됨</string>
     <string name="upgrades_gplay_already_owned_error">Google Play에서 이미 이 업그레이드를 소유하고 있다고 표시되지만 복구할 수 없습니다. 원래 구매에 사용한 Google 계정으로 로그인했는지 확인한 후 \'구매 복구\'를 시도하세요.</string>
     <string name="upgrade_screen_preamble">Permission Pilot은 광고가 없고 개인 정보를 존중합니다. 업그레이드는 지속적인 개발을 지원합니다.</string>
+    <string name="upgrade_screen_offers_unavailable_title">가격을 사용할 수 없음</string>
+    <string name="upgrade_screen_offers_unavailable_message">지금은 가격을 불러올 수 없습니다. Google Play를 확인하고 잠시 후 다시 시도해 주세요.</string>
     <string name="upgrade_screen_subscription_trial_action">무료 체험 시작</string>
     <string name="upgrade_screen_subscription_action">구독하기</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/년, 언제든 취소 가능</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">여러 계정이 Google Play를 혼동시킬 수 있습니다. Google Play 웹사이트를 통해 앱을 설치하면 특정 계정과 연결됩니다.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Google Play 동기화는 시간이 걸릴 수 있습니다. 기기를 다시 시작하거나 Google Play 스토어 캐시를 지우거나 잠시 기다려보세요.</string>
     <string name="upgrade_screen_restore_contact_hint">여전히 해결되지 않나요? 구매한 이메일로 지원팀에 문의하고 Google Play 주문 번호를 함께 알려주세요.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">%1$s 얻기</string>
+    <string name="upgrade_screen_benefits_title">업그레이드 혜택</string>
+    <string name="upgrade_screen_thanks_toast">감사합니다! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro가 여전히 활성화되어 있습니다. Google Play에서 구매를 다시 확인하기를 기다리는 중이며, 그 사이에 모든 Pro 기능이 잠금 해제된 상태로 유지됩니다.</string>
+    <string name="upgrade_screen_restore_body">복원은 Google Play에 현재 계정에 대해 이 앱의 구매를 다시 확인하도록 요청합니다. 새로운 구매를 시작하지는 않습니다.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Google Play와의 확인이 시간 내에 완료되지 않아 구매 상태를 여전히 알 수 없습니다. 계정에 변경 사항이 없습니다.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot가 Google Play에 연결할 수 없습니다. Google Play가 설치되어 있고 최신 버전인가요? Google 계정이 로그인되어 있나요? Google Play 앱의 캐시를 지우고 기기를 재부팅해 보세요.</string>
+    <string name="upgrades_gplay_billing_error_label">Google Play 문제</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play에서 문제가 발생했습니다. 나중에 다시 시도하거나 기기를 다시시작 해주세요.\n\n상세정보: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play 오류</string>
+    <string name="upgrades_gplay_internal_error_description">Google Play 내부 오류가 발생했습니다. 다음을 시도해 보세요:\n\n• 기기 재시작\n• Google Play 스토어 캐시 지우기\n• 나중에 다시 시도</string>
+    <string name="upgrades_gplay_network_error_title">연결 오류</string>
+    <string name="upgrades_gplay_network_error_description">Google Play에 연결할 수 없습니다. 인터넷 연결을 확인하고 다시 시도해 주세요.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">오퍼를 사용할 수 없음</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play에서 현재 이 업그레이드 옵션을 제공하지 않습니다. 나중에 다시 시도하거나 Google Play 스토어를 확인해 보세요.</string>
 </resources>

--- a/app/src/gplay/res/values-ku-rTR/strings.xml
+++ b/app/src/gplay/res/values-ku-rTR/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">Jixwe Kirî</string>
     <string name="upgrades_gplay_already_owned_error">Google Play raportê dike ku tu vê bulaşê jixwe di xwe de heye, lê nikare were gerandin. Kontrol bike ku tu bê nava ketî bi hesabê Google ya ku ji bo kirina yekem hatiye bikaranîn, û paşê \"Beşdarkirina Venîştin\" biceribîne.</string>
     <string name="upgrade_screen_preamble">Permission Pilot بێ رێکلامەیە و نھێنیتکەت پھابوو دەکات. بەرزترکردن پشتگیریکردنی گەشەپێکردنی دەوامەیە.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Bihayên ne berdest in</string>
+    <string name="upgrade_screen_offers_unavailable_message">Bihayên îro nikarin barkirin. Google Play kontrol bike û dûv re hewl bide.</string>
     <string name="upgrade_screen_subscription_trial_action">دەستپێککردنی تەستی بەژیوانی</string>
     <string name="upgrade_screen_subscription_action">بوونهەڵبەست</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/sal, hûndirim bê gerd</string>
@@ -61,4 +63,28 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Gelek hesab dikarin Google Play-ê têkev bikin. Stkirina sepê ji rûpela malê ya Google Play bê bicih dike ku ew bi hesabeke diyarkirî re têkilî bibe.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Hemdamîya Google Play dikare demek bigire. Biceribînin ku sîstema nû bikiriş, dîskerê Google Play Store paqij bikiriş, an jî bê derewî sekinê.</string>
     <string name="upgrade_screen_restore_contact_hint">Hîn jî tê êşkirtin? Piştiranê ji e-nameyê ya ku kirînê kiribe bikişîne û jimara fermangeha Google Play-ê ya te cih bikiriş.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">%1$s wergir</string>
+    <string name="upgrade_screen_benefits_title">Sûdên pêşbirkî</string>
+    <string name="upgrade_screen_thanks_toast">Tu ên çêtirîn! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro hîn çalak e. Tê bendewarekirin ku Google Play kirîdanî were pejirandin. Hemû taybetmendiyên Pro ne girtî ne.</string>
+    <string name="upgrade_screen_restore_body">Vegerandine ji Google Play dixwaze ku kirîdanên vê sepanê ji bo hesabê niha were kontrol kirin. Ew kirîdarî nû dest pê nakin.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Kontrola Google Play ne qediya. Status kirîdanê te ne tê zanîn. Tiştek li ser hesaba te ne hat guhertin.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot nikare bi Google Play re peyivîn. Google Play sazkirî û nûce ye? Hesabê Google têketî ye? Cache Google Play paqij bike û cihazê vegerandinê.</string>
+    <string name="upgrades_gplay_billing_error_label">Pirsgirêka Google Play</string>
+    <string name="upgrades_gplay_billing_error_description">Pirsgirêk bi Google Play re derket. Paşê hewl bide an cihazê vegerandinê.
+
+Hûrguş: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Hejmarkirina Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Çalakiya hundirî Google Play derket. Vir hewl bidin:
+
+• Cihazê vegerandinê
+• Cache Google Play paqij bike
+• Paşê hewl bide</string>
+    <string name="upgrades_gplay_network_error_title">Hejmarkirina girêdanê</string>
+    <string name="upgrades_gplay_network_error_description">Nikare bi Google Play re girê bidin. Girêdana internetê kontrol bike û hewl bide.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Peşniyaz ne berdest e</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play niha vê opsiyonê pêşkêş nake. Paşê hewl bide an Google Play Store kontrol bike.</string>
 </resources>

--- a/app/src/gplay/res/values-nb/strings.xml
+++ b/app/src/gplay/res/values-nb/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">Allerede kjøpt</string>
     <string name="upgrades_gplay_already_owned_error">Google Play rapporterer at du allerede eier denne oppgraderingen, men den kunne ikke gjenopprettes. Sjekk at du er logget inn med Google-kontoen som ble brukt for det opprinnelige kjøpet, og prøv deretter \"Gjenopprett kjøp\".</string>
     <string name="upgrade_screen_preamble">Permission Pilot er uten annonser og respekterer ditt personvern. Oppgradering støtter fortsatt utvikling.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Priser ikke tilgjengelige</string>
+    <string name="upgrade_screen_offers_unavailable_message">Prisene kunne ikke lastes inn nå. Sjekk Google Play og prøv igjen om en stund.</string>
     <string name="upgrade_screen_subscription_trial_action">Start gratis prøveperiode</string>
     <string name="upgrade_screen_subscription_action">Abonner</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/år, avbryt når som helst</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Flere kontoer kan forvirre Google Play. Installering av appen gjennom Google Play-nettstedet tvinger appen til å knyttes til en bestemt konto.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Google Play-synkronisering kan ta en stund. Prøv å starte på nytt, tøm Google Play Store-cachen, eller bare vent.</string>
     <string name="upgrade_screen_restore_contact_hint">Fortsatt fast? Kontakt kundestøtte fra e-posten som gjorde kjøpet og ta med ditt Google Play-ordrenummer.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Hent %1$s</string>
+    <string name="upgrade_screen_benefits_title">Oppgraderingsfordeler</string>
+    <string name="upgrade_screen_thanks_toast">Du er den beste! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro er fortsatt aktiv. Venter på at Google Play skal bekrefte kjøpet ditt på nytt, alle Pro-funksjoner forblir aktive inntil videre.</string>
+    <string name="upgrade_screen_restore_body">Gjenoppretting ber Google Play om å sjekke denne appens kjøp på nytt for gjeldende konto. Den starter ikke et nytt kjøp.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Sjekken med Google Play ble ikke ferdig i tide, så kjøpsstatusen din er fortsatt ukjent. Ingenting har endret seg på kontoen din.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot kan ikke koble til Google Play. Er Google Play installert og oppdatert? Er Google-kontoen din logget inn? Prøv å tømme hurtigbufferen til Google Play-appen, og start enheten på nytt.</string>
+    <string name="upgrades_gplay_billing_error_label">Google Play problem</string>
+    <string name="upgrades_gplay_billing_error_description">Det oppstod et problem med Google Play. Prøv igjen senere eller start enheten på nytt.\n\nDetaljer: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play-feil</string>
+    <string name="upgrades_gplay_internal_error_description">En intern Google Play-feil oppstod. Prøv følgende:\n\n• Start enheten på nytt\n• Tøm Google Play Store-hurtigbufferen\n• Prøv igjen senere</string>
+    <string name="upgrades_gplay_network_error_title">Tilkoblingsfeil</string>
+    <string name="upgrades_gplay_network_error_description">Kan ikke koble til Google Play. Sjekk internettforbindelsen og prøv igjen.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Tilbud ikke tilgjengelig</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play tilbyr ikke dette oppgraderingsalternativet for øyeblikket. Prøv igjen senere eller sjekk Google Play Store.</string>
 </resources>

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">Reeds gekocht</string>
     <string name="upgrades_gplay_already_owned_error">Google Play meldt dat je deze upgrade al bezit, maar deze kon niet worden hersteld. Controleer of je bent aangemeld met het Google-account dat voor de oorspronkelijke aankoop werd gebruikt, en probeer vervolgens \'Aankoop herstellen\'.</string>
     <string name="upgrade_screen_preamble">Permission Pilot is advertentievrij en respecteert je privacy. Upgraden ondersteunt verdere ontwikkeling.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Prijzen niet beschikbaar</string>
+    <string name="upgrade_screen_offers_unavailable_message">Prijzen kunnen op dit moment niet worden geladen. Controleer Google Play en probeer het straks opnieuw.</string>
     <string name="upgrade_screen_subscription_trial_action">Start gratis proefperiode</string>
     <string name="upgrade_screen_subscription_action">Abonneren</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/jaar, annuleer op elk moment</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Meerdere accounts kunnen Google Play verwarren. Het installeren van de app via de Google Play-website zorgt ervoor dat deze aan een specifiek account wordt gekoppeld.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Google Play-synchronisatie kan even duren. Probeer opnieuw op te starten, de Google Play Store-cache te wissen of gewoon te wachten.</string>
     <string name="upgrade_screen_restore_contact_hint">Nog steeds vast? Neem contact op met ondersteuning vanuit het e-mailadres waarmee je de aankoop hebt gedaan en voeg je Google Play-ordernummer toe.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Verkrijg %1$s</string>
+    <string name="upgrade_screen_benefits_title">Voordelen van de upgrade</string>
+    <string name="upgrade_screen_thanks_toast">Jij bent de beste! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro is nog steeds actief. Wachten tot Google Play je aankoop opnieuw bevestigt; alle Pro-functies blijven ondertussen ontgrendeld.</string>
+    <string name="upgrade_screen_restore_body">Herstellen vraagt Google Play om de aankopen van deze app voor het huidige account opnieuw te controleren. Het start geen nieuwe aankoop.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">De controle bij Google Play is niet op tijd voltooid, waardoor de status van je aankoop nog steeds onbekend is. Er is niets gewijzigd in je account.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot kan geen verbinding maken met Google Play. Is Google Play geïnstalleerd en up-to-date? Is je Google-account ingelogd? Probeer de cache van de Google Play-app te wissen en je apparaat opnieuw op te starten.</string>
+    <string name="upgrades_gplay_billing_error_label">Google Play Probleem</string>
+    <string name="upgrades_gplay_billing_error_description">Er was een probleem met Google Play. Probeer het later opnieuw of herstart uw apparaat.\n\nDetails: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play-fout</string>
+    <string name="upgrades_gplay_internal_error_description">Er is een interne Google Play-fout opgetreden. Probeer het volgende:\n\n• Herstart je apparaat\n• Wis de cache van de Google Play Store\n• Probeer het later opnieuw</string>
+    <string name="upgrades_gplay_network_error_title">Verbindingsfout</string>
+    <string name="upgrades_gplay_network_error_description">Kan geen verbinding maken met Google Play. Controleer je internetverbinding en probeer het opnieuw.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Aanbieding niet beschikbaar</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play biedt deze upgrade-optie momenteel niet aan. Probeer het later opnieuw of raadpleeg de Google Play Store.</string>
 </resources>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">Już zakupiono</string>
     <string name="upgrades_gplay_already_owned_error">Sklep Google Play informuje, że posiadasz już tę aktualizację, ale nie można jej przywrócić. Sprawdź, czy jesteś zalogowany na koncie Google użytym do pierwotnego zakupu, a następnie spróbuj Przywróć zakup.</string>
     <string name="upgrade_screen_preamble">Pilot Uprawnień jest wolny od reklam i szanuje twoją prywatność. Aktualizacja wspiera dalszy rozwój.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Ceny niedostępne</string>
+    <string name="upgrade_screen_offers_unavailable_message">Ceny nie mogły zostać załadowane. Sprawdź Sklep Google Play i spróbuj ponownie za chwilę.</string>
     <string name="upgrade_screen_subscription_trial_action">Rozpocznij wersję próbną</string>
     <string name="upgrade_screen_subscription_action">Subskrybuj</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/rok, anuluj w dowolnym momencie</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Wiele kont może powodować problemy w Sklepie Google Play. Instalacja aplikacji za pośrednictwem witryny Sklepie Google Play wymusza powiązanie jej z konkretnym kontem.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Synchronizacja Sklepu Google Play może chwilę potrwać. Spróbuj uruchomić ponownie komputer, wyczyścić pamięć podręczną Sklepu Google Play lub po prostu poczekać.</string>
     <string name="upgrade_screen_restore_contact_hint">Nadal masz problem? Skontaktuj się z pomocą techniczną z adresu e-mail, z którego dokonano zakupu, podając numer zamówienia Google Play.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Uzyskaj %1$s</string>
+    <string name="upgrade_screen_benefits_title">Korzyści z uaktualnienia</string>
+    <string name="upgrade_screen_thanks_toast">Jesteś najlepszy! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Wersja Pro jest nadal aktywna. Czekamy na ponowne potwierdzenie zakupu przez Sklep Google Play, a wszystkie funkcje wersji Pro pozostają odblokowane.</string>
+    <string name="upgrade_screen_restore_body">Przywrócenie powoduje, że Sklep Google Play ponownie sprawdza zakupy tej aplikacji na bieżącym koncie. Nie rozpoczyna nowego zakupu.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Weryfikacja w Sklepie Google Play nie zakończyła się na czas, więc status twojego zakupu jest nadal nieznany. Na twoim koncie nic się nie zmieniło.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Pilot uprawnień nie może połączyć się z Google Play. Czy Google Play jest zainstalowany i aktualny? Czy Twoje konto Google jest zalogowane? Spróbuj wyczyścić pamięć podręczną aplikacji Google Play i zrestartować urządzenie.</string>
+    <string name="upgrades_gplay_billing_error_label">Problem z Google Play</string>
+    <string name="upgrades_gplay_billing_error_description">Wystąpił problem z Google Play. Spróbuj ponownie później lub zrestartuj urządzenie.\n\nSzczegóły: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Błąd Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Wystąpił wewnętrzny błąd Google Play. Spróbuj następujących czynności:\n\n• Zrestartuj urządzenie\n• Wyczyść pamięć podręczną Sklepu Google Play\n• Spróbuj ponownie później</string>
+    <string name="upgrades_gplay_network_error_title">Błąd połączenia</string>
+    <string name="upgrades_gplay_network_error_description">Nie udało się połączyć się z Google Play. Sprawdź swoje połączenie internetowe i spróbuj ponownie.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Oferta niedostępna</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Sklep Google Play obecnie nie oferuje tej opcji aktualizacji. Spróbuj ponownie później lub sprawdź w Sklepie Google Play.</string>
 </resources>

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">Já comprado</string>
     <string name="upgrades_gplay_already_owned_error">O Google Play informa que você já possui esta atualização, mas ela não pôde ser restaurada. Verifique se você está conectado à conta do Google usada para a compra original e tente \"Restaurar compra\".</string>
     <string name="upgrade_screen_preamble">O Permission Pilot é livre de anúncios e respeita sua privacidade. Fazer um upgrade apoia o desenvolvimento contínuo.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Preços indisponíveis</string>
+    <string name="upgrade_screen_offers_unavailable_message">Os preços não puderam ser carregados agora. Verifique o Google Play e tente novamente em instantes.</string>
     <string name="upgrade_screen_subscription_trial_action">Iniciar teste gratuito</string>
     <string name="upgrade_screen_subscription_action">Se inscrever</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/ano, cancele a qualquer momento</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Múltiplas contas podem confundir o Google Play. Instalar o aplicativo através do site do Google Play força sua vinculação a uma conta específica.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">A sincronização do Google Play pode levar um tempo. Tente reiniciar, limpar o cache do Google Play Store ou simplesmente aguardar.</string>
     <string name="upgrade_screen_restore_contact_hint">Ainda com problemas? Entre em contato com o suporte usando o e-mail que realizou a compra e inclua seu número de pedido do Google Play.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Obter %1$s</string>
+    <string name="upgrade_screen_benefits_title">Benefícios da atualização</string>
+    <string name="upgrade_screen_thanks_toast">Você é o melhor! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro ainda está ativo. Aguardando que o Google Play confirme novamente sua compra, todos os recursos do Pro permanecem desbloqueados enquanto isso.</string>
+    <string name="upgrade_screen_restore_body">A restauração solicita ao Google Play verificar novamente as compras deste aplicativo da conta atual. Ela não inicia uma nova compra.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">A verificação com o Google Play não foi finalizada a tempo, portanto o status da sua compra ainda é desconhecido. Nada foi alterado em sua conta.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">O Permission Pilot não pode se conectar ao Google Play. O Google Play está instalado e atualizado? Sua Conta Google está conectada? Tente limpar o cache do aplicativo Google Play e reiniciar o seu dispositivo.</string>
+    <string name="upgrades_gplay_billing_error_label">Problema do Google Play</string>
+    <string name="upgrades_gplay_billing_error_description">Houve um problema com o Google Play. Por favor, tente novamente mais tarde ou reinicie o seu dispositivo.\n\nDetalhes: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Erro do Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Um erro interno do Google Play ocorreu. Tente o seguinte:\n\n• Reinicie seu dispositivo\n• Limpe o cache do Google Play Store\n• Tente novamente mais tarde</string>
+    <string name="upgrades_gplay_network_error_title">Erro de conexão</string>
+    <string name="upgrades_gplay_network_error_description">Não é possível conectar ao Google Play. Verifique sua conexão com a internet e tente novamente.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Oferta indisponível</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play não está oferecendo esta opção de atualização no momento. Tente novamente mais tarde ou verifique a Google Play Store.</string>
 </resources>

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">Já comprado</string>
     <string name="upgrades_gplay_already_owned_error">Google Play reporta que já possui esta atualização, mas não conseguiu ser restaurada. Verifique se tem sessão iniciada com a conta Google utilizada para a compra original e tente \'Restaurar compra\'.</string>
     <string name="upgrade_screen_preamble">O Permission Pilot é sem anúncios e respeita a sua privacidade. Atualizar apoia o desenvolvimento contínuo.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Preços indisponíveis</string>
+    <string name="upgrade_screen_offers_unavailable_message">Os preços não puderam ser carregados neste momento. Verifique o Google Play e tente novamente em alguns instantes.</string>
     <string name="upgrade_screen_subscription_trial_action">Iniciar teste gratuito</string>
     <string name="upgrade_screen_subscription_action">Subscrever</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/ano, cancelar em qualquer altura</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Várias contas podem confundir o Google Play. Instalar a aplicação através do site do Google Play força a associação a uma conta específica.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">A sincronização do Google Play pode demorar. Tente reiniciar o dispositivo, limpar a cache do Google Play ou simplesmente aguarde.</string>
     <string name="upgrade_screen_restore_contact_hint">Continua sem solução? Contacte o apoio através do endereço de e-mail usado na compra e inclua o número da encomenda do Google Play.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Obter %1$s</string>
+    <string name="upgrade_screen_benefits_title">Benefícios da atualização</string>
+    <string name="upgrade_screen_thanks_toast">É incrível! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">O Pro continua ativo. Enquanto o Google Play volta a confirmar a compra, todas as funcionalidades Pro permanecem desbloqueadas.</string>
+    <string name="upgrade_screen_restore_body">O restauro pede ao Google Play que volte a verificar as compras desta aplicação na conta atual. Não inicia uma nova compra.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">A verificação com o Google Play não terminou a tempo, portanto o estado da sua compra ainda é desconhecido. Nada mudou na sua conta.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">O Permission Pilot não consegue estabelecer ligação ao Google Play. O Google Play está instalado e atualizado? Tem sessão iniciada na sua Conta Google? Tente limpar a cache da aplicação Google Play e reiniciar o dispositivo.</string>
+    <string name="upgrades_gplay_billing_error_label">Problema do Google Play</string>
+    <string name="upgrades_gplay_billing_error_description">Houve um problema com o Google Play. Por favor, tente novamente mais tarde ou reinicie o seu dispositivo.\n\nDetalhes: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Erro no Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Ocorreu um erro interno do Google Play. Tente o seguinte:\n\n• Reinicie o dispositivo\n• Limpe a cache da Google Play Store\n• Tente novamente mais tarde</string>
+    <string name="upgrades_gplay_network_error_title">Erro de ligação</string>
+    <string name="upgrades_gplay_network_error_description">Não foi possível estabelecer ligação ao Google Play. Verifique a ligação à Internet e tente novamente.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Oferta indisponível</string>
+    <string name="upgrades_gplay_offer_unavailable_description">O Google Play não está a oferecer atualmente esta opção de atualização. Tente novamente mais tarde ou consulte a Google Play Store.</string>
 </resources>

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">Deja cumpărat</string>
     <string name="upgrades_gplay_already_owned_error">Google Play raportează că deja deții acest upgrade, dar nu a putut fi restaurat. Verifică că ești conectat cu contul Google folosit pentru achiziția originală, apoi încearcă „Restaurează achiziția”.</string>
     <string name="upgrade_screen_preamble">Permission Pilot este fără reclame şi îți respectă confidențialitatea. Actualizarea sprijină dezvoltarea continuă.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Prețuri indisponibile</string>
+    <string name="upgrade_screen_offers_unavailable_message">Prețurile nu au putut fi încărcate acum. Verificați Google Play și încercați din nou într-un moment.</string>
     <string name="upgrade_screen_subscription_trial_action">Începe încercarea gratuită</string>
     <string name="upgrade_screen_subscription_action">Abonează-te</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/an, anulează oricând</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Conturi multiple pot confunda Google Play. Instalarea aplicației prin site-ul Google Play o forțează să se asocieze cu un cont specific.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Sincronizarea Google Play poate dura ceva timp. Încearcă să repornești, să ștergi memoria cache a Google Play Store sau pur și simplu să aștepți.</string>
     <string name="upgrade_screen_restore_contact_hint">Încă blocat? Contactează asistența din e-mailul care a realizat achiziția și include numărul comenzii Google Play.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Obțineți %1$s</string>
+    <string name="upgrade_screen_benefits_title">Beneficiile upgrade-ului</string>
+    <string name="upgrade_screen_thanks_toast">Ești cel mai bun! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro este încă activ. Se așteaptă ca Google Play să confirme din nou achiziția dvs., toate caracteristicile Pro rămân deblochate în același timp.</string>
+    <string name="upgrade_screen_restore_body">Restaurarea cere Google Play să revizuiască achizițiile acestei aplicații pentru contul actual. Nu pornește o nouă achiziție.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Verificarea cu Google Play nu s-a încheiat la timp, deci starea achiziției dvs. este încă necunoscută. Nimic nu s-a schimbat pe contul dvs.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot nu se poate conecta la Google Play. Google Play este instalat și actualizat? Este conectat contul dvs. Google? Încercați să curățați memoria cache a aplicației Google Play și reporniți dispozitivul.</string>
+    <string name="upgrades_gplay_billing_error_label">Problemă din partea Google Play</string>
+    <string name="upgrades_gplay_billing_error_description">A fost o problemă cu Google Play. Vă rugăm să încercați din nou mai târziu sau să reporniți dispozitivul.\n\nDetalii: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Eroare Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">O eroare internă Google Play a apărut. Vă rugăm să încercați următoarele:\n\n• Reporniți dispozitivul\n• Curățați memoria cache a Google Play Store\n• Încercați din nou mai târziu</string>
+    <string name="upgrades_gplay_network_error_title">Eroare de conexiune</string>
+    <string name="upgrades_gplay_network_error_description">Nu se poate conecta la Google Play. Vă rugăm să verificați conexiunea dvs. la internet și încercați din nou.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Ofertă indisponibilă</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play nu oferă în prezent această opțiune de upgrade. Vă rugăm să încercați din nou mai târziu sau să verificați Google Play Store.</string>
 </resources>

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">Уже приобретено</string>
     <string name="upgrades_gplay_already_owned_error">Google Play сообщает, что вы уже владеете этим обновлением, но оно не удалось восстановить. Убедитесь, что вы вошли с помощью учетной записи Google, используемой для первоначальной покупки, затем попробуйте «Восстановить покупку».</string>
     <string name="upgrade_screen_preamble">Permission Pilot не содержит рекламы и уважает вашу конфиденциальность. Обновление поддерживает дальнейшую разработку.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Цены недоступны</string>
+    <string name="upgrade_screen_offers_unavailable_message">Не удалось загрузить цены. Проверьте Google Play и повторите попытку через некоторое время.</string>
     <string name="upgrade_screen_subscription_trial_action">Начать бесплатный пробный период</string>
     <string name="upgrade_screen_subscription_action">Подписаться</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/год, отменить в любое время</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Несколько аккаунтов могут запутать Google Play. Установка приложения через сайт Google Play заставляет его привязаться к определенному аккаунту.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Синхронизация Google Play может занять время. Попробуйте перезагрузить устройство, очистить кэш Google Play Store или просто подождать.</string>
     <string name="upgrade_screen_restore_contact_hint">Всё ещё не получается? Свяжитесь с поддержкой с адреса электронной почты, который произвёл покупку, и укажите номер заказа Google Play.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Получить %1$s</string>
+    <string name="upgrade_screen_benefits_title">Преимущества обновления</string>
+    <string name="upgrade_screen_thanks_toast">Вы лучший! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro по-прежнему активен. Ожидаем повторного подтверждения покупки в Google Play, все функции Pro остаются разблокированы.</string>
+    <string name="upgrade_screen_restore_body">Восстановление просит Google Play повторно проверить покупки этого приложения для текущего аккаунта. Это не запускает новую покупку.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Проверка с Google Play не закончилась вовремя, поэтому статус покупки до сих пор неизвестен. В Вашей учетной записи ничего не изменилось.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot не может подключиться к Google Play. Установлен и обновлен ли Google Play? Вошли ли Вы в аккаунт Google? Попробуйте очистить кэш приложения Google Play и перезагрузить устройство.</string>
+    <string name="upgrades_gplay_billing_error_label">Проблема с Google Play</string>
+    <string name="upgrades_gplay_billing_error_description">Возникла проблема с Google Play. Пожалуйста, повторите попытку позже или перезагрузите устройство.\n\nПодробности: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Ошибка Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Произошла внутренняя ошибка Google Play. Пожалуйста, попробуйте следующее:\n\n• Перезапустите устройство\n• Очистите кэш Google Play Store\n• Повторите попытку позже</string>
+    <string name="upgrades_gplay_network_error_title">Ошибка соединения</string>
+    <string name="upgrades_gplay_network_error_description">Не удалось подключиться к Google Play. Пожалуйста, проверьте подключение к интернету и повторите попытку.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Предложение недоступно</string>
+    <string name="upgrades_gplay_offer_unavailable_description">В настоящее время Google Play не предлагает эту опцию обновления. Пожалуйста, повторите попытку позже или проверьте Google Play Store.</string>
 </resources>

--- a/app/src/gplay/res/values-sk/strings.xml
+++ b/app/src/gplay/res/values-sk/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">Už zakúpené</string>
     <string name="upgrades_gplay_already_owned_error">Google Play hlási, že už vlastníte tento upgrade, ale nepodarilo sa ho obnoviť. Skontrolujte, že ste prihlásení s účtom Google, ktorý ste používali pri pôvodnom nákupe, a potom skúste „Obnoviť nákup“.</string>
     <string name="upgrade_screen_preamble">Permission Pilot je bez reklam a rešpektuje vaše súkromie. Upgrade podporuje ďalejší vyvoj.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Ceny nie sú dostupné</string>
+    <string name="upgrade_screen_offers_unavailable_message">Ceny sa teraz nemohli načítať. Skontrolujte Google Play a skúste znova o chvíľu.</string>
     <string name="upgrade_screen_subscription_trial_action">Vyskúšajte zadarmo</string>
     <string name="upgrade_screen_subscription_action">Predplatiť</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/rok, kedykoľvek zrušiť</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Viaceré účty môžu zmiasť Google Play. Inštalácia aplikácie prostredníctvom webovej stránky Google Play si vynúti priradenie ku konkrétnemu účtu.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Synchronizácia Google Play môže chvíľu trvať. Skúste reštartovať, vymazať vyrovnávaciu pamäť Google Play Store alebo jednoducho počkať.</string>
     <string name="upgrade_screen_restore_contact_hint">Stále v problémoch? Kontaktujte podporu z e-mailu, ktorý bol použitý na nákup, a uveďte číslo svojej objednávky Google Play.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Získať %1$s</string>
+    <string name="upgrade_screen_benefits_title">Výhody upgradu</string>
+    <string name="upgrade_screen_thanks_toast">Ste najlepší! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro je stále aktívny. Čakáme na potvrdenie nákupu od Google Play, všetky funkcie Pro zostávajú odomknuté medzitým.</string>
+    <string name="upgrade_screen_restore_body">Obnovenie požiada Google Play, aby znova skontroloval nákupy tejto aplikácie pre aktuálny účet. Neštartuje nový nákup.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Kontrola v Google Play neskončila včas, takže váš stav nákupu je stále neznámy. Na vašom účte sa nič nezmenilo.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot sa nemôže pripojiť k službe Google Play. Je Google Play nainštalovaný a aktuálny? Je váš účet Google prihlásený? Skúste vymazať vyrovnávaciu pamäť aplikácie Google Play a reštartujte zariadenie.</string>
+    <string name="upgrades_gplay_billing_error_label">Problém s Google Play</string>
+    <string name="upgrades_gplay_billing_error_description">Vyskytol sa problém so službou Google Play. Skúste to znova neskôr alebo reštartujte zariadenie.\n\nPodrobnosti: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Chyba Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Vyskytla sa interná chyba služby Google Play. Prosím, skúste nasledovné:\n\n• Reštartujte zariadenie\n• Vymazte vyrovnávaciu pamäť Google Play Store\n• Skúste neskôr</string>
+    <string name="upgrades_gplay_network_error_title">Chyba pripojenia</string>
+    <string name="upgrades_gplay_network_error_description">Nie je možné pripojiť sa k Google Play. Prosím, skontrolujte svoje internetové pripojenie a skúste znova.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Ponuka nie je dostupná</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play v súčasnosti neponúka túto možnosť upgradu. Skúste neskôr alebo skontrolujte Google Play Store.</string>
 </resources>

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">Већ куплено</string>
     <string name="upgrades_gplay_already_owned_error">Google Play извештава да већ поседујете ово унапређење, али га није могуће вратити. Проверите да ли сте пријављени са Google налогом који је коришћен за оригиналну куповину, а затим покушајте „Враћање куповине”.</string>
     <string name="upgrade_screen_preamble">Permission Pilot нема реклама и поштује вашу приватност. Надоградњом подржавате даљи развој.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Цене нису доступне</string>
+    <string name="upgrade_screen_offers_unavailable_message">Цене се тренутно не могу учитати. Проверите Google Play и покушајте поново за тренутак.</string>
     <string name="upgrade_screen_subscription_trial_action">Покрените бесплатно испробавање</string>
     <string name="upgrade_screen_subscription_action">Претплати се</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/година, отказ било када</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Више налога може збунити Google Play. Инсталирање апликације преко Google Play веб сајта приморава асоцијацију са одређеним налогом.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Синхронизација Google Play може потрајати. Покушајте поново покретање, брисање Google Play Store кеша или једноставно сачекајте.</string>
     <string name="upgrade_screen_restore_contact_hint">И даље имате проблем? Контактирајте подршку са имејла који је направио куповину и укључите ваш Google Play број наруџбине.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Набави %1$s</string>
+    <string name="upgrade_screen_benefits_title">Предности надградње</string>
+    <string name="upgrade_screen_thanks_toast">Ви сте најбољи! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro је и даље активан. Чекамо Google Play да поново потврди вашу куповину, све Pro функције остају откључане у међувремену.</string>
+    <string name="upgrade_screen_restore_body">Враћање захтева од Google Play да поново провери куповине ове апликације за ваш налог. То не почиње нову куповину.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Провера са Google Play-ом се није завршила на време, тако да ваш статус куповине остаје неизвестан. Ништа се није променило на вашем налогу.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot не може да се повеже са Google Play. Да ли је Google Play инсталиран и ажуриран? Да ли је ваш Google налог пријављен? Покушајте да обришете кеш Google Play апликације и поново покрените уређај.</string>
+    <string name="upgrades_gplay_billing_error_label">Проблем са Google Play</string>
+    <string name="upgrades_gplay_billing_error_description">Дошло је до проблема са Google Play. Покушајте поново касније или поново покрените уређај.\n\nДетаљи: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Грешка Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Дошло је до интерне грешке Google Play. Покушајте следеће:\n\n• Поново покрените уређај\n• Обришите кеш Google Play Store\n• Покушајте касније</string>
+    <string name="upgrades_gplay_network_error_title">Грешка повезивања</string>
+    <string name="upgrades_gplay_network_error_description">Није могуће повезати се са Google Play. Проверите вашу интернет везу и покушајте поново.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Понуда није доступна</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play тренутно не нуди ову опцију надградње. Покушајте поново касније или проверите Google Play Store.</string>
 </resources>

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">Redan köpt</string>
     <string name="upgrades_gplay_already_owned_error">Google Play rapporterar att du redan äger denna uppgradering, men den kunde inte återställas. Kontrollera att du är inloggad med Google-kontot som användes för det ursprungliga köpet och försök sedan med \"Återställ köp\".</string>
     <string name="upgrade_screen_preamble">Permission Pilot är reklamfri och respekterar din integritet. Att uppgradera stödjer fortsatt utveckling.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Priser är inte tillgängliga</string>
+    <string name="upgrade_screen_offers_unavailable_message">Priserna kunde inte läsas in just nu. Kontrollera Google Play och försök igen om en stund.</string>
     <string name="upgrade_screen_subscription_trial_action">Starta gratis prov</string>
     <string name="upgrade_screen_subscription_action">Prenumerera</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/år, avbryt när som helst</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Flera konton kan förvirra Google Play. Om du installerar appen via Google Play-webbplatsen tvingas den associeras med ett specifikt konto.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Google Play-synkronisering kan ta en stund. Försök starta om, rensa Google Play Store-cachen eller vänta bara.</string>
     <string name="upgrade_screen_restore_contact_hint">Fortfarande fastnad? Kontakta supporten från den e-postadress som gjorde köpet och inkludera ditt Google Play-ordernummer.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Hämta %1$s</string>
+    <string name="upgrade_screen_benefits_title">Uppgraderingsfördelar</string>
+    <string name="upgrade_screen_thanks_toast">Du är bäst! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro är fortfarande aktiv. Väntar på att Google Play ska bekräfta ditt köp igen, alla Pro-funktioner förblir olåsta under tiden.</string>
+    <string name="upgrade_screen_restore_body">Återställning ber Google Play att kontrollera den här appens köp på nytt för det aktuella kontot. Det startar inte ett nytt köp.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Kontrollen med Google Play slutfördes inte i tid, så din köpstatus är fortfarande okänd. Inget har ändrats på ditt konto.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot kan inte ansluta till Google Play. Är Google Play installerat och uppdaterat? Är ditt Google-konto inloggat? Försök rensa cachen för Google Play-appen och starta om enheten.</string>
+    <string name="upgrades_gplay_billing_error_label">Google Play-problem</string>
+    <string name="upgrades_gplay_billing_error_description">Det uppstod ett problem med Google Play. Försök igen senare eller starta om enheten.\n\nInformation: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play-fel</string>
+    <string name="upgrades_gplay_internal_error_description">Ett internt Google Play-fel uppstod. Försök med följande:\n\n• Starta om enheten\n• Rensa Google Play Store-cachen\n• Försök igen senare</string>
+    <string name="upgrades_gplay_network_error_title">Anslutningsfel</string>
+    <string name="upgrades_gplay_network_error_description">Det gick inte att ansluta till Google Play. Kontrollera din internetanslutning och försök igen.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Erbjudandet är inte tillgängligt</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play erbjuder inte denna uppgradering just nu. Försök igen senare eller kontrollera Google Play Store.</string>
 </resources>

--- a/app/src/gplay/res/values-th/strings.xml
+++ b/app/src/gplay/res/values-th/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">ซื้อแล้ว</string>
     <string name="upgrades_gplay_already_owned_error">Google Play รายงานว่าคุณเป็นเจ้าของการอัปเกรดนี้แล้ว แต่ไม่สามารถคืนค่าได้ ตรวจสอบว่าคุณลงชื่อเข้าใช้ด้วยบัญชี Google ที่ใช้สำหรับการซื้อครั้งแรก จากนั้นลองใช้ \"คืนค่าการซื้อ\"</string>
     <string name="upgrade_screen_preamble">Permission Pilot ไม่มีโฆษณาและเคารพความเป็นส่วนตัวของคุณ การอัปเกรดช่วยสนับสนุนการพัฒนาอย่างต่อเนื่อง</string>
+    <string name="upgrade_screen_offers_unavailable_title">ราคาไม่พร้อมใช้งาน</string>
+    <string name="upgrade_screen_offers_unavailable_message">ราคาไม่สามารถโหลดได้ในขณะนี้ ตรวจสอบ Google Play และลองอีกครั้งในอีกสักครู่</string>
     <string name="upgrade_screen_subscription_trial_action">เริ่มทดลองใช้องค์ฟรี</string>
     <string name="upgrade_screen_subscription_action">สมัครสมาชิก</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/ปี ยกเลิกได้ตลอดเวลา</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">บัญชีหลายบัญชีอาจทำให้ Google Play สับสน การติดตั้งแอปผ่านเว็บไซต์ Google Play จะทำให้มันเชื่อมโยงกับบัญชีเฉพาะเจาะจง</string>
     <string name="upgrade_screen_restore_sync_patience_hint">การซิงค์ Google Play อาจใช้เวลาสักครู่ ลองรีบูต ล้างแคชของ Google Play Store หรือเพียงแค่รอสักครู่</string>
     <string name="upgrade_screen_restore_contact_hint">ยังติดอยู่หรือ? ติดต่อฝ่ายสนับสนุนจากอีเมลที่ใช้ซื้อ พร้อมแนบหมายเลขคำสั่งซื้อ Google Play ของคุณ</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">รับ %1$s</string>
+    <string name="upgrade_screen_benefits_title">ประโยชน์ของการอัปเกรด</string>
+    <string name="upgrade_screen_thanks_toast">คุณเป็นคนที่ดีที่สุด! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro ยังคงใช้งานอยู่ รอการยืนยันการซื้อของคุณอีกครั้งจาก Google Play ฟีเจอร์ Pro ทั้งหมดจะถูกปลดล็อคในระหว่างนี้</string>
+    <string name="upgrade_screen_restore_body">การเรียกคืนจะขอให้ Google Play ตรวจสอบการซื้อของแอปนี้สำหรับบัญชีปัจจุบันอีกครั้ง ไม่ได้เริ่มการซื้อใหม่</string>
+    <string name="upgrade_screen_restore_inconclusive_message">การตรวจสอบกับ Google Play ไม่เสร็จทันเวลา ดังนั้นสถานะการซื้อของคุณยังไม่ชัดเจน ไม่มีการเปลี่ยนแปลงใด ๆ ในบัญชีของคุณ</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot ไม่สามารถเชื่อมต่อกับ Google Play ได้ Google Play ได้รับการติดตั้งและอัปเดตแล้วหรือไม่? บัญชี Google ของคุณเข้าสู่ระบบแล้วหรือไม่? ลองล้างแคชของแอป Google Play และรีบูตอุปกรณ์ของคุณ</string>
+    <string name="upgrades_gplay_billing_error_label">Google Play เกิดปัญหา</string>
+    <string name="upgrades_gplay_billing_error_description">มีปัญหาเกิดขึ้นกับ Google Play โปรดลองอีกครั้งในภายหลังหรือรีสตาร์ทอุปกรณ์ของคุณ\n\n รายละเอียด: %s</string>
+    <string name="upgrades_gplay_internal_error_title">ข้อผิดพลาด Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">เกิดข้อผิดพลาด Google Play ภายใน โปรดลองดำเนินการต่อไปนี้:\n\n• รีสตาร์ตอุปกรณ์ของคุณ\n• ล้างแคช Google Play Store\n• ลองอีกครั้งในภายหลัง</string>
+    <string name="upgrades_gplay_network_error_title">ข้อผิดพลาดการเชื่อมต่อ</string>
+    <string name="upgrades_gplay_network_error_description">ไม่สามารถเชื่อมต่อกับ Google Play ได้ โปรดตรวจสอบการเชื่อมต่ออินเทอร์เน็ตของคุณและลองอีกครั้ง</string>
+    <string name="upgrades_gplay_offer_unavailable_title">ข้อเสนอไม่พร้อมใช้งาน</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play ไม่ได้เสนอตัวเลือกการอัปเกรดนี้ในขณะนี้ โปรดลองอีกครั้งในภายหลังหรือตรวจสอบ Google Play Store</string>
 </resources>

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">Zaten satın alındı</string>
     <string name="upgrades_gplay_already_owned_error">Google Play, bu yükseltmeye zaten sahip olduğunuzu belirtiyor, ancak geri yüklenemedi. Orijinal satın alma işlemi için kullanılan Google hesabıyla oturum açmış olduğunuzdan emin olun, ardından \"Satın almayı geri yükle\" seçeneğini deneyin.</string>
     <string name="upgrade_screen_preamble">Permission Pilot reklamsız ve gizliliğinize saygı gösteriyor. Yükseltme yapılması, sürekli geliştirmeyi destekler.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Fiyatlar kullanılamıyor</string>
+    <string name="upgrade_screen_offers_unavailable_message">Fiyatlar şu anda yüklenemedi. Google Play\'i kontrol edin ve bir süre sonra tekrar deneyin.</string>
     <string name="upgrade_screen_subscription_trial_action">Ücretsiz deneme süresini başlatın</string>
     <string name="upgrade_screen_subscription_action">Abone ol</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/yıl, istediğiniz zaman iptal edebilirsiniz</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Birden fazla hesap Google Play\'i karıştırabilir. Belirli bir hesapla ilişkilendirmeye zorlayan Google Play web sitesi üzerinden uygulamayı yükleyin.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Google Play senkronizasyonu zaman alabilir. Yeniden başlatmayı, Google Play Store önbelleğini temizlemeyi veya sadece beklemeyi deneyin.</string>
     <string name="upgrade_screen_restore_contact_hint">Hâlâ takılı kaldınız mı? Satın almayı yapan e-posta hesabından destek birimiyle iletişime geçin ve Google Play sipariş numaranızı ekleyin.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">%1$s Al</string>
+    <string name="upgrade_screen_benefits_title">Yükseltme Faydaları</string>
+    <string name="upgrade_screen_thanks_toast">Sen en iyisisin! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro hâlâ etkindir. Google Play satın almayı yeniden onaylaması bekleniyor, bu sırada tüm Pro özellikleri kilit açık kalır.</string>
+    <string name="upgrade_screen_restore_body">Geri yükleme, Google Play\'den bu uygulamanın geçerli hesap için satın almalarını yeniden kontrol etmesini ister. Yeni bir satın alma başlatmaz.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Google Play ile yapılan kontrol zamanında bitmedi, bu nedenle satın alma durumunuz hâlâ bilinmiyor. Hesabınızda hiçbir şey değişmedi.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot Google Play\'e bağlanamıyor. Google Play yüklü ve güncel mi? Google Hesabınız ile oturum açtınız mı? Google Play uygulamasının önbelleğini temizlemeyi ve cihazınızı yeniden başlatmayı deneyin.</string>
+    <string name="upgrades_gplay_billing_error_label">Google Play Sorunu</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play ile ilgili bir sorun oluştu. Lütfen daha sonra tekrar deneyin veya cihazınızı yeniden başlatın.\n\nDetaylar: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play Hatası</string>
+    <string name="upgrades_gplay_internal_error_description">Bir iç Google Play hatası oluştu. Lütfen aşağıdakileri deneyin:\n\n• Cihazınızı yeniden başlatın\n• Google Play Store önbelleğini temizleyin\n• Daha sonra tekrar deneyin</string>
+    <string name="upgrades_gplay_network_error_title">Bağlantı Hatası</string>
+    <string name="upgrades_gplay_network_error_description">Google Play\'e bağlanılamıyor. Lütfen internet bağlantınızı kontrol edin ve tekrar deneyin.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Teklif Kullanılamıyor</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play şu anda bu yükseltme seçeneğini sunmuyor. Lütfen daha sonra tekrar deneyin veya Google Play Store\'u kontrol edin.</string>
 </resources>

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">Вже придбано</string>
     <string name="upgrades_gplay_already_owned_error">Google Play повідомляє, що ви вже володієте цим оновленням, але його не вдалося відновити. Переконайтесь, що ви увійшли з обліковим записом Google, який використовувався для початкової покупки, а потім спробуйте «Відновити покупку».</string>
     <string name="upgrade_screen_preamble">Permission Pilot без реклами і поважає вашу приватність. Оновлення підтримує подальшу розробку.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Ціни недоступні</string>
+    <string name="upgrade_screen_offers_unavailable_message">Ціни не можуть бути завантажені зараз. Перевірте Google Play і спробуйте ще раз через деякий час.</string>
     <string name="upgrade_screen_subscription_trial_action">Випробувати пробний період</string>
     <string name="upgrade_screen_subscription_action">Підписатися</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/рік, скасуйте у будь-який час</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Кілька акаунтів можуть спричинити проблеми в Google Play. Встановлення програми через веб-сайт Google Play примушує її асоціюватися з конкретним акаунтом.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Синхронізація Google Play може зайняти деякий час. Спробуйте перезавантажити пристрій, очистити кеш Google Play Store або просто почекайте.</string>
     <string name="upgrade_screen_restore_contact_hint">Все ще застрягли? Зв\'яжіться з підтримкою, використовуючи електронну пошту, яка здійснила покупку, та вкажіть номер замовлення Google Play.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Отримати %1$s</string>
+    <string name="upgrade_screen_benefits_title">Переваги оновлення</string>
+    <string name="upgrade_screen_thanks_toast">Ви найкращі! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro все ще активна. Очікуємо, поки Google Play повторно підтвердить вашу покупку. Усі функції Pro залишаються розблокованими в цей час.</string>
+    <string name="upgrade_screen_restore_body">Відновлення просить Google Play повторно перевірити покупки цього додатку для поточного облікового запису. Це не починає нову покупку.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Перевірка з Google Play не завершилась вчасно, тому статус вашої покупки все ще невідомий. На вашому обліковому записі нічого не змінилось.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot не може підключитися до Google Play. Чи встановлено та оновлено Google Play? Ви ввійшли до свого облікового запису Google? Спробуйте очистити кеш додатку Google Play і перезавантажити пристрій.</string>
+    <string name="upgrades_gplay_billing_error_label">Проблема з Google Play</string>
+    <string name="upgrades_gplay_billing_error_description">Виникла проблема з Google Play. Будь ласка, спробуйте пізніше або перезавантажте пристрій.\n\nДеталі: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Помилка Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Сталася внутрішня помилка Google Play. Спробуйте виконати наступні дії:\n\n• Перезапустіть пристрій\n• Очистіть кеш Google Play Store\n• Спробуйте пізніше</string>
+    <string name="upgrades_gplay_network_error_title">Помилка підключення</string>
+    <string name="upgrades_gplay_network_error_description">Неможливо підключитися до Google Play. Перевірте підключення до Інтернету та спробуйте ще раз.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Пропозиція недоступна</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play наразі не пропонує цей варіант оновлення. Спробуйте ще раз пізніше або перевірте Google Play Store.</string>
 </resources>

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">Đã mua</string>
     <string name="upgrades_gplay_already_owned_error">Google Play báo cáo rằng bạn đã sở hữu nâng cấp này, nhưng không thể khôi phục được. Kiểm tra rằng bạn đã đăng nhập bằng tài khoản Google được sử dụng để mua hàng ban đầu, sau đó hãy thử \"Khôi phục mua hàng\".</string>
     <string name="upgrade_screen_preamble">Permission Pilot không có quảng cáo và tôn trọng quyền riêng tư của bạn. Việc nâng cấp ủng hộ quá trình phát triển liên tục.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Giá không có sẵn</string>
+    <string name="upgrade_screen_offers_unavailable_message">Không thể tải giá lúc này. Kiểm tra Google Play và thử lại trong giây lát.</string>
     <string name="upgrade_screen_subscription_trial_action">Bắt đầu dùng thử miễn phí</string>
     <string name="upgrade_screen_subscription_action">Đăng ký</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/năm, hủy bất cứ lúc nào</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Nhiều tài khoản có thể làm Google Play nhầm lẫn. Cài đặt ứng dụng từ trang web Google Play sẽ buộc nó liên kết với một tài khoản cụ thể.</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Đồng bộ hóa Google Play có thể mất một lúc. Hãy thử khởi động lại, xóa bộ nhớ đệm Google Play Store hoặc chỉ chờ đợi.</string>
     <string name="upgrade_screen_restore_contact_hint">Vẫn gặp vấn đề? Liên hệ hỗ trợ từ email đã thực hiện mua hàng và kèm theo số đơn hàng Google Play của bạn.</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">Nhận %1$s</string>
+    <string name="upgrade_screen_benefits_title">Lợi ích nâng cấp</string>
+    <string name="upgrade_screen_thanks_toast">Bạn là tuyệt nhất! ❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro vẫn còn hoạt động. Chờ Google Play xác nhận lại lần nữa, tất cả các tính năng Pro vẫn được mở khóa trong thời gian này.</string>
+    <string name="upgrade_screen_restore_body">Khôi phục yêu cầu Google Play kiểm tra lại các mua hàng của ứng dụng này cho tài khoản hiện tại. Nó không bắt đầu mua hàng mới.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Kiểm tra với Google Play không hoàn thành kịp thời, vì vậy trạng thái mua hàng của bạn vẫn còn chưa xác định. Không có gì thay đổi trên tài khoản của bạn.</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot không thể kết nối với Google Play. Google Play đã được cài đặt và cập nhật chưa? Tài khoản Google của bạn đã đăng nhập chưa? Hãy thử xóa bộ nhớ đệm của ứng dụng Google Play và khởi động lại thiết bị của bạn.</string>
+    <string name="upgrades_gplay_billing_error_label">Sự cố Google Play</string>
+    <string name="upgrades_gplay_billing_error_description">Đã xảy ra sự cố với Google Play. Vui lòng thử lại sau hoặc khởi động lại thiết bị của bạn.\n\nChi tiết: %s</string>
+    <string name="upgrades_gplay_internal_error_title">Lỗi Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Đã xảy ra lỗi nội bộ của Google Play. Vui lòng thử những điều sau:\n\n• Khởi động lại thiết bị của bạn\n• Xóa bộ nhớ cache của Google Play Store\n• Thử lại sau</string>
+    <string name="upgrades_gplay_network_error_title">Lỗi kết nối</string>
+    <string name="upgrades_gplay_network_error_description">Không thể kết nối với Google Play. Vui lòng kiểm tra kết nối internet của bạn và thử lại.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Ưu đãi không có sẵn</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play hiện không cung cấp tùy chọn nâng cấp này. Vui lòng thử lại sau hoặc kiểm tra Google Play Store.</string>
 </resources>

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">已购买</string>
     <string name="upgrades_gplay_already_owned_error">Google Play 报告您已拥有此升级，但无法恢复。请检查您是否使用原始购买所用的 Google 帐户登录，然后尝试“恢复购买”。</string>
     <string name="upgrade_screen_preamble">Permission Pilot 无广告且尊重您的隐私。升级支持持续开发。</string>
+    <string name="upgrade_screen_offers_unavailable_title">价格不可用</string>
+    <string name="upgrade_screen_offers_unavailable_message">无法加载价格。请检查 Google Play，稍后再试。</string>
     <string name="upgrade_screen_subscription_trial_action">开始免费试用</string>
     <string name="upgrade_screen_subscription_action">订阅</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/年，随时可取消</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">多个账户可能会导致 Google Play 出现问题。通过 Google Play 网站安装应用可确保其与特定账户关联。</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Google Play 同步可能需要一些时间。请尝试重启、清除 Google Play Store 缓存或耐心等待。</string>
     <string name="upgrade_screen_restore_contact_hint">问题仍未解决？请从进行购买的电子邮件地址联系支持，并提供您的 Google Play 订单号。</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">获取 %1$s</string>
+    <string name="upgrade_screen_benefits_title">升级权益</string>
+    <string name="upgrade_screen_thanks_toast">你是最棒的！❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro 仍然有效。等待 Google Play 重新确认您的购买，在此期间所有 Pro 功能保持解锁状态。</string>
+    <string name="upgrade_screen_restore_body">恢复会要求 Google Play 重新检查此应用在当前账户上的购买情况。这不会开始新的购买。</string>
+    <string name="upgrade_screen_restore_inconclusive_message">与 Google Play 的检查未能及时完成，因此您的购买状态仍然未知。您的账户未发生任何变化。</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot 无法连接到 Google Play 商店。Google Play 商店是否已安装并更新至最新版本？您的 Google 账户是否已登录？请尝试清除 Google Play 商店应用的缓存，然后重启您的设备。</string>
+    <string name="upgrades_gplay_billing_error_label">Google Play 问题</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play 出现了问题。请稍后再试或重启您的设备。\n\n详情：%s</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play 错误</string>
+    <string name="upgrades_gplay_internal_error_description">发生了 Google Play 内部错误。请尝试以下方法：\n\n• 重启您的设备\n• 清除 Google Play Store 缓存\n• 稍后重试</string>
+    <string name="upgrades_gplay_network_error_title">连接错误</string>
+    <string name="upgrades_gplay_network_error_description">无法连接到 Google Play。请检查您的网络连接并重试。</string>
+    <string name="upgrades_gplay_offer_unavailable_title">优惠不可用</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play 目前不提供此升级选项。请稍后重试或查看 Google Play Store。</string>
 </resources>

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -5,6 +5,8 @@
     <string name="upgrades_gplay_already_owned_title">已購買</string>
     <string name="upgrades_gplay_already_owned_error">Google Play 報告您已擁有此升級，但無法復原。請檢查您是否使用原始購買所用的 Google 帳戶登入，然後嘗試「復原購買」。</string>
     <string name="upgrade_screen_preamble">Permission Pilot 無廣告且尊重您的隱私。升級可支持持續開發。</string>
+    <string name="upgrade_screen_offers_unavailable_title">價格無法取得</string>
+    <string name="upgrade_screen_offers_unavailable_message">目前無法載入價格。請查看 Google Play 並稍後重試。</string>
     <string name="upgrade_screen_subscription_trial_action">開始免費試用</string>
     <string name="upgrade_screen_subscription_action">訂閱</string>
     <string name="upgrade_screen_subscription_action_hint_yearly">%s/年，隨時可取消</string>
@@ -61,4 +63,22 @@
     <string name="upgrade_screen_restore_multiaccount_hint">多個帳戶可能會導致 Google Play 混亂。透過 Google Play 網站安裝應用程式會強制將其與特定帳戶關聯。</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Google Play 同步可能需要一段時間。請嘗試重新啟動、清除 Google Play Store 快取或耐心等候。</string>
     <string name="upgrade_screen_restore_contact_hint">仍未解決？請使用進行購買的電子郵件帳戶聯絡支援，並提供您的 Google Play 訂單編號。</string>
+    <!-- Screen title shown while Pro is not active -->
+    <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->
+    <string name="upgrade_screen_title_template">取得 %1$s</string>
+    <string name="upgrade_screen_benefits_title">升級權益</string>
+    <string name="upgrade_screen_thanks_toast">您是最棒的！❤️</string>
+    <string name="upgrade_screen_grace_body_short">Pro 仍在有效狀態。等待 Google Play 重新確認您的購買，同時所有 Pro 功能保持解鎖狀態。</string>
+    <string name="upgrade_screen_restore_body">還原會要求 Google Play 重新檢查該應用程式在目前帳戶的購買。這不會發起新的購買。</string>
+    <string name="upgrade_screen_restore_inconclusive_message">與 Google Play 的檢查未能及時完成，因此您的購買狀態仍不明。您帳戶中未有任何變更。</string>
+    <!-- Billing error descriptions -->
+    <string name="upgrades_gplay_unavailable_error_description">Permission Pilot 無法連線至 Google Play。請確認 Google Play 已安裝且為最新版本，同時確保已經登入 Google 帳戶。您可以嘗試清除 Google Play 應用程式的快取或重新啟動您的裝置以修正此問題。</string>
+    <string name="upgrades_gplay_billing_error_label">Google Play 問題</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play 發生問題。請稍後再試一次或重新啟動您的裝置。\n\n詳細資訊：%s</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play 錯誤</string>
+    <string name="upgrades_gplay_internal_error_description">發生 Google Play 內部錯誤。請嘗試以下操作：\n\n• 重新啟動您的裝置\n• 清除 Google Play 商店快取\n• 稍後重試</string>
+    <string name="upgrades_gplay_network_error_title">連線錯誤</string>
+    <string name="upgrades_gplay_network_error_description">無法連線至 Google Play。請檢查您的網際網路連線並重試。</string>
+    <string name="upgrades_gplay_offer_unavailable_title">優惠無法取得</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play 目前未提供此升級選項。請稍後重試或查看 Google Play 商店。</string>
 </resources>

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -562,7 +562,12 @@
     <string name="upgrade_benefit_monitoring">Toestemmingsmonitering</string>
     <string name="upgrade_benefit_support">Ondersteun die ontwikkelaar</string>
     <string name="upgrade_benefit_manifest_viewer">Blaai deur rou app-manifeste</string>
+    <string name="general_navigate_up_action">Gaan terug</string>
+    <string name="general_progress_loading">Laai…</string>
     <string name="general_upgrade_action">Opgradeer</string>
+    <string name="general_copy_action">Kopieer</string>
+    <string name="general_copied_to_clipboard_msg">Gekopieer na die Knipbord</string>
+    <string name="general_view_details_for_x_action">Bekyk besonderhede vir %1$s</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Opgradering-status en opsies</string>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -562,7 +562,12 @@
     <string name="upgrade_benefit_monitoring">የፍቃድ መ፱ኬሪያ</string>
     <string name="upgrade_benefit_support">ደቀናዉን ይደግፉ</string>
     <string name="upgrade_benefit_manifest_viewer">ደርቋል የመተግበሪያ ማኒፌስቶችን ከስዘ</string>
+    <string name="general_navigate_up_action">ወደ ላይ ሂድ</string>
+    <string name="general_progress_loading">መጫን…</string>
     <string name="general_upgrade_action">አሻሽል</string>
+    <string name="general_copy_action">ቅዳ</string>
+    <string name="general_copied_to_clipboard_msg">ወደ ክሊፕቦርድ ተቅዱ</string>
+    <string name="general_view_details_for_x_action">ለ%1$s ዝርዝር ይመልከቱ</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">ማሻሻያ ሁኔታ እና ምርጫ</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -654,7 +654,12 @@
     <string name="upgrade_benefit_monitoring">مراقبة الأذونات</string>
     <string name="upgrade_benefit_support">دعم المطوّر</string>
     <string name="upgrade_benefit_manifest_viewer">تصفح بيانات التطبيق الخام</string>
+    <string name="general_navigate_up_action">العودة للخلف</string>
+    <string name="general_progress_loading">جاري التحميل…</string>
     <string name="general_upgrade_action">ترقية</string>
+    <string name="general_copy_action">نسخ</string>
+    <string name="general_copied_to_clipboard_msg">نسخت إلى الحافظة</string>
+    <string name="general_view_details_for_x_action">عرض التفاصيل عن %1$s</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">حالة الترقية والخيارات</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -562,7 +562,12 @@
     <string name="upgrade_benefit_monitoring">İcazə nəzarəti</string>
     <string name="upgrade_benefit_support">Geliştiricini dəstəklə</string>
     <string name="upgrade_benefit_manifest_viewer">Tətbiqin xam manifestalarına baxmaq</string>
+    <string name="general_navigate_up_action">Yuxarıya get</string>
+    <string name="general_progress_loading">Yüklənir…</string>
     <string name="general_upgrade_action">Yüksəlt</string>
+    <string name="general_copy_action">Kopyala</string>
+    <string name="general_copied_to_clipboard_msg">Lövhəyə kopyalandı</string>
+    <string name="general_view_details_for_x_action">%1$s üçün detalları görün</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Yüksəltmə statusu və seçənəkləri</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -608,7 +608,12 @@
     <string name="upgrade_benefit_monitoring">Маніторынг дазволаў</string>
     <string name="upgrade_benefit_support">Падтрымаць разпрацоўшчыка</string>
     <string name="upgrade_benefit_manifest_viewer">Прагляд зыходных маніфестаў праграм</string>
+    <string name="general_navigate_up_action">Перайсці вверх</string>
+    <string name="general_progress_loading">Загрузка…</string>
     <string name="general_upgrade_action">Абнавіць</string>
+    <string name="general_copy_action">Скапіраваць</string>
+    <string name="general_copied_to_clipboard_msg">Скапіявана ў буфер абмену</string>
+    <string name="general_view_details_for_x_action">Прагледзець подробнасці %1$s</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Статус абнаўлення і варыянты</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -562,7 +562,12 @@
     <string name="upgrade_benefit_monitoring">Наблюдение на разрешения</string>
     <string name="upgrade_benefit_support">Подкрепете разработчика</string>
     <string name="upgrade_benefit_manifest_viewer">Преглед на сурови манифести на приложения</string>
+    <string name="general_navigate_up_action">Нагоре</string>
+    <string name="general_progress_loading">Зареждане…</string>
     <string name="general_upgrade_action">Надграждане</string>
+    <string name="general_copy_action">Копиране</string>
+    <string name="general_copied_to_clipboard_msg">Копирано в буферната памет</string>
+    <string name="general_view_details_for_x_action">Преглед на детайли за %1$s</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Статус на обновлението и опции</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -562,7 +562,12 @@
     <string name="upgrade_benefit_monitoring">অনুমতি পর্যবেক্ষণ</string>
     <string name="upgrade_benefit_support">ডিভেলপারকে সমর্থন করুন</string>
     <string name="upgrade_benefit_manifest_viewer">কাঁচা অ্যাপ ম্যানিফেস্ট ব্রাউজ করুন</string>
+    <string name="general_navigate_up_action">উপরে যান</string>
+    <string name="general_progress_loading">লোড হচ্ছে…</string>
     <string name="general_upgrade_action">আপগ্রেড করুন</string>
+    <string name="general_copy_action">কপি বা অনুলিপি করুন</string>
+    <string name="general_copied_to_clipboard_msg">ক্লিপবোর্ডে কপি করা হয়েছে</string>
+    <string name="general_view_details_for_x_action">%1$s এর বিবরণ দেখুন</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">আপগ্রেড স্ট্যাটাস এবং বিকল্পসমূহ</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -562,7 +562,12 @@
     <string name="upgrade_benefit_monitoring">Monitoratge de permisos</string>
     <string name="upgrade_benefit_support">Doneu suport al desenvolupador</string>
     <string name="upgrade_benefit_manifest_viewer">Navega pels manifests d’aplicacions en brut</string>
+    <string name="general_navigate_up_action">Navega cap amunt</string>
+    <string name="general_progress_loading">S\'està carregant…</string>
     <string name="general_upgrade_action">Millora</string>
+    <string name="general_copy_action">Copia</string>
+    <string name="general_copied_to_clipboard_msg">S\'ha copiat al porta-retalls</string>
+    <string name="general_view_details_for_x_action">Mostra els detalls de %1$s</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Estat de l\'actualització i opcions</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -608,7 +608,12 @@
     <string name="upgrade_benefit_monitoring">Monitorování oprávnění</string>
     <string name="upgrade_benefit_support">Podpořit vývojáře</string>
     <string name="upgrade_benefit_manifest_viewer">Procházet surové manifesty aplikací</string>
+    <string name="general_navigate_up_action">Přejít nahoru</string>
+    <string name="general_progress_loading">Načítání…</string>
     <string name="general_upgrade_action">Upgradovat</string>
+    <string name="general_copy_action">Kopírovat</string>
+    <string name="general_copied_to_clipboard_msg">Zkopírováno do schránky</string>
+    <string name="general_view_details_for_x_action">Zobrazit podrobnosti pro %1$s</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Stav upgradu a možnosti</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -562,7 +562,12 @@
     <string name="upgrade_benefit_monitoring">Tilladelsesøvervågning</string>
     <string name="upgrade_benefit_support">Støt udvikleren</string>
     <string name="upgrade_benefit_manifest_viewer">Gennemse rå app-manifester</string>
+    <string name="general_navigate_up_action">Naviger op</string>
+    <string name="general_progress_loading">Indlæser…</string>
     <string name="general_upgrade_action">Opgrader</string>
+    <string name="general_copy_action">Kopiér</string>
+    <string name="general_copied_to_clipboard_msg">Kopieret til udklipsholderen</string>
+    <string name="general_view_details_for_x_action">Vis detaljer for %1$s</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Opgraderingsstatus og indstillinger</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -562,7 +562,12 @@
     <string name="upgrade_benefit_monitoring">Berechtigungsüberwachung</string>
     <string name="upgrade_benefit_support">Entwickler unterstützen</string>
     <string name="upgrade_benefit_manifest_viewer">Roh-App-Manifeste durchsuchen</string>
+    <string name="general_navigate_up_action">Nach oben navigieren</string>
+    <string name="general_progress_loading">Wird geladen</string>
     <string name="general_upgrade_action">Upgrade</string>
+    <string name="general_copy_action">Kopieren</string>
+    <string name="general_copied_to_clipboard_msg">In die Zwischenablage kopiert</string>
+    <string name="general_view_details_for_x_action">Details für %1$s anzeigen</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Upgrade-Status und Optionen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -562,7 +562,11 @@
     <string name="upgrade_benefit_monitoring">Παρακολούθηση αδειών</string>
     <string name="upgrade_benefit_support">Υποστήριξη του δημιουργού</string>
     <string name="upgrade_benefit_manifest_viewer">Περιήγηση σε raw manifests εφαρμογών</string>
+    <string name="general_progress_loading">Φόρτωση…</string>
     <string name="general_upgrade_action">Αναβάθμιση</string>
+    <string name="general_copy_action">Αντιγραφή</string>
+    <string name="general_copied_to_clipboard_msg">Αντιγράφηκε στο πρόχειρο</string>
+    <string name="general_view_details_for_x_action">Προβολή λεπτομερειών για %1$s</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Κατάσταση αναβάθμισης και επιλογές</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -562,7 +562,12 @@
     <string name="upgrade_benefit_monitoring">Supervisión de permisos</string>
     <string name="upgrade_benefit_support">Apoya al desarrollador</string>
     <string name="upgrade_benefit_manifest_viewer">Explorar manifiestos de apps sin procesar</string>
+    <string name="general_navigate_up_action">Navegar arriba</string>
+    <string name="general_progress_loading">Cargando…</string>
     <string name="general_upgrade_action">Actualizar</string>
+    <string name="general_copy_action">Copiar</string>
+    <string name="general_copied_to_clipboard_msg">Copiado en el portapapeles</string>
+    <string name="general_view_details_for_x_action">Ver detalles de %1$s</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Estado de actualización y opciones</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -562,7 +562,12 @@
     <string name="upgrade_benefit_monitoring">Lupaseuranta</string>
     <string name="upgrade_benefit_support">Tue kehittäjää</string>
     <string name="upgrade_benefit_manifest_viewer">Selaa sovelluksen raakamanifesteja</string>
+    <string name="general_navigate_up_action">Siirry ylös</string>
+    <string name="general_progress_loading">Ladataan…</string>
     <string name="general_upgrade_action">Päivitä</string>
+    <string name="general_copy_action">Kopioi</string>
+    <string name="general_copied_to_clipboard_msg">Kopioitu leikepöydälle</string>
+    <string name="general_view_details_for_x_action">Näytä %1$s:n tiedot</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Päivityksen tila ja vaihtoehdot</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -563,7 +563,12 @@
     <string name="upgrade_benefit_monitoring">Surveillance des permissions</string>
     <string name="upgrade_benefit_support">Soutenir le développeur</string>
     <string name="upgrade_benefit_manifest_viewer">Parcourir les manifestes bruts des applis</string>
+    <string name="general_navigate_up_action">Naviguer vers le haut</string>
+    <string name="general_progress_loading">Chargement…</string>
     <string name="general_upgrade_action">Surclasser</string>
+    <string name="general_copy_action">Copier</string>
+    <string name="general_copied_to_clipboard_msg">A été copié dans le presse-papiers</string>
+    <string name="general_view_details_for_x_action">Afficher les détails de %1$s</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Statut de la mise à niveau et options</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -562,7 +562,12 @@
     <string name="upgrade_benefit_monitoring">अनुमति निगरानी</string>
     <string name="upgrade_benefit_support">डेवलपर का समर्थन करें</string>
     <string name="upgrade_benefit_manifest_viewer">कच्चे ऐप मेनिफेस्ट ब्राउज़ करें</string>
+    <string name="general_navigate_up_action">ऊपर जाएँ</string>
+    <string name="general_progress_loading">लोड हो रहा है…</string>
     <string name="general_upgrade_action">उन्नत करें</string>
+    <string name="general_copy_action">कॉपी करें</string>
+    <string name="general_copied_to_clipboard_msg">क्लिपबोर्ड पर प्रतिलिपि बनाई गई</string>
+    <string name="general_view_details_for_x_action">%1$s के लिए विवरण देखें</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">अपग्रेड की स्थिति और विकल्प</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -585,7 +585,12 @@
     <string name="upgrade_benefit_monitoring">Praćenje dozvola</string>
     <string name="upgrade_benefit_support">Podržite programera</string>
     <string name="upgrade_benefit_manifest_viewer">Pregledaj neobrañene manifeste aplikacija</string>
+    <string name="general_navigate_up_action">Idi gore</string>
+    <string name="general_progress_loading">Učitavanje…</string>
     <string name="general_upgrade_action">Nadogradnja</string>
+    <string name="general_copy_action">Kopiraj</string>
+    <string name="general_copied_to_clipboard_msg">Kopirano u međuspremnik</string>
+    <string name="general_view_details_for_x_action">Prikaži detalje za %1$s</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Stanje nadogradnje i mogućnosti</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -562,7 +562,12 @@
     <string name="upgrade_benefit_monitoring">Jogosultság-figyelelés</string>
     <string name="upgrade_benefit_support">Támogasd a fejlesztőt</string>
     <string name="upgrade_benefit_manifest_viewer">Nyers alkalmazás-manifestek böngészése</string>
+    <string name="general_navigate_up_action">Vissza</string>
+    <string name="general_progress_loading">Betöltés…</string>
     <string name="general_upgrade_action">Frissítés</string>
+    <string name="general_copy_action">Másolás</string>
+    <string name="general_copied_to_clipboard_msg">Vágólapra másolva</string>
+    <string name="general_view_details_for_x_action">Tekintsd meg a részleteket: %1$s</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Frissítés állapota és lehetőségei</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -562,7 +562,12 @@
     <string name="upgrade_benefit_monitoring">Monitoraggio permessi</string>
     <string name="upgrade_benefit_support">Supporta lo sviluppatore</string>
     <string name="upgrade_benefit_manifest_viewer">Sfoglia i manifest grezzi delle app</string>
+    <string name="general_navigate_up_action">Torna su</string>
+    <string name="general_progress_loading">Caricamento…</string>
     <string name="general_upgrade_action">Aggiorna</string>
+    <string name="general_copy_action">Copia</string>
+    <string name="general_copied_to_clipboard_msg">Copiato negli appunti</string>
+    <string name="general_view_details_for_x_action">Visualizza i dettagli per %1$s</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Stato dell’aggiornamento e opzioni</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -608,7 +608,12 @@
     <string name="upgrade_benefit_monitoring">ניטור הרשאות</string>
     <string name="upgrade_benefit_support">תמוך במפתח</string>
     <string name="upgrade_benefit_manifest_viewer">עיון במניפסטים גולמיים של אפליקציות</string>
+    <string name="general_navigate_up_action">עלה</string>
+    <string name="general_progress_loading">טוען…</string>
     <string name="general_upgrade_action">שדרוג</string>
+    <string name="general_copy_action">העתקה</string>
+    <string name="general_copied_to_clipboard_msg">הועתק ללוח</string>
+    <string name="general_view_details_for_x_action">הצג פרטים עבור %1$s</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">סטטוס השדרוג ואפשרויות</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -539,7 +539,12 @@
     <string name="upgrade_benefit_monitoring">権限監視</string>
     <string name="upgrade_benefit_support">開発者をサポート</string>
     <string name="upgrade_benefit_manifest_viewer">アプリの生のマニフェストを閲覧</string>
+    <string name="general_navigate_up_action">上へ移動</string>
+    <string name="general_progress_loading">読み込み中…</string>
     <string name="general_upgrade_action">アップグレード</string>
+    <string name="general_copy_action">コピー</string>
+    <string name="general_copied_to_clipboard_msg">クリップボードにコピーしました</string>
+    <string name="general_view_details_for_x_action">%1$sの詳細を表示</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">アップグレード状態とオプション</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -539,7 +539,12 @@
     <string name="upgrade_benefit_monitoring">권한 모니터링</string>
     <string name="upgrade_benefit_support">개발자 지원하기</string>
     <string name="upgrade_benefit_manifest_viewer">원시 앱 매니페스트 탐색</string>
+    <string name="general_navigate_up_action">위로 이동</string>
+    <string name="general_progress_loading">불러오는 중…</string>
     <string name="general_upgrade_action">업그레이드</string>
+    <string name="general_copy_action">복사</string>
+    <string name="general_copied_to_clipboard_msg">클립보드로 복사됨</string>
+    <string name="general_view_details_for_x_action">%1$s의 세부정보 보기</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">업그레이드 상태 및 옵션</string>

--- a/app/src/main/res/values-ku-rTR/strings.xml
+++ b/app/src/main/res/values-ku-rTR/strings.xml
@@ -562,7 +562,12 @@
     <string name="upgrade_benefit_monitoring">چاودێریکردنی ئەجازە</string>
     <string name="upgrade_benefit_support">پشتگیریکردنی پێوەندەکار</string>
     <string name="upgrade_benefit_manifest_viewer">Manîfestoyên xav ên sepaê bigere</string>
+    <string name="general_navigate_up_action">Vegere</string>
+    <string name="general_progress_loading">Tê barkirin…</string>
     <string name="general_upgrade_action">بەرزترکردن</string>
+    <string name="general_copy_action">Kopî bike</string>
+    <string name="general_copied_to_clipboard_msg">Copî kir</string>
+    <string name="general_view_details_for_x_action">Hûrguşên %1$s bibîn</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Rewşa Bulaş û Vebijark</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -562,7 +562,12 @@
     <string name="upgrade_benefit_monitoring">Tillatelsesovervåking</string>
     <string name="upgrade_benefit_support">Støtt utvikleren</string>
     <string name="upgrade_benefit_manifest_viewer">Bla gjennom rå app-manifester</string>
+    <string name="general_navigate_up_action">Gå opp</string>
+    <string name="general_progress_loading">Laster…</string>
     <string name="general_upgrade_action">Oppgrader</string>
+    <string name="general_copy_action">Kopier</string>
+    <string name="general_copied_to_clipboard_msg">Kopiert til utklippstavlen</string>
+    <string name="general_view_details_for_x_action">Vis detaljer for %1$s</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Oppgraderingsstatus og alternativer</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -562,7 +562,11 @@
     <string name="upgrade_benefit_monitoring">Toestemmingsbewaking</string>
     <string name="upgrade_benefit_support">Ondersteun de ontwikkelaar</string>
     <string name="upgrade_benefit_manifest_viewer">Bekijk onbewerkte app-manifesten</string>
+    <string name="general_navigate_up_action">Navigeer omhoog</string>
+    <string name="general_progress_loading">Bezig met laden…</string>
     <string name="general_upgrade_action">Upgraden</string>
+    <string name="general_copy_action">Kopiëren</string>
+    <string name="general_view_details_for_x_action">Details weergeven voor %1$s</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Upgradestatus en opties</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -608,7 +608,12 @@
     <string name="upgrade_benefit_monitoring">Monitorowanie uprawnień</string>
     <string name="upgrade_benefit_support">Wesprzyj programistę</string>
     <string name="upgrade_benefit_manifest_viewer">Przeglądaj nieprzetworzone manifesty aplikacji</string>
+    <string name="general_navigate_up_action">Przejdź wyżej</string>
+    <string name="general_progress_loading">Ładowanie…</string>
     <string name="general_upgrade_action">Uaktualnij</string>
+    <string name="general_copy_action">Kopiuj</string>
+    <string name="general_copied_to_clipboard_msg">Skopiowano do schowka</string>
+    <string name="general_view_details_for_x_action">Wyświetl szczegóły dla %1$s</string>
     <string name="upgrade_title_prefix">Pilot Uprawnień</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Status i opcje aktualizacji</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -562,7 +562,12 @@
     <string name="upgrade_benefit_monitoring">Monitoramento de permissões</string>
     <string name="upgrade_benefit_support">Apoiar o desenvolvedor</string>
     <string name="upgrade_benefit_manifest_viewer">Navegar pelos manifestos brutos de apps</string>
+    <string name="general_navigate_up_action">Voltar</string>
+    <string name="general_progress_loading">Carregando…</string>
     <string name="general_upgrade_action">Atualizar</string>
+    <string name="general_copy_action">Copiar</string>
+    <string name="general_copied_to_clipboard_msg">Copiado para área de transferência</string>
+    <string name="general_view_details_for_x_action">Ver detalhes de %1$s</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Status de atualização e opções</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -562,7 +562,12 @@
     <string name="upgrade_benefit_monitoring">Monitorização de permissões</string>
     <string name="upgrade_benefit_support">Apoiar o desenvolvedor</string>
     <string name="upgrade_benefit_manifest_viewer">Navegar pelos manifestos brutos das aplicações</string>
+    <string name="general_navigate_up_action">Navegar para cima</string>
+    <string name="general_progress_loading">A carregar…</string>
     <string name="general_upgrade_action">Atualizar</string>
+    <string name="general_copy_action">Copiar</string>
+    <string name="general_copied_to_clipboard_msg">Copiado para a área de transferência</string>
+    <string name="general_view_details_for_x_action">Ver detalhes de %1$s</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Estado e opções da atualização para Pro</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -585,7 +585,12 @@
     <string name="upgrade_benefit_monitoring">Monitorizare permisiuni</string>
     <string name="upgrade_benefit_support">Sprijină dezvoltatorul</string>
     <string name="upgrade_benefit_manifest_viewer">Răsfoiește manifestele brute ale aplicațiilor</string>
+    <string name="general_navigate_up_action">Sus</string>
+    <string name="general_progress_loading">Se încarcă…</string>
     <string name="general_upgrade_action">Actualizează</string>
+    <string name="general_copy_action">Copiază</string>
+    <string name="general_copied_to_clipboard_msg">Copiat în clipboard</string>
+    <string name="general_view_details_for_x_action">Vizualizați detaliile pentru %1$s</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Status upgrade și opțiuni</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -608,7 +608,12 @@
     <string name="upgrade_benefit_monitoring">Мониторинг разрешений</string>
     <string name="upgrade_benefit_support">Поддержать разработчика</string>
     <string name="upgrade_benefit_manifest_viewer">Просмотр разрых манифестов приложений</string>
+    <string name="general_navigate_up_action">Перейти вверх</string>
+    <string name="general_progress_loading">Загрузка…</string>
     <string name="general_upgrade_action">Обновить</string>
+    <string name="general_copy_action">Копировать</string>
+    <string name="general_copied_to_clipboard_msg">Скопировано в буфер</string>
+    <string name="general_view_details_for_x_action">Просмотреть сведения о %1$s</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Статус и параметры обновления</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -608,7 +608,12 @@
     <string name="upgrade_benefit_monitoring">Monitorovanie oprávnení</string>
     <string name="upgrade_benefit_support">Podporiť vývojára</string>
     <string name="upgrade_benefit_manifest_viewer">Prechádzať surové manifesty aplikácií</string>
+    <string name="general_navigate_up_action">Prejsť hore</string>
+    <string name="general_progress_loading">Načítava…</string>
     <string name="general_upgrade_action">Inovovať</string>
+    <string name="general_copy_action">Kopírovať</string>
+    <string name="general_copied_to_clipboard_msg">Skopírované do schránky</string>
+    <string name="general_view_details_for_x_action">Zobraziť podrobnosti pre %1$s</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Stav upgradu a možnosti</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -585,7 +585,12 @@
     <string name="upgrade_benefit_monitoring">Надзор дозвола</string>
     <string name="upgrade_benefit_support">Подржите програмера</string>
     <string name="upgrade_benefit_manifest_viewer">Прегледајте сирове манифесте апликација</string>
+    <string name="general_navigate_up_action">Иди нагоре</string>
+    <string name="general_progress_loading">Учитавање…</string>
     <string name="general_upgrade_action">Надогради</string>
+    <string name="general_copy_action">Копирај</string>
+    <string name="general_copied_to_clipboard_msg">Копирано у исечак</string>
+    <string name="general_view_details_for_x_action">Погледај детаље за %1$s</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Статус унапређења и опције</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -562,7 +562,12 @@
     <string name="upgrade_benefit_monitoring">Övervakning av behörigheter</string>
     <string name="upgrade_benefit_support">Stöd utvecklaren</string>
     <string name="upgrade_benefit_manifest_viewer">Bläddra i råa appmanifest</string>
+    <string name="general_navigate_up_action">Navigera upp</string>
+    <string name="general_progress_loading">Läser in…</string>
     <string name="general_upgrade_action">Uppgradera</string>
+    <string name="general_copy_action">Kopiera</string>
+    <string name="general_copied_to_clipboard_msg">Kopierat till urklipp</string>
+    <string name="general_view_details_for_x_action">Visa detaljer för %1$s</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Uppgraderingsstatus och alternativ</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -539,7 +539,12 @@
     <string name="upgrade_benefit_monitoring">การตรวจจับสิทธิ์</string>
     <string name="upgrade_benefit_support">สนับสนุนนักพัฒนา</string>
     <string name="upgrade_benefit_manifest_viewer">ดู Manifest ดิบของแอป</string>
+    <string name="general_navigate_up_action">ไปขึ้น</string>
+    <string name="general_progress_loading">กำลังโหลด…</string>
     <string name="general_upgrade_action">อัปเกรด</string>
+    <string name="general_copy_action">คัดลอก</string>
+    <string name="general_copied_to_clipboard_msg">คัดลอกไปยังคลิปบอร์ด</string>
+    <string name="general_view_details_for_x_action">ดูรายละเอียดสำหรับ %1$s</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">สถานะการอัปเกรดและตัวเลือก</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -562,7 +562,12 @@
     <string name="upgrade_benefit_monitoring">İzin izleme</string>
     <string name="upgrade_benefit_support">Geliştiriciyi destekle</string>
     <string name="upgrade_benefit_manifest_viewer">Ham uygulama manifestolarına göz at</string>
+    <string name="general_navigate_up_action">Yukarı git</string>
+    <string name="general_progress_loading">Yükleniyor…</string>
     <string name="general_upgrade_action">Yükselt</string>
+    <string name="general_copy_action">Kopyala</string>
+    <string name="general_copied_to_clipboard_msg">Panoya kopyalandı</string>
+    <string name="general_view_details_for_x_action">%1$s için ayrıntıları görüntüle</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Yükseltme durumu ve seçenekleri</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -608,7 +608,12 @@
     <string name="upgrade_benefit_monitoring">Моніторинг дозволів</string>
     <string name="upgrade_benefit_support">Підтримати розробника</string>
     <string name="upgrade_benefit_manifest_viewer">Переглядати необроблені маніфести застосунків</string>
+    <string name="general_navigate_up_action">Назад</string>
+    <string name="general_progress_loading">Завантаження…</string>
     <string name="general_upgrade_action">Оновити</string>
+    <string name="general_copy_action">Копіювати</string>
+    <string name="general_copied_to_clipboard_msg">Збережено у буфері</string>
+    <string name="general_view_details_for_x_action">Переглянути деталі для %1$s</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Статус оновлення та параметри</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -539,7 +539,12 @@
     <string name="upgrade_benefit_monitoring">Giám sát quyền</string>
     <string name="upgrade_benefit_support">Hỗ trợ nhà phát triển</string>
     <string name="upgrade_benefit_manifest_viewer">Duyệt manifest thô của ứng dụng</string>
+    <string name="general_navigate_up_action">Quay lại</string>
+    <string name="general_progress_loading">Đang tải…</string>
     <string name="general_upgrade_action">Nâng cấp</string>
+    <string name="general_copy_action">Sao chép</string>
+    <string name="general_copied_to_clipboard_msg">Chép vào bộ nhớ tạm</string>
+    <string name="general_view_details_for_x_action">Xem chi tiết về %1$s</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Trạng thái nâng cấp và tùy chọn</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -539,7 +539,12 @@
     <string name="upgrade_benefit_monitoring">权限监控</string>
     <string name="upgrade_benefit_support">支持开发者</string>
     <string name="upgrade_benefit_manifest_viewer">浏览原始应用清单</string>
+    <string name="general_navigate_up_action">返回</string>
+    <string name="general_progress_loading">正在加载…</string>
     <string name="general_upgrade_action">升级</string>
+    <string name="general_copy_action">复制</string>
+    <string name="general_copied_to_clipboard_msg">已复制到剪切板</string>
+    <string name="general_view_details_for_x_action">查看 %1$s 的详情</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">升级状态和选项</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -539,7 +539,12 @@
     <string name="upgrade_benefit_monitoring">權限監控</string>
     <string name="upgrade_benefit_support">支持開發者</string>
     <string name="upgrade_benefit_manifest_viewer">瀏覽原始應用程式清單</string>
+    <string name="general_navigate_up_action">向上導覽</string>
+    <string name="general_progress_loading">正在載入…</string>
     <string name="general_upgrade_action">升級</string>
+    <string name="general_copy_action">複製</string>
+    <string name="general_copied_to_clipboard_msg">已複製到剪貼簿</string>
+    <string name="general_view_details_for_x_action">檢視 %1$s 的詳細資訊</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">升級狀態與選項</string>


### PR DESCRIPTION
## What changed

Updated app translations across all supported languages via Crowdin — recently added strings (support/upgrade screens, a few general actions) are now translated instead of falling back to English.

## Technical Context

- Every locale was validated before being pulled in for vandalism, mistranslation, and encoding issues; several needed a mechanical escape fix (raw line breaks in the download replaced with `\n`), and a handful of bad machine-translated or corrupted entries were removed or reverted rather than accepted as-is.
- One French entry (`upgrade_screen_how_body`) was dropped for this pull: Crowdin's own export for it was malformed (missing XML tag, orphaned fragment), so it currently falls back to English until the source is fixed upstream and re-pulled.
- Also updates local development tooling configuration (`.claude/settings.json`), unrelated to app behavior.
