### PR TITLE
General: Update translations from Crowdin

### DIFF
--- a/app/src/foss/res/values-ar/strings.xml
+++ b/app/src/foss/res/values-ar/strings.xml
@@ -20,6 +20,7 @@
     <!-- Support pitch -->
     <string name="upgrade_screen_title">دعم Permission Pilot</string>
     <string name="upgrade_screen_why_title">فوائد الترقية</string>
+    <string name="upgrade_screen_how_title">كيف أساعدك</string>
     <string name="upgrade_screen_how_body">كن داعما وراعيا للتطوير! انقر على الزر أدناه لتفعيل جميع الميزات الإضافية وفتح ملفي الخاص برعاة GitHub.</string>
     <string name="upgrade_screen_thanks_toast">شكراً على دعمك لتطوير المصادر المفتوحة ❤️</string>
 </resources>

--- a/app/src/gplay/res/values-af-rZA/strings.xml
+++ b/app/src/gplay/res/values-af-rZA/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">Die kontrole met Google Play het nie betyds voltooi nie, dus is jou aankoupstatus nog steeds onbekend. Niks het op jou rekening verander nie.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot kan nie aan Google Play koppel nie. Is Google Play geïnstalleer en opgedateer? Is jou Google-rekening aangemeld? Probeer om die kas van die Google Play-toepassing skoon te maak en jou toestel herlaai.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Kon nie Google Play oopmaak nie. Dit kan ontbreek, uitgeskakeld of beperk wees op hierdie toestel.</string>
     <string name="upgrades_gplay_billing_error_label">Google Play-probleem</string>
     <string name="upgrades_gplay_billing_error_description">Daar was \'n probleem met Google Play. Probeer asseblief later weer of herstart jou toestel.\n\nBesonderhede: %s</string>
     <string name="upgrades_gplay_internal_error_title">Google Play-fout</string>

--- a/app/src/gplay/res/values-am/strings.xml
+++ b/app/src/gplay/res/values-am/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">Google Play ጋር ያለው ማረጋገጫ በጊዜ አልተጠናቀቀም፣ ስለሆነም የእርስዎ የግዥ ሁኔታ አሁንም ያልታወቀ ነው። በእርስዎ መለያ ላይ ምንም ነገር አልተወለጠም።</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot ከGoogle Play ጋር መገናኘት አይችልም። Google Play ተጭኖ እና ወቅታዊ ነው? የGoogle መለያዎ ገብቷል? የGoogle Play መተግበሪያ መሸጎጫ ማጥራት እና መሳሪያዎን እንደገና ማስጀመር ይሞክሩ።</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play ን መክፈት አልተቻለም። በዚህ መሳሪያ ላይ ሊጠፋ፣ ሊዘጋ ወይም ሊገደብ ይችላል።</string>
     <string name="upgrades_gplay_billing_error_label">Google Play ችግር</string>
     <string name="upgrades_gplay_billing_error_description">Google Play ጋር ችግር ተፈጠረ። ከጥቂት ደቂቃዎች በኋላ እንደገና ይሞክሩ ወይም መሳሪያዎን እንደገና ያስጀምሩ።\n\nዝርዝር: %s</string>
     <string name="upgrades_gplay_internal_error_title">Google Play ስህተት</string>

--- a/app/src/gplay/res/values-ar/strings.xml
+++ b/app/src/gplay/res/values-ar/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">لم ينتهِ الفحص مع Google Play في الوقت المحدد، لذلك حالة شرائك لا تزال غير معروفة. لم يتغير شيء على حسابك.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">يتعذر على Permission Pilot الاتصال بـ Google Play. هل تم تثبيت Google Play وتحديثه؟ هل تم تسجيل الدخول إلى حسابك في Google؟ حاول مسح ذاكرة التخزين المؤقت لتطبيق Google Play وإعادة تشغيل جهازك.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">لم يتمكن من فتح Google Play. قد يكون التطبيق غير موجود أو معطل أو محظور على هذا الجهاز.</string>
     <string name="upgrades_gplay_billing_error_label">هناك مشكلة مع المتجر التطبيقات Google Play</string>
     <string name="upgrades_gplay_billing_error_description">واجهنا مشكلة مع Google Play، المرجو المحاولة ثانية لاحقا أو إعادة تشغيل جهازك. \n\nالتفاصيل: %s</string>
     <string name="upgrades_gplay_internal_error_title">خطأ في Google Play</string>

--- a/app/src/gplay/res/values-az/strings.xml
+++ b/app/src/gplay/res/values-az/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">Google Play ilə yoxlama vaxtında bitmədi, buna görə də alış statusunuz hələ də naməlumdur. Hesabınızda heç bir şey dəyişməyib.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot Google Play-ə qoşula bilmir. Google Play quraşdırılıb və yenilənib? Google hesabınız daxil olub? Google Play tətbiqinin keşini təmizləməyi və cihazınızı yenidən başlatmagı sınayın.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play açıla bilmədi. Bu cihazda yoxdur, deaktiv və ya məhdudlaşdırılmış ola bilər.</string>
     <string name="upgrades_gplay_billing_error_label">Google Play Problemi</string>
     <string name="upgrades_gplay_billing_error_description">Google Play ilə problem yarandı. Xahiş edirik bir az sonra yenidən cəhd edin və ya cihazınızı yenidən başladın.\n\nDetallar: %s</string>
     <string name="upgrades_gplay_internal_error_title">Google Play xətası</string>

--- a/app/src/gplay/res/values-be/strings.xml
+++ b/app/src/gplay/res/values-be/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">Праверка Google Play не паспела завершыцца, таму статус вашай пакупкі ўсё яшчэ невядомы. Нічога не змянілася ў вашым уліковым запісе.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot не можа падключыцца да Google Play. Ці ўсталяваны і абноўлены Google Play? Вы ўвайшлі ў свой уліковы запіс Google? Паспрабуйце ачысціць кэш праграмы Google Play і перазагрузіць прыладу.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Не удалося адкрыць Google Play. Магчыма, яна адсутнічае, адключана або абмежавана на гэтым прыладзе.</string>
     <string name="upgrades_gplay_billing_error_label">Праблема з Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Узнікла праблема з Google Play. Паўтарыце спробу пазней або перазагрузіце прыладу.\n\nПадрабязнасці: %s</string>
     <string name="upgrades_gplay_internal_error_title">Памылка Google Play</string>

--- a/app/src/gplay/res/values-bg/strings.xml
+++ b/app/src/gplay/res/values-bg/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">Проверката с Google Play не завърши навреме, затова състоянието на вашата покупка остава неизвестно. Нищо не се е променило по вашия акаунт.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot не може да се свърже с Google Play. Инсталиран ли е Google Play и актуален ли е? Влязъл ли е вашият Google акаунт? Опитайте да изчистите кеша на приложението Google Play и да рестартирате устройството си.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Не успях да отворя Google Play. Възможно е да е отсъстващо, деактивирано или ограничено на това устройство.</string>
     <string name="upgrades_gplay_billing_error_label">Проблем с Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Възникна проблем с Google Play. Опитайте отново по-късно или рестартирайте устройството си.\n\nПодробности: %s</string>
     <string name="upgrades_gplay_internal_error_title">Грешка на Google Play</string>

--- a/app/src/gplay/res/values-bn-rBD/strings.xml
+++ b/app/src/gplay/res/values-bn-rBD/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">Google Play এর সাথে পরীক্ষা সময়মতো শেষ হয়নি, তাই আপনার ক্রয় স্থিতি এখনও অজানা। আপনার অ্যাকাউন্টে কিছুই পরিবর্তন হয়নি।</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot Google Play এর সাথে সংযোগ করতে পারছে না। Google Play কি ইনস্টল এবং আপ টু ডেট? আপনার Google অ্যাকাউন্ট লগ ইন আছে? Google Play অ্যাপের ক্যাশ সাফ করে এবং আপনার ডিভাইস রিবুট করে চেষ্টা করুন।</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">গুগল প্লে খুলতে পারেনি। এটি এই ডিভাইসে না থাকতে পারে, নিষ্ক্রিয় থাকতে পারে বা সীমাবদ্ধ থাকতে পারে।</string>
     <string name="upgrades_gplay_billing_error_label">গুগল প্লে সমস্যা</string>
     <string name="upgrades_gplay_billing_error_description">Google Play তে সমস্যা হয়েছে। অনুগ্রহ করে পরে আবার চেষ্টা করুন অথবা আপনার ডিভাইসটি পুনরায় চালু করুন।\n\nবিস্তারিত: %s</string>
     <string name="upgrades_gplay_internal_error_title">Google Play ত্রুটি</string>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">La comprovació amb el Google Play no ha acabat a temps, així que l\'estat de la vostra compra segueix sent desconegut. Res ha canviat al vostre compte.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">El Permission Pilot no es pot connectar al Google Play. El Google Play està instal·lat i actualitzat? Heu iniciat la sessió al vostre compte de Google? Proveu d\'esborrar la memòria cau de l\'aplicació Google Play i reinicieu el dispositiu.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">No s\'ha pogut obrir Google Play. Pot ser que manqui, estigui desactivat o restringit en aquest dispositiu.</string>
     <string name="upgrades_gplay_billing_error_label">Problema del Google Play</string>
     <string name="upgrades_gplay_billing_error_description">S\'ha produït un problema amb el Google Play. Torneu-ho a provar més tard o reinicieu el dispositiu.\n\nDetalls: %s</string>
     <string name="upgrades_gplay_internal_error_title">Error del Google Play</string>

--- a/app/src/gplay/res/values-cs/strings.xml
+++ b/app/src/gplay/res/values-cs/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">Kontrola s Obchodem Google Play nebyla dokončena včas, takže stav nákupu zůstává neznámý. Na vašem účtu se nic nezměnilo.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot se nemůže připojit k Obchodu Google Play. Je Obchod Google Play nainstalován a aktualizován? Jste přihlášeni k účtu Google? Zkuste vymazat mezipaměť Obchodu Google Play a restartovat zařízení.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Nešlo otevřít Obchod Play. Možná chybí, je zakázán nebo omezený v tomto zařízení.</string>
     <string name="upgrades_gplay_billing_error_label">Problém s Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Došlo k problému s Google Play. Zkuste to prosím znovu později nebo restartujte zařízení.\n\nPodrobnosti: %s</string>
     <string name="upgrades_gplay_internal_error_title">Chyba Google Play</string>

--- a/app/src/gplay/res/values-da/strings.xml
+++ b/app/src/gplay/res/values-da/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">Kontrollen med Google Play blev ikke færdig i tide, så din købsstatus er stadig ukendt. Intet er ændret på din konto.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot kan ikke forbinde til Google Play. Er Google Play installeret og opdateret? Er din Google-konto logget ind? Prøv at rydde cachen i Google Play-appen og genstarte din enhed.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Kunne ikke åbne Google Play. Det kan være manglende, deaktiveret eller begrænset på denne enhed.</string>
     <string name="upgrades_gplay_billing_error_label">Google Play Problem</string>
     <string name="upgrades_gplay_billing_error_description">Der opstod et problem med Google Play. Prøv igen senere eller genstart din enhed.\n\nDetaljer: %s</string>
     <string name="upgrades_gplay_internal_error_title">Google Play-fejl</string>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">Die Überprüfung mit Google Play wurde nicht rechtzeitig abgeschlossen, daher ist dein Kaufstatus weiterhin unbekannt. An deinem Konto wurde nichts geändert.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot kann keine Verbindung zu Google Play herstellen. Ist Google Play installiert und auf dem neuesten Stand? Bist du mit deinem Google-Konto angemeldet? Versuche, den Cache der Google Play-App zu leeren und dein Gerät neu zu starten.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play konnte nicht geöffnet werden. Es ist möglicherweise nicht installiert, deaktiviert oder auf diesem Gerät eingeschränkt.</string>
     <string name="upgrades_gplay_billing_error_label">Google Play Problem</string>
     <string name="upgrades_gplay_billing_error_description">Es gab ein Problem mit Google Play. Bitte versuche es später erneut oder starte dein Gerät neu.\n\nDetails: %s</string>
     <string name="upgrades_gplay_internal_error_title">Google Play Fehler</string>

--- a/app/src/gplay/res/values-el/strings.xml
+++ b/app/src/gplay/res/values-el/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">Ο έλεγχος με το Google Play δεν ολοκληρώθηκε εγκαίρως, οπότε η κατάσταση αγοράς σας είναι ακόμα άγνωστη. Τίποτα δεν έχει αλλάξει στο λογαριασμό σας.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Η εφαρμογή Permission Pilot δεν μπορεί να συνδεθεί με το Google Play. Είναι εγκατεστημένο και ενημερωμένο το Google Play; Είναι συνδεδεμένος ο λογαριασμός σας Google; Δοκιμάστε να καθαρίσετε την προσωρινή μνήμη cache της εφαρμογής Google Play και να επανεκκινήσετε τη συσκευή σας.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Δεν ήταν δυνατό να ανοίξει το Google Play. Ενδέχεται να λείπει, να είναι απενεργοποιημένο ή περιορισμένο σε αυτή τη συσκευή.</string>
     <string name="upgrades_gplay_billing_error_label">Πρόβλημα Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Παρουσιάστηκε κάποιο πρόβλημα με το Google Play. Δοκιμάστε ξανά αργότερα ή επανεκκινήστε τη συσκευή σας.\n\nΛεπτομέρειες: %s</string>
     <string name="upgrades_gplay_internal_error_title">Σφάλμα Google Play</string>

--- a/app/src/gplay/res/values-es/strings.xml
+++ b/app/src/gplay/res/values-es/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">La comprobación con Google Play no se completó a tiempo, por lo que tu estado de compra sigue siendo desconocido. Nada ha cambiado en tu cuenta.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot no puede conectarse a Google Play. ¿Está Google Play instalado y actualizado? ¿Has iniciado sesión con tu cuenta de Google? Prueba a borrar la caché de la aplicación Google Play y reinicia tu dispositivo.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">No se pudo abrir Google Play. Puede que no esté disponible, deshabilitado o restringido en este dispositivo.</string>
     <string name="upgrades_gplay_billing_error_label">Problema con Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Hubo un problema con la Google Play. Inténtalo de nuevo más tarde o reinicia tu dispositivo.\n\nDetalles: %s</string>
     <string name="upgrades_gplay_internal_error_title">Error de Google Play</string>

--- a/app/src/gplay/res/values-fi/strings.xml
+++ b/app/src/gplay/res/values-fi/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">Google Play -tarkistus ei valmistunut ajoissa, joten ostotilastasi on edelleen tuntematon. Tilillä ei ole muuttunut mitään.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot ei voi yhdistää Google Playhin. Onko Google Play asennettu ja ajan tasalla? Onko Google-tilisi kirjautunut sisään? Kokeile tyhjentää Google Play -sovelluksen välimuisti ja käynnistä laitteesi uudelleen.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Playta ei voitu avata. Se saattaa puuttua, olla poistettu käytöstä tai rajoitettu tällä laitteella.</string>
     <string name="upgrades_gplay_billing_error_label">Google Play -vika</string>
     <string name="upgrades_gplay_billing_error_description">Google Playssa oli ongelma. Yritäthän myöhemmin uudelleen tai käynnistäthän laite uudelleen.\n\nYksityiskohdat: %s</string>
     <string name="upgrades_gplay_internal_error_title">Google Play -vika</string>

--- a/app/src/gplay/res/values-fr/strings.xml
+++ b/app/src/gplay/res/values-fr/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">La vérification avec Google Play n\'a pas pu se terminer à temps, votre statut d\'achat reste donc inconnu. Rien n\'a changé sur votre compte.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot ne peut pas se connecter à Google Play. L\'appli Google Play est-elle installée et à jour ? Votre compte Google est-il connecté ? Essayez de vider le cache de l\'appli Google Play et de redémarrer votre appareil.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Impossible d\'ouvrir Google Play. Il se peut qu\'il soit absent, désactivé ou restreint sur cet appareil.</string>
     <string name="upgrades_gplay_billing_error_label">Problème avec Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Un problème est survenu avec Google Play. Réessayez ultérieurement ou redémarrer votre appareil.\n\nDétails : %s</string>
     <string name="upgrades_gplay_internal_error_title">Erreur Google Play</string>

--- a/app/src/gplay/res/values-hi-rIN/strings.xml
+++ b/app/src/gplay/res/values-hi-rIN/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">Google Play के साथ जांच समय पर पूरी नहीं हुई, इसलिए आपकी खरीदारी की स्थिति अभी भी अज्ञात है। आपके खाते पर कुछ भी नहीं बदला है।</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot Google Play से कनेक्ट नहीं हो सकता। क्या Google Play इंस्टॉल और अप-टू-डेट है? क्या आपका Google खाता लॉग इन है? Google Play ऐप का कैश साफ़ करने और अपने डिवाइस को रीबूट करने का प्रयास करें।</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play नहीं खुल सका। यह इस डिवाइस पर गायब, अक्षम या प्रतिबंधित हो सकता है।</string>
     <string name="upgrades_gplay_billing_error_label">Google Play समस्या</string>
     <string name="upgrades_gplay_billing_error_description">Google Play में समस्या थी। कृपया बाद में फिर से कोशिश करें या अपने डिवाइस को पुनः शुरू करें।\n\nविवरण: %s</string>
     <string name="upgrades_gplay_internal_error_title">Google Play त्रुटि</string>

--- a/app/src/gplay/res/values-hr/strings.xml
+++ b/app/src/gplay/res/values-hr/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">Provjera s Google Playem nije završena na vrijeme, pa je status vaše kupnje i dalje nepoznat. Ništa se nije promijenilo na vašem računu.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot se ne može povezati s Google Playem. Je li Google Play instaliran i ažuriran? Jeste li prijavljeni na svoj Google račun? Pokušajte očistiti predmemoriju Google Play aplikacije i ponovno pokrenuti uređaj.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Nije bilo moguće otvoriti Google Play. Možda nedostaje, onemogućena je ili ograničena na ovom uređaju.</string>
     <string name="upgrades_gplay_billing_error_label">Greška Google Playa</string>
     <string name="upgrades_gplay_billing_error_description">Došlo je do problema s Google Playom. Pokušajte ponovno kasnije ili ponovno pokrenite uređaj.\n\nDetalji: %s</string>
     <string name="upgrades_gplay_internal_error_title">Greška Google Playa</string>

--- a/app/src/gplay/res/values-hu/strings.xml
+++ b/app/src/gplay/res/values-hu/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">Az ellenőrzés a Google Play-vel nem fejeződött be időben, így a vásárlási állapot még mindig ismeretlen. A fiókod nem változott.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">A Permission Pilot nem tud csatlakozni a Google Playhez. Telepített és naprakész a Google Play? Be vagy jelentkezve Google-fiókkal? Próbáld meg törölni a Google Play alkalmazás gyorsítótárát és indítsd újra az eszközt.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Nem lehet megnyitni a Google Play-t. Előfordulhat, hogy hiányzik, letiltva van, vagy korlátozva van ezen az eszközön.</string>
     <string name="upgrades_gplay_billing_error_label">Google Play probléma</string>
     <string name="upgrades_gplay_billing_error_description">Hiba lépett fel a Google Play-vel. Próbálkozz később, vagy indítsd újra az eszközt.\n\nRészletek: %s</string>
     <string name="upgrades_gplay_internal_error_title">Google Play hiba</string>

--- a/app/src/gplay/res/values-it/strings.xml
+++ b/app/src/gplay/res/values-it/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">Il controllo con Google Play non è terminato in tempo, quindi lo stato del tuo acquisto è ancora sconosciuto. Nulla è cambiato nel tuo account.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot non può connettersi a Google Play. Google Play è installato e aggiornato? Il tuo account Google è connesso? Prova a svuotare la cache dell\'app Google Play e riavviare il dispositivo.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Impossibile aprire Google Play. Potrebbe mancare, essere disabilitato o limitato su questo dispositivo.</string>
     <string name="upgrades_gplay_billing_error_label">Problema con Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Si è verificato un problema con Google Play. Per favore riprova più tardi o riavvia il dispositivo.\n\nDettagli: %s</string>
     <string name="upgrades_gplay_internal_error_title">Errore di Google Play</string>

--- a/app/src/gplay/res/values-iw/strings.xml
+++ b/app/src/gplay/res/values-iw/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">הבדיקה עם Google Play לא הסתיימה בזמן, ולכן סטטוס הרכישה שלך עדיין לא ידוע. שום דבר לא השתנה בחשבונך.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot לא יכול להתחבר ל-Google Play. האם Google Play מותקן ומעודכן? האם חשבון Google שלך מחובר? נסה לנקות את המטמון של אפליקציית Google Play ולאתחל את המכשיר שלך.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">לא ניתן לפתוח את Google Play. ייתכן שהוא חסר, מכובה או מוגבל במכשיר זה.</string>
     <string name="upgrades_gplay_billing_error_label">בעיה ב-Google Play</string>
     <string name="upgrades_gplay_billing_error_description">היתה בעיה עם Google Play. אנא נסה שוב מאוחר יותר או הפעל את המכשיר שלך מחדש.\n\nפרטים: %s</string>
     <string name="upgrades_gplay_internal_error_title">שגיאת Google Play</string>

--- a/app/src/gplay/res/values-ja/strings.xml
+++ b/app/src/gplay/res/values-ja/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">Google Playとのチェックが時間内に完了しなかったため、購入ステータスはまだ不明です。アカウントには何も変更されていません。</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot は Google Play に接続できません。Google Playはインストールされており、最新の状態ですか？ あなたのGoogleアカウントはログインしていますか？ Google Playアプリのキャッシュをクリアしてデバイスを再起動してみてください。</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Playを開けませんでした。このデバイスにインストールされていないか、無効にされているか、制限されている可能性があります。</string>
     <string name="upgrades_gplay_billing_error_label">アプリ内購入の問題</string>
     <string name="upgrades_gplay_billing_error_description">Google Playで問題が発生しました。後でもう一度試すか、デバイスを再起動してください。\n\n詳細: %s</string>
     <string name="upgrades_gplay_internal_error_title">Google Play エラー</string>

--- a/app/src/gplay/res/values-ko/strings.xml
+++ b/app/src/gplay/res/values-ko/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">Google Play와의 확인이 시간 내에 완료되지 않아 구매 상태를 여전히 알 수 없습니다. 계정에 변경 사항이 없습니다.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot가 Google Play에 연결할 수 없습니다. Google Play가 설치되어 있고 최신 버전인가요? Google 계정이 로그인되어 있나요? Google Play 앱의 캐시를 지우고 기기를 재부팅해 보세요.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play를 열 수 없습니다. 이 기기에서 설치되지 않았거나, 비활성화되었거나, 제한되었을 수 있습니다.</string>
     <string name="upgrades_gplay_billing_error_label">Google Play 문제</string>
     <string name="upgrades_gplay_billing_error_description">Google Play에서 문제가 발생했습니다. 나중에 다시 시도하거나 기기를 다시시작 해주세요.\n\n상세정보: %s</string>
     <string name="upgrades_gplay_internal_error_title">Google Play 오류</string>

--- a/app/src/gplay/res/values-ku-rTR/strings.xml
+++ b/app/src/gplay/res/values-ku-rTR/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">Kontrola Google Play ne qediya. Status kirîdanê te ne tê zanîn. Tiştek li ser hesaba te ne hat guhertin.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot nikare bi Google Play re peyivîn. Google Play sazkirî û nûce ye? Hesabê Google têketî ye? Cache Google Play paqij bike û cihazê vegerandinê.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play neyê vekirin. Dibe ku ew tune be, neçalak kirî be an jî li ser vê cîhazbankî sînordarkî be.</string>
     <string name="upgrades_gplay_billing_error_label">Pirsgirêka Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Pirsgirêk bi Google Play re derket. Paşê hewl bide an cihazê vegerandinê.
 

--- a/app/src/gplay/res/values-nb/strings.xml
+++ b/app/src/gplay/res/values-nb/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">Sjekken med Google Play ble ikke ferdig i tide, så kjøpsstatusen din er fortsatt ukjent. Ingenting har endret seg på kontoen din.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot kan ikke koble til Google Play. Er Google Play installert og oppdatert? Er Google-kontoen din logget inn? Prøv å tømme hurtigbufferen til Google Play-appen, og start enheten på nytt.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Kunne ikke åpne Google Play. Det kan være manglende, deaktivert eller begrenset på denne enheten.</string>
     <string name="upgrades_gplay_billing_error_label">Google Play problem</string>
     <string name="upgrades_gplay_billing_error_description">Det oppstod et problem med Google Play. Prøv igjen senere eller start enheten på nytt.\n\nDetaljer: %s</string>
     <string name="upgrades_gplay_internal_error_title">Google Play-feil</string>

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">De controle bij Google Play is niet op tijd voltooid, waardoor de status van je aankoop nog steeds onbekend is. Er is niets gewijzigd in je account.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot kan geen verbinding maken met Google Play. Is Google Play geïnstalleerd en up-to-date? Is je Google-account ingelogd? Probeer de cache van de Google Play-app te wissen en je apparaat opnieuw op te starten.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Kon Google Play niet openen. Het kan ontbreken, uitgeschakeld zijn of beperkt zijn op dit apparaat.</string>
     <string name="upgrades_gplay_billing_error_label">Google Play Probleem</string>
     <string name="upgrades_gplay_billing_error_description">Er was een probleem met Google Play. Probeer het later opnieuw of herstart uw apparaat.\n\nDetails: %s</string>
     <string name="upgrades_gplay_internal_error_title">Google Play-fout</string>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">Weryfikacja w Sklepie Google Play nie zakończyła się na czas, więc status twojego zakupu jest nadal nieznany. Na twoim koncie nic się nie zmieniło.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Pilot uprawnień nie może połączyć się z Google Play. Czy Google Play jest zainstalowany i aktualny? Czy Twoje konto Google jest zalogowane? Spróbuj wyczyścić pamięć podręczną aplikacji Google Play i zrestartować urządzenie.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Nie można otworzyć Google Play. Aplikacja może być niedostępna, wyłączona lub ograniczona na tym urządzeniu.</string>
     <string name="upgrades_gplay_billing_error_label">Problem z Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Wystąpił problem z Google Play. Spróbuj ponownie później lub zrestartuj urządzenie.\n\nSzczegóły: %s</string>
     <string name="upgrades_gplay_internal_error_title">Błąd Google Play</string>

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">A verificação com o Google Play não foi finalizada a tempo, portanto o status da sua compra ainda é desconhecido. Nada foi alterado em sua conta.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">O Permission Pilot não pode se conectar ao Google Play. O Google Play está instalado e atualizado? Sua Conta Google está conectada? Tente limpar o cache do aplicativo Google Play e reiniciar o seu dispositivo.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Não foi possível abrir o Google Play. Pode estar ausente, desabilitado ou restrito neste dispositivo.</string>
     <string name="upgrades_gplay_billing_error_label">Problema do Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Houve um problema com o Google Play. Por favor, tente novamente mais tarde ou reinicie o seu dispositivo.\n\nDetalhes: %s</string>
     <string name="upgrades_gplay_internal_error_title">Erro do Google Play</string>

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">A verificação com o Google Play não terminou a tempo, portanto o estado da sua compra ainda é desconhecido. Nada mudou na sua conta.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">O Permission Pilot não consegue estabelecer ligação ao Google Play. O Google Play está instalado e atualizado? Tem sessão iniciada na sua Conta Google? Tente limpar a cache da aplicação Google Play e reiniciar o dispositivo.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Não foi possível abrir o Google Play. Pode estar ausente, desativado ou restrito neste dispositivo.</string>
     <string name="upgrades_gplay_billing_error_label">Problema do Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Houve um problema com o Google Play. Por favor, tente novamente mais tarde ou reinicie o seu dispositivo.\n\nDetalhes: %s</string>
     <string name="upgrades_gplay_internal_error_title">Erro no Google Play</string>

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">Verificarea cu Google Play nu s-a încheiat la timp, deci starea achiziției dvs. este încă necunoscută. Nimic nu s-a schimbat pe contul dvs.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot nu se poate conecta la Google Play. Google Play este instalat și actualizat? Este conectat contul dvs. Google? Încercați să curățați memoria cache a aplicației Google Play și reporniți dispozitivul.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Nu s-a putut deschide Google Play. Ar putea să lipsească, să fie dezactivat sau restricționat pe acest dispozitiv.</string>
     <string name="upgrades_gplay_billing_error_label">Problemă din partea Google Play</string>
     <string name="upgrades_gplay_billing_error_description">A fost o problemă cu Google Play. Vă rugăm să încercați din nou mai târziu sau să reporniți dispozitivul.\n\nDetalii: %s</string>
     <string name="upgrades_gplay_internal_error_title">Eroare Google Play</string>

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">Проверка с Google Play не закончилась вовремя, поэтому статус покупки до сих пор неизвестен. В Вашей учетной записи ничего не изменилось.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot не может подключиться к Google Play. Установлен и обновлен ли Google Play? Вошли ли Вы в аккаунт Google? Попробуйте очистить кэш приложения Google Play и перезагрузить устройство.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Не удалось открыть Google Play. Возможно, оно отсутствует, отключено или ограничено на этом устройстве.</string>
     <string name="upgrades_gplay_billing_error_label">Проблема с Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Возникла проблема с Google Play. Пожалуйста, повторите попытку позже или перезагрузите устройство.\n\nПодробности: %s</string>
     <string name="upgrades_gplay_internal_error_title">Ошибка Google Play</string>

--- a/app/src/gplay/res/values-sk/strings.xml
+++ b/app/src/gplay/res/values-sk/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">Kontrola v Google Play neskončila včas, takže váš stav nákupu je stále neznámy. Na vašom účte sa nič nezmenilo.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot sa nemôže pripojiť k službe Google Play. Je Google Play nainštalovaný a aktuálny? Je váš účet Google prihlásený? Skúste vymazať vyrovnávaciu pamäť aplikácie Google Play a reštartujte zariadenie.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Nepodarilo sa otvoriť Google Play. Aplikácia chýba, je vypnutá alebo obmedzená na tomto zariadení.</string>
     <string name="upgrades_gplay_billing_error_label">Problém s Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Vyskytol sa problém so službou Google Play. Skúste to znova neskôr alebo reštartujte zariadenie.\n\nPodrobnosti: %s</string>
     <string name="upgrades_gplay_internal_error_title">Chyba Google Play</string>

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">Провера са Google Play-ом се није завршила на време, тако да ваш статус куповине остаје неизвестан. Ништа се није променило на вашем налогу.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot не може да се повеже са Google Play. Да ли је Google Play инсталиран и ажуриран? Да ли је ваш Google налог пријављен? Покушајте да обришете кеш Google Play апликације и поново покрените уређај.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Не могу да отворим Google Play. Могуће је да недостаје, онемогућен је или ограничен на овом уређају.</string>
     <string name="upgrades_gplay_billing_error_label">Проблем са Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Дошло је до проблема са Google Play. Покушајте поново касније или поново покрените уређај.\n\nДетаљи: %s</string>
     <string name="upgrades_gplay_internal_error_title">Грешка Google Play</string>

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">Kontrollen med Google Play slutfördes inte i tid, så din köpstatus är fortfarande okänd. Inget har ändrats på ditt konto.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot kan inte ansluta till Google Play. Är Google Play installerat och uppdaterat? Är ditt Google-konto inloggat? Försök rensa cachen för Google Play-appen och starta om enheten.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Kunde inte öppna Google Play. Det kan saknas, vara inaktiverat eller begränsat på den här enheten.</string>
     <string name="upgrades_gplay_billing_error_label">Google Play-problem</string>
     <string name="upgrades_gplay_billing_error_description">Det uppstod ett problem med Google Play. Försök igen senare eller starta om enheten.\n\nInformation: %s</string>
     <string name="upgrades_gplay_internal_error_title">Google Play-fel</string>

--- a/app/src/gplay/res/values-th/strings.xml
+++ b/app/src/gplay/res/values-th/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">การตรวจสอบกับ Google Play ไม่เสร็จทันเวลา ดังนั้นสถานะการซื้อของคุณยังไม่ชัดเจน ไม่มีการเปลี่ยนแปลงใด ๆ ในบัญชีของคุณ</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot ไม่สามารถเชื่อมต่อกับ Google Play ได้ Google Play ได้รับการติดตั้งและอัปเดตแล้วหรือไม่? บัญชี Google ของคุณเข้าสู่ระบบแล้วหรือไม่? ลองล้างแคชของแอป Google Play และรีบูตอุปกรณ์ของคุณ</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">ไม่สามารถเปิด Google Play ได้ อาจจะหายไป ปิดใช้งาน หรือถูกจำกัดบนอุปกรณ์นี้</string>
     <string name="upgrades_gplay_billing_error_label">Google Play เกิดปัญหา</string>
     <string name="upgrades_gplay_billing_error_description">มีปัญหาเกิดขึ้นกับ Google Play โปรดลองอีกครั้งในภายหลังหรือรีสตาร์ทอุปกรณ์ของคุณ\n\n รายละเอียด: %s</string>
     <string name="upgrades_gplay_internal_error_title">ข้อผิดพลาด Google Play</string>

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">Google Play ile yapılan kontrol zamanında bitmedi, bu nedenle satın alma durumunuz hâlâ bilinmiyor. Hesabınızda hiçbir şey değişmedi.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot Google Play\'e bağlanamıyor. Google Play yüklü ve güncel mi? Google Hesabınız ile oturum açtınız mı? Google Play uygulamasının önbelleğini temizlemeyi ve cihazınızı yeniden başlatmayı deneyin.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play açılamadı. Cihazda bulunmayabilir, devre dışı veya kısıtlanmış olabilir.</string>
     <string name="upgrades_gplay_billing_error_label">Google Play Sorunu</string>
     <string name="upgrades_gplay_billing_error_description">Google Play ile ilgili bir sorun oluştu. Lütfen daha sonra tekrar deneyin veya cihazınızı yeniden başlatın.\n\nDetaylar: %s</string>
     <string name="upgrades_gplay_internal_error_title">Google Play Hatası</string>

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">Перевірка з Google Play не завершилась вчасно, тому статус вашої покупки все ще невідомий. На вашому обліковому записі нічого не змінилось.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot не може підключитися до Google Play. Чи встановлено та оновлено Google Play? Ви ввійшли до свого облікового запису Google? Спробуйте очистити кеш додатку Google Play і перезавантажити пристрій.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Не вдалося відкрити Google Play. Можливо, додаток відсутній, вимкнений або обмежений на цьому пристрої.</string>
     <string name="upgrades_gplay_billing_error_label">Проблема з Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Виникла проблема з Google Play. Будь ласка, спробуйте пізніше або перезавантажте пристрій.\n\nДеталі: %s</string>
     <string name="upgrades_gplay_internal_error_title">Помилка Google Play</string>

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">Kiểm tra với Google Play không hoàn thành kịp thời, vì vậy trạng thái mua hàng của bạn vẫn còn chưa xác định. Không có gì thay đổi trên tài khoản của bạn.</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot không thể kết nối với Google Play. Google Play đã được cài đặt và cập nhật chưa? Tài khoản Google của bạn đã đăng nhập chưa? Hãy thử xóa bộ nhớ đệm của ứng dụng Google Play và khởi động lại thiết bị của bạn.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Không thể mở Google Play. Nó có thể bị thiếu, bị vô hiệu hóa hoặc bị hạn chế trên thiết bị này.</string>
     <string name="upgrades_gplay_billing_error_label">Sự cố Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Đã xảy ra sự cố với Google Play. Vui lòng thử lại sau hoặc khởi động lại thiết bị của bạn.\n\nChi tiết: %s</string>
     <string name="upgrades_gplay_internal_error_title">Lỗi Google Play</string>

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">与 Google Play 的检查未能及时完成，因此您的购买状态仍然未知。您的账户未发生任何变化。</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot 无法连接到 Google Play 商店。Google Play 商店是否已安装并更新至最新版本？您的 Google 账户是否已登录？请尝试清除 Google Play 商店应用的缓存，然后重启您的设备。</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">无法打开 Google Play。该应用可能在此设备上缺失、已禁用或受限。</string>
     <string name="upgrades_gplay_billing_error_label">Google Play 问题</string>
     <string name="upgrades_gplay_billing_error_description">Google Play 出现了问题。请稍后再试或重启您的设备。\n\n详情：%s</string>
     <string name="upgrades_gplay_internal_error_title">Google Play 错误</string>

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -73,6 +73,8 @@
     <string name="upgrade_screen_restore_inconclusive_message">與 Google Play 的檢查未能及時完成，因此您的購買狀態仍不明。您帳戶中未有任何變更。</string>
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Permission Pilot 無法連線至 Google Play。請確認 Google Play 已安裝且為最新版本，同時確保已經登入 Google 帳戶。您可以嘗試清除 Google Play 應用程式的快取或重新啟動您的裝置以修正此問題。</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">無法開啟 Google Play。此應用可能未安裝、已停用或在此設備上受到限制。</string>
     <string name="upgrades_gplay_billing_error_label">Google Play 問題</string>
     <string name="upgrades_gplay_billing_error_description">Google Play 發生問題。請稍後再試一次或重新啟動您的裝置。\n\n詳細資訊：%s</string>
     <string name="upgrades_gplay_internal_error_title">Google Play 錯誤</string>

--- a/fastlane/metadata/android/pt-PT/full_description.txt
+++ b/fastlane/metadata/android/pt-PT/full_description.txt
@@ -23,3 +23,15 @@ As permissões estão pré-agrupadas para facilitar a navegação (p. ex., Conta
 Ao clicar numa permissão, são mostradas todas as aplicações que solicitam acesso a essa permissão.
 
 As aplicações e as permissões podem ser pesquisadas por texto livre, ordenadas e filtradas segundo diferentes critérios.
+
+<b>Visão Geral</b>
+Um painel resumo que mostra a contagem de aplicações por categoria — privacidade, segurança, origem da instalação e muito mais. Cada linha de categoria navega diretamente para uma lista de aplicações filtrada.
+
+<b>Observador de Permissões</b>
+Receba notificações quando uma atualização de aplicação adiciona novas permissões ou altera as existentes. O Observador de Permissões verifica as suas aplicações após cada atualização e cria um relatório se algo mudou.
+
+<b>Exportação de Dados</b>
+Exporte dados de aplicações ou permissões em Markdown, CSV ou JSON.
+
+<b>Visualizador de Manifesto</b>
+Navegue pelos manifestos brutos das aplicações com secções pesquisáveis e categorizadas. Veja quais as aplicações que podem descobrir outras aplicações instaladas.


### PR DESCRIPTION
## What changed

Updated translations pulled from Crowdin:

- The message shown when the Google Play app is missing or disabled on the device is now translated in 39 languages (Google Play flavor).
- Arabic translation for the "How I can help" heading on the support screen (FOSS flavor).
- The Portuguese (Portugal) Play Store listing now describes the Overview, Permission Watcher, Data Export, and Manifest Viewer features.

## Technical Context

- Routine Crowdin pull; no source string changes.
