### PR TITLE
General: Ask happy users for a Play Store review

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -256,6 +256,8 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:${Versions.Serialization.core}")
 
     "gplayImplementation"("com.android.billingclient:billing:8.3.0")
+    "gplayImplementation"("com.google.android.play:review:2.0.2")
+    "gplayImplementation"("com.google.android.play:review-ktx:2.0.2")
 
     // Support libs
     implementation("androidx.core:core-ktx:1.13.1")

--- a/app/src/foss/java/eu/darken/myperm/common/review/FossReviewTool.kt
+++ b/app/src/foss/java/eu/darken/myperm/common/review/FossReviewTool.kt
@@ -1,0 +1,30 @@
+package eu.darken.myperm.common.review
+
+import android.app.Activity
+import eu.darken.myperm.common.debug.logging.Logging.Priority.INFO
+import eu.darken.myperm.common.debug.logging.log
+import eu.darken.myperm.common.debug.logging.logTag
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FossReviewTool @Inject constructor() : ReviewTool {
+
+    override val state: Flow<ReviewTool.State> = flowOf(ReviewTool.State())
+
+    override suspend fun dismiss() {
+        log(TAG, INFO) { "dismiss()" }
+        // NOOP
+    }
+
+    override suspend fun reviewNow(activity: Activity) {
+        log(TAG, INFO) { "reviewNow($activity)" }
+        // NOOP
+    }
+
+    companion object {
+        private val TAG = logTag("Review", "Tool", "FOSS")
+    }
+}

--- a/app/src/foss/java/eu/darken/myperm/common/review/ReviewModule.kt
+++ b/app/src/foss/java/eu/darken/myperm/common/review/ReviewModule.kt
@@ -1,0 +1,16 @@
+package eu.darken.myperm.common.review
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ReviewModule {
+
+    @Binds
+    @Singleton
+    abstract fun reviewTool(tool: FossReviewTool): ReviewTool
+}

--- a/app/src/gplay/java/eu/darken/myperm/common/review/GplayReviewTool.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/review/GplayReviewTool.kt
@@ -1,0 +1,193 @@
+package eu.darken.myperm.common.review
+
+import android.app.Activity
+import com.google.android.play.core.ktx.launchReview
+import com.google.android.play.core.ktx.requestReview
+import com.google.android.play.core.review.ReviewInfo
+import com.google.android.play.core.review.ReviewManager
+import eu.darken.myperm.common.coroutine.AppScope
+import eu.darken.myperm.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.myperm.common.debug.logging.Logging.Priority.INFO
+import eu.darken.myperm.common.debug.logging.Logging.Priority.WARN
+import eu.darken.myperm.common.debug.logging.asLog
+import eu.darken.myperm.common.debug.logging.log
+import eu.darken.myperm.common.debug.logging.logTag
+import eu.darken.myperm.common.flow.replayingShare
+import eu.darken.myperm.common.flow.throttleLatest
+import eu.darken.myperm.common.upgrade.UpgradeRepo
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.sync.Mutex
+import java.time.Duration
+import java.time.Instant
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.system.measureTimeMillis
+
+@Singleton
+class GplayReviewTool @Inject constructor(
+    @AppScope private val appScope: CoroutineScope,
+    private val settings: ReviewSettings,
+    private val manager: ReviewManager,
+    upgradeRepo: UpgradeRepo,
+) : ReviewTool {
+
+    // Test seam: the probe backoff runs on AppScope (a real dispatcher), so a virtual-time test
+    // cannot advance the production bound. Same pattern as UpgradeRepoGplay.launchTimeoutMs.
+    internal var probeRetryDelay: Duration = PROBE_RETRY_DELAY
+
+    // Local bookkeeping only: decided without talking to Play, so an ineligible user never
+    // triggers a Play round-trip.
+    private val isLocallyEligible: Flow<Boolean> = combine(
+        settings.lastDismissed.flow,
+        settings.reviewedAt.flow,
+        upgradeRepo.upgradeInfo,
+    ) { lastDismissed, reviewedAt, upgradeInfo ->
+        val now = Instant.now()
+
+        // Free trial is 14 days, only ask for review after the user has paid something
+        val hasPaidForPro = Duration.between(upgradeInfo.upgradedAt ?: now, now) > Duration.ofDays(21)
+        val isSnoozed = Duration.between(lastDismissed ?: Instant.EPOCH, now) < Duration.ofDays(14)
+        val hasReviewed = reviewedAt != null
+
+        log(TAG) { "Eligibility: hasPaidForPro=$hasPaidForPro (${upgradeInfo.upgradedAt})" }
+        log(TAG) { "Eligibility: isSnoozed=$isSnoozed ($lastDismissed), hasReviewed=$hasReviewed ($reviewedAt)" }
+
+        hasPaidForPro && !isSnoozed && !hasReviewed
+    }
+        .distinctUntilChanged()
+
+    // Only probed once the user is eligible: Play counts requests against the app's quota, and an
+    // `isNoOp` answer is Play's deliberate verdict, i.e. an answer and not a failure to retry.
+    private val isReviewAvailable: Flow<Boolean> = isLocallyEligible
+        .flatMapLatest { eligible ->
+            if (!eligible) return@flatMapLatest flowOf(false)
+
+            flow {
+                for (attempt in 1..PROBE_ATTEMPTS) {
+                    val info = try {
+                        manager.requestReview()
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        log(TAG, WARN) { "Probe $attempt/$PROBE_ATTEMPTS failed: ${e.asLog()}" }
+                        if (attempt < PROBE_ATTEMPTS) delay(probeRetryDelay.toMillis())
+                        continue
+                    }
+                    log(TAG) { "Probe $attempt/$PROBE_ATTEMPTS returned ${info.desc()}" }
+                    emit(info.canShow)
+                    return@flow
+                }
+                // Re-probed when eligibility changes or on the next process start
+                log(TAG, WARN) { "Probe gave up after $PROBE_ATTEMPTS attempts" }
+                emit(false)
+            }
+        }
+        .replayingShare(appScope)
+
+    override val state: Flow<ReviewTool.State> = combine(
+        isLocallyEligible,
+        isReviewAvailable,
+        settings.reviewedAt.flow,
+    ) { eligible, available, reviewedAt ->
+        log(TAG) { "State: eligible=$eligible, available=$available, reviewedAt=$reviewedAt" }
+        ReviewTool.State(
+            shouldAskForReview = eligible && available,
+            hasReviewed = reviewedAt != null,
+        )
+    }
+        .throttleLatest(500)
+        .onStart { emit(ReviewTool.State()) }
+        .replayingShare(appScope)
+
+    // Single-flight: a second tap must not queue up behind the first, or Play's flow would be
+    // launched again the moment the user returns from it.
+    private val reviewLock = Mutex()
+
+    override suspend fun dismiss() {
+        log(TAG, INFO) { "dismiss()" }
+        settings.lastDismissed.value(Instant.now())
+    }
+
+    override suspend fun reviewNow(activity: Activity) {
+        log(TAG, INFO) { "reviewNow($activity)" }
+
+        if (!reviewLock.tryLock()) {
+            log(TAG, WARN) { "reviewNow(...) is already in progress, skipping" }
+            return
+        }
+
+        try {
+            // ReviewInfo is short lived, Google wants it requested shortly before the launch,
+            // a token cached at process start is likely stale by the time the user taps.
+            val reviewInfo = try {
+                manager.requestReview()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // A transient failure is not user intent: don't snooze the card, the next tap retries
+                log(TAG, ERROR) { "Failed to get a fresh ReviewInfo: ${e.asLog()}" }
+                return
+            }
+            log(TAG) { "reviewNow(...): Fresh ${reviewInfo.desc()}" }
+
+            if (!reviewInfo.canShow) {
+                // Play's quota verdict, asking again right away would be pointless
+                log(TAG, WARN) { "Play says we can't show the prompt, snoozing" }
+                settings.lastDismissed.value(Instant.now())
+                return
+            }
+
+            if (activity.isFinishing || activity.isDestroyed) {
+                log(TAG, WARN) { "Activity is gone, aborting: $activity" }
+                return
+            }
+
+            val reviewTime = measureTimeMillis {
+                try {
+                    manager.launchReview(activity, reviewInfo)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log(TAG, ERROR) { "Failed to launch review flow: ${e.asLog()}" }
+                    return
+                }
+            }
+            log(TAG) { "Review completed after ${reviewTime}ms" }
+
+            if (Duration.ofMillis(reviewTime) >= Duration.ofSeconds(2)) {
+                log(TAG, INFO) { "Marking review as completed" }
+                settings.reviewedAt.value(Instant.now())
+            } else {
+                log(TAG, INFO) { "Review was too quick, counting as dismiss" }
+                settings.lastDismissed.value(Instant.now())
+            }
+        } finally {
+            reviewLock.unlock()
+        }
+    }
+
+    private val ReviewInfo.canShow: Boolean
+        get() = when {
+            toString().contains("isNoOp=true") -> false
+            else -> true
+        }
+
+    private fun ReviewInfo.desc(): String {
+        return "ReviewInfo(canShow=$canShow, ${toString()})"
+    }
+
+    companion object {
+        private val TAG = logTag("Review", "Tool", "Gplay")
+        private const val PROBE_ATTEMPTS = 3
+        private val PROBE_RETRY_DELAY = Duration.ofSeconds(30)
+    }
+}

--- a/app/src/gplay/java/eu/darken/myperm/common/review/GplayReviewTool.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/review/GplayReviewTool.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
@@ -64,6 +65,14 @@ class GplayReviewTool @Inject constructor(
         hasPaidForPro && !isSnoozed && !hasReviewed
     }
         .distinctUntilChanged()
+        // Upstream of the shares: a settings read that throws (e.g. an undecodable stored timestamp)
+        // would otherwise kill the sharing coroutine on AppScope, i.e. crash the process, and never
+        // reach any collector's own error handling.
+        .catch { e ->
+            if (e is CancellationException) throw e
+            log(TAG, ERROR) { "Eligibility failed: ${e.asLog()}" }
+            emit(false)
+        }
 
     // Only probed once the user is eligible: Play counts requests against the app's quota, and an
     // `isNoOp` answer is Play's deliberate verdict, i.e. an answer and not a failure to retry.
@@ -106,6 +115,11 @@ class GplayReviewTool @Inject constructor(
     }
         .throttleLatest(500)
         .onStart { emit(ReviewTool.State()) }
+        .catch { e ->
+            if (e is CancellationException) throw e
+            log(TAG, ERROR) { "State failed: ${e.asLog()}" }
+            emit(ReviewTool.State())
+        }
         .replayingShare(appScope)
 
     // Single-flight: a second tap must not queue up behind the first, or Play's flow would be

--- a/app/src/gplay/java/eu/darken/myperm/common/review/ReviewModule.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/review/ReviewModule.kt
@@ -1,0 +1,27 @@
+package eu.darken.myperm.common.review
+
+import android.content.Context
+import com.google.android.play.core.review.ReviewManager
+import com.google.android.play.core.review.ReviewManagerFactory
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ReviewModule {
+
+    @Binds
+    @Singleton
+    abstract fun reviewTool(tool: GplayReviewTool): ReviewTool
+
+    companion object {
+        @Provides
+        @Singleton
+        fun reviewManager(@ApplicationContext context: Context): ReviewManager = ReviewManagerFactory.create(context)
+    }
+}

--- a/app/src/gplay/java/eu/darken/myperm/common/review/ReviewSettings.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/review/ReviewSettings.kt
@@ -1,0 +1,45 @@
+package eu.darken.myperm.common.review
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.myperm.common.datastore.createValue
+import eu.darken.myperm.common.debug.logging.logTag
+import eu.darken.myperm.common.serialization.InstantSerializer
+import kotlinx.serialization.builtins.nullable
+import kotlinx.serialization.json.Json
+import java.time.Instant
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ReviewSettings @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val json: Json,
+) {
+
+    private val Context.dataStore by preferencesDataStore(name = "settings_review_gplay")
+
+    val dataStore: DataStore<Preferences>
+        get() = context.dataStore
+
+    // The injected Json has no serializers module, so the reified `Instant?` lookup the kotlinx
+    // createValue overload does would fail on the first write. The ISO serializer is wired
+    // explicitly instead. A stored value that fails to decode throws: a timestamp we can't read is
+    // not the same as "never dismissed", and silently defaulting would re-ask the user forever.
+    private fun instantValue(keyName: String) = dataStore.createValue<Instant?>(
+        key = stringPreferencesKey(keyName),
+        reader = { rawValue -> (rawValue as? String)?.let { json.decodeFromString(InstantSerializer.nullable, it) } },
+        writer = { value -> value?.let { json.encodeToString(InstantSerializer.nullable, it) } },
+    )
+
+    val lastDismissed = instantValue("review.dismissedAt")
+    val reviewedAt = instantValue("review.reviewedAt")
+
+    companion object {
+        internal val TAG = logTag("Review", "Settings", "Gplay")
+    }
+}

--- a/app/src/main/java/eu/darken/myperm/common/flow/FlowExtensions.kt
+++ b/app/src/main/java/eu/darken/myperm/common/flow/FlowExtensions.kt
@@ -7,6 +7,7 @@ import eu.darken.myperm.common.debug.logging.log
 import eu.darken.myperm.common.error.hasCause
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlin.time.Duration
 
@@ -48,6 +49,13 @@ internal fun <T> Flow<T>.withPrevious(): Flow<Pair<T?, T>> = this
         it as Pair<T?, T>
     }
 
+
+fun <T> Flow<T>.throttleLatest(delayMillis: Long): Flow<T> = this
+    .conflate()
+    .transform {
+        emit(it)
+        delay(delayMillis)
+    }
 
 fun <T> Flow<T>.onError(block: suspend (Throwable) -> Unit) = this.catch {
     block(it)

--- a/app/src/main/java/eu/darken/myperm/common/review/ReviewTool.kt
+++ b/app/src/main/java/eu/darken/myperm/common/review/ReviewTool.kt
@@ -1,0 +1,18 @@
+package eu.darken.myperm.common.review
+
+import android.app.Activity
+import kotlinx.coroutines.flow.Flow
+
+interface ReviewTool {
+
+    val state: Flow<State>
+
+    data class State(
+        val shouldAskForReview: Boolean = false,
+        val hasReviewed: Boolean = false,
+    )
+
+    suspend fun dismiss()
+
+    suspend fun reviewNow(activity: Activity)
+}

--- a/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewScreen.kt
@@ -62,6 +62,7 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.activity.compose.LocalActivity
 import androidx.hilt.navigation.compose.hiltViewModel
 import eu.darken.myperm.R
 import eu.darken.myperm.apps.ui.list.AppsFilterOptions
@@ -83,6 +84,8 @@ fun OverviewScreenHost(vm: OverviewViewModel = hiltViewModel()) {
 
     val state by vm.state.collectAsState()
     val isRefreshing by vm.isRefreshing.collectAsState()
+    // Play's review flow needs the hosting activity, and there is no guarantee one is available.
+    val activity = LocalActivity.current
 
     state?.let {
         OverviewScreen(
@@ -91,6 +94,9 @@ fun OverviewScreenHost(vm: OverviewViewModel = hiltViewModel()) {
             onRefresh = { vm.onRefresh() },
             onSettings = { vm.goToSettings() },
             onCategoryClick = { filters -> vm.onCategoryClicked(filters) },
+            onReviewNow = { activity?.let { host -> vm.onReviewNow(host) } },
+            onReviewDismiss = { vm.onReviewDismiss() },
+            canReview = activity != null,
         )
     }
 }
@@ -121,6 +127,9 @@ fun OverviewScreen(
     onRefresh: () -> Unit,
     onSettings: () -> Unit,
     onCategoryClick: (Set<AppsFilterOptions.Filter>) -> Unit = {},
+    onReviewNow: () -> Unit = {},
+    onReviewDismiss: () -> Unit = {},
+    canReview: Boolean = true,
 ) {
     val (fabVisible, scrollConnection) = rememberFabVisibility()
 
@@ -205,6 +214,13 @@ fun OverviewScreen(
                     val device = state.deviceInfo
                     if (summary != null) {
                         HeroCard(summary, device)
+                        if (state.showReviewCard) {
+                            ReviewCard(
+                                onReview = onReviewNow,
+                                onDismiss = onReviewDismiss,
+                                reviewEnabled = canReview,
+                            )
+                        }
                         SummaryList(summary, onCategoryClick)
                     }
                 }

--- a/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewViewModel.kt
+++ b/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewViewModel.kt
@@ -1,6 +1,7 @@
 package eu.darken.myperm.main.ui.overview
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.os.Build
 import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -17,6 +18,7 @@ import eu.darken.myperm.common.coroutine.DispatcherProvider
 import eu.darken.myperm.common.debug.logging.log
 import eu.darken.myperm.common.debug.logging.logTag
 import eu.darken.myperm.common.navigation.Nav
+import eu.darken.myperm.common.review.ReviewTool
 import eu.darken.myperm.common.room.entity.PkgType
 import eu.darken.myperm.common.uix.ViewModel4
 import eu.darken.myperm.common.upgrade.UpgradeRepo
@@ -24,6 +26,7 @@ import eu.darken.myperm.permissions.core.known.APerm
 import eu.darken.myperm.settings.core.GeneralSettings
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
@@ -39,6 +42,7 @@ class OverviewViewModel @Inject constructor(
     private val appRepo: AppRepo,
     private val upgradeRepo: UpgradeRepo,
     private val generalSettings: GeneralSettings,
+    private val reviewTool: ReviewTool,
 ) : ViewModel4(dispatcherProvider = dispatcherProvider) {
 
     data class DeviceInfo(
@@ -86,6 +90,7 @@ class OverviewViewModel @Inject constructor(
         val isLoading: Boolean = true,
         val scanError: Throwable? = null,
         val refreshError: Throwable? = null,
+        val showReviewCard: Boolean = false,
     )
 
     private val deviceData: Flow<DeviceInfo> = flow {
@@ -120,17 +125,23 @@ class OverviewViewModel @Inject constructor(
             .onEach { lastKnownUpgradeInfo = it }
             .onStart { emit(lastKnownUpgradeInfo) },
         appRepo.scanError,
-    ) { device, summary, upgrade, scanError ->
+        // A broken review tool must not take the dashboard down with it.
+        reviewTool.state.catch { emit(ReviewTool.State()) },
+    ) { device, summary, upgrade, scanError, review ->
         val hasData = summary != null
+        // Blocking: no data AND scan failed → error screen takes over.
+        val blockingError = if (!hasData) scanError else null
+        // Non-blocking: have data AND latest refresh failed → inline banner.
+        val inlineError = if (hasData) scanError else null
         State(
             deviceInfo = device,
             summaryInfo = summary,
             upgradeInfo = upgrade,
-            // Blocking: no data AND scan failed → error screen takes over.
-            scanError = if (!hasData) scanError else null,
-            // Non-blocking: have data AND latest refresh failed → inline banner.
-            refreshError = if (hasData) scanError else null,
+            scanError = blockingError,
+            refreshError = inlineError,
             isLoading = !hasData && scanError == null,
+            // Asking for a review while the screen is showing a failure is bad timing.
+            showReviewCard = review.shouldAskForReview && blockingError == null && inlineError == null,
         )
     }.asStateFlow()
 
@@ -214,6 +225,16 @@ class OverviewViewModel @Inject constructor(
 
     fun goToSettings() {
         navTo(Nav.Settings.Index)
+    }
+
+    fun onReviewNow(activity: Activity) = launch {
+        log(TAG) { "onReviewNow($activity)" }
+        reviewTool.reviewNow(activity)
+    }
+
+    fun onReviewDismiss() = launch {
+        log(TAG) { "onReviewDismiss()" }
+        reviewTool.dismiss()
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/myperm/main/ui/overview/ReviewCard.kt
+++ b/app/src/main/java/eu/darken/myperm/main/ui/overview/ReviewCard.kt
@@ -1,0 +1,80 @@
+package eu.darken.myperm.main.ui.overview
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import eu.darken.myperm.R
+import eu.darken.myperm.common.compose.PermPilotMascot
+import eu.darken.myperm.common.compose.Preview2
+import eu.darken.myperm.common.compose.PreviewWrapper
+
+@Composable
+internal fun ReviewCard(
+    onReview: () -> Unit,
+    onDismiss: () -> Unit,
+    reviewEnabled: Boolean = true,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        ),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                PermPilotMascot(size = 40.dp)
+                Text(
+                    text = stringResource(R.string.review_app_body),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+            }
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.End,
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text(text = stringResource(R.string.review_app_dismiss_action))
+                }
+                Button(
+                    onClick = onReview,
+                    enabled = reviewEnabled,
+                ) {
+                    Text(text = stringResource(R.string.review_app_review_action))
+                }
+            }
+        }
+    }
+}
+
+@Preview2
+@Composable
+private fun ReviewCardPreview() = PreviewWrapper {
+    ReviewCard(
+        onReview = {},
+        onDismiss = {},
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -788,4 +788,8 @@
         <item quantity="other">Free version is limited to %d items and Markdown format. Upgrade for unlimited exports and all formats.</item>
     </plurals>
     <string name="export_upgrade_action">Upgrade</string>
+
+    <string name="review_app_body">Would you like to leave Permission Pilot a review? ❤️</string>
+    <string name="review_app_review_action">Review</string>
+    <string name="review_app_dismiss_action">Maybe later</string>
 </resources>

--- a/app/src/test/java/eu/darken/myperm/main/ui/overview/OverviewViewModelTest.kt
+++ b/app/src/test/java/eu/darken/myperm/main/ui/overview/OverviewViewModelTest.kt
@@ -2,15 +2,18 @@ package eu.darken.myperm.main.ui.overview
 
 import androidx.lifecycle.SavedStateHandle
 import eu.darken.myperm.apps.core.AppRepo
+import eu.darken.myperm.common.review.ReviewTool
 import eu.darken.myperm.common.upgrade.UpgradeRepo
 import eu.darken.myperm.settings.core.GeneralSettings
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
@@ -64,6 +67,10 @@ class OverviewViewModelTest : BaseTest() {
     private val upgradeRepo: UpgradeRepo = mockk(relaxed = true)
     private val generalSettings: GeneralSettings = mockk(relaxed = true)
 
+    // Never relaxed: a relaxed `state` would hand the combine an empty flow, and the whole render
+    // state would silently stop being computed.
+    private val reviewTool: ReviewTool = mockk()
+
     @Before
     fun setup() {
         Dispatchers.setMain(testDispatcher)
@@ -72,6 +79,7 @@ class OverviewViewModelTest : BaseTest() {
         every { appRepo.isScanning } returns MutableStateFlow(false)
         every { appRepo.scanError } returns MutableStateFlow<Throwable?>(null)
         every { upgradeRepo.upgradeInfo } returns upgradeInfoFlow
+        every { reviewTool.state } returns flowOf(ReviewTool.State())
     }
 
     @After
@@ -85,6 +93,7 @@ class OverviewViewModelTest : BaseTest() {
         appRepo = appRepo,
         upgradeRepo = upgradeRepo,
         generalSettings = generalSettings,
+        reviewTool = reviewTool,
     )
 
     @Test
@@ -109,5 +118,32 @@ class OverviewViewModelTest : BaseTest() {
         vm.state.value?.upgradeInfo?.isPro shouldBe true
 
         secondCollector.cancel()
+    }
+
+    @Test
+    fun `a refresh failure suppresses the review card`() = runTest(testDispatcher) {
+        every { reviewTool.state } returns flowOf(ReviewTool.State(shouldAskForReview = true))
+
+        // Non-vacuity: without an error the same eligibility does show the card.
+        createVM().let { vm ->
+            val subscription = launch { vm.state.collect { } }
+            advanceUntilIdle()
+            vm.state.value?.showReviewCard shouldBe true
+            subscription.cancel()
+        }
+
+        // Data plus a failed refresh: the screen carries an inline error banner, which is the wrong
+        // moment to ask the user for a five star rating.
+        every { appRepo.scanError } returns MutableStateFlow<Throwable?>(IllegalStateException("scan failed"))
+
+        createVM().let { vm ->
+            val subscription = launch { vm.state.collect { } }
+            advanceUntilIdle()
+            vm.state.value!!.apply {
+                refreshError shouldNotBe null
+                showReviewCard shouldBe false
+            }
+            subscription.cancel()
+        }
     }
 }

--- a/app/src/test/java/eu/darken/myperm/main/ui/overview/ReviewCardTest.kt
+++ b/app/src/test/java/eu/darken/myperm/main/ui/overview/ReviewCardTest.kt
@@ -1,0 +1,93 @@
+package eu.darken.myperm.main.ui.overview
+
+import android.content.Context
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.myperm.R
+import eu.darken.myperm.common.compose.PreviewWrapper
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+class ReviewCardTest : BaseComposeRobolectricTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private fun string(id: Int): String = context.getString(id)
+
+    private fun show(
+        reviewEnabled: Boolean = true,
+        onReview: () -> Unit = {},
+        onDismiss: () -> Unit = {},
+    ) {
+        composeRule.setContent {
+            PreviewWrapper {
+                ReviewCard(
+                    onReview = onReview,
+                    onDismiss = onDismiss,
+                    reviewEnabled = reviewEnabled,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `the card offers both the review and the maybe later action`() {
+        show()
+
+        composeRule.onNodeWithText(string(R.string.review_app_body)).assertIsDisplayed()
+        composeRule.onNodeWithText(string(R.string.review_app_review_action)).assertIsDisplayed()
+        composeRule.onNodeWithText(string(R.string.review_app_dismiss_action)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `tapping review invokes the review callback`() {
+        var reviews = 0
+        var dismisses = 0
+        show(onReview = { reviews++ }, onDismiss = { dismisses++ })
+
+        composeRule.onNodeWithText(string(R.string.review_app_review_action)).performClick()
+
+        composeRule.runOnIdle {
+            reviews shouldBe 1
+            dismisses shouldBe 0
+        }
+    }
+
+    @Test
+    fun `tapping maybe later invokes the dismiss callback`() {
+        var reviews = 0
+        var dismisses = 0
+        show(onReview = { reviews++ }, onDismiss = { dismisses++ })
+
+        composeRule.onNodeWithText(string(R.string.review_app_dismiss_action)).performClick()
+
+        composeRule.runOnIdle {
+            dismisses shouldBe 1
+            reviews shouldBe 0
+        }
+    }
+
+    @Test
+    fun `without a hosting activity the review action is disabled`() {
+        // Play's flow needs an activity, so the host disables the action when it has none. Maybe
+        // later stays available: dismissing is purely local bookkeeping.
+        var reviews = 0
+        var dismisses = 0
+        show(reviewEnabled = false, onReview = { reviews++ }, onDismiss = { dismisses++ })
+
+        composeRule.onNodeWithText(string(R.string.review_app_review_action)).assertIsNotEnabled()
+        composeRule.onNodeWithText(string(R.string.review_app_review_action)).performClick()
+        composeRule.onNodeWithText(string(R.string.review_app_dismiss_action)).assertIsEnabled()
+
+        composeRule.runOnIdle {
+            reviews shouldBe 0
+            dismisses shouldBe 0
+        }
+    }
+}

--- a/app/src/testGplay/java/eu/darken/myperm/common/review/GplayReviewToolTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/review/GplayReviewToolTest.kt
@@ -19,11 +19,13 @@ import io.mockk.verify
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.SerializationException
 import org.junit.jupiter.api.Test
 import testhelper.BaseTest
 import testhelper.coroutine.runTest2
@@ -246,6 +248,30 @@ class GplayReviewToolTest : BaseTest() {
         verify(exactly = 0) { manager.launchReviewFlow(any(), any()) }
         coVerify(exactly = 0) { lastDismissedMock.value(any()) }
         coVerify(exactly = 0) { reviewedAtMock.value(any()) }
+    }
+
+    @Test fun `a settings read that throws does not take the app down`() = runTest2 {
+        // A stored timestamp that can't be decoded (see ReviewSettingsTest) surfaces as a throwing
+        // settings flow. Without a catch upstream of the shares it would kill the sharing coroutine
+        // on AppScope, which has no exception handler, and never reach any collector.
+        val corrupt = mockk<DataStoreValue<Instant?>>(relaxed = true).apply {
+            every { flow } returns flow { throw SerializationException("undecodable timestamp") }
+        }
+        every { settings.lastDismissed } returns corrupt
+        every { settings.reviewedAt } returns rwSetting(null)
+        val upgradeInfo = mockk<UpgradeRepo.Info>()
+        every { upgradeInfo.upgradedAt } returns Instant.now().minus(Duration.ofDays(30))
+        every { upgradeRepo.upgradeInfo } returns flowOf(upgradeInfo)
+        val tool = GplayReviewTool(
+            appScope = backgroundScope,
+            settings = settings,
+            manager = manager,
+            upgradeRepo = upgradeRepo,
+        )
+
+        tool.computedState() shouldBe ReviewTool.State()
+
+        verify(exactly = 0) { manager.requestReviewFlow() }
     }
 
     @Test fun `cancellation during the probe is not swallowed into the retry path`() = runTest2 {

--- a/app/src/testGplay/java/eu/darken/myperm/common/review/GplayReviewToolTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/review/GplayReviewToolTest.kt
@@ -1,0 +1,263 @@
+package eu.darken.myperm.common.review
+
+import android.app.Activity
+import com.google.android.gms.tasks.OnFailureListener
+import com.google.android.gms.tasks.OnSuccessListener
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
+import com.google.android.play.core.review.ReviewInfo
+import com.google.android.play.core.review.ReviewManager
+import eu.darken.myperm.common.datastore.DataStoreValue
+import eu.darken.myperm.common.upgrade.UpgradeRepo
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.jupiter.api.Test
+import testhelper.BaseTest
+import testhelper.coroutine.runTest2
+import java.time.Duration
+import java.time.Instant
+
+class GplayReviewToolTest : BaseTest() {
+
+    private val manager = mockk<ReviewManager>()
+    private val settings = mockk<ReviewSettings>()
+    private val upgradeRepo = mockk<UpgradeRepo>()
+    private lateinit var lastDismissedMock: DataStoreValue<Instant?>
+    private lateinit var reviewedAtMock: DataStoreValue<Instant?>
+
+    // Relaxed so the `.value(new)` writes succeed. `value` is a member function here, so the mock
+    // answers it directly — the persistence assertions verify `value(...)`, not the `update` it
+    // would delegate to on a real DataStoreValue.
+    private fun <T> rwSetting(initial: T): DataStoreValue<T> = mockk<DataStoreValue<T>>(relaxed = true).apply {
+        every { flow } returns flowOf(initial)
+    }
+
+    // The tool's own scope has to run on the test scheduler, otherwise the probe backoff and the
+    // state throttle would burn real time.
+    private fun TestScope.tool(
+        upgradedAt: Instant? = Instant.now().minus(Duration.ofDays(30)),
+        lastDismissed: Instant? = null,
+        reviewedAt: Instant? = null,
+    ): GplayReviewTool {
+        lastDismissedMock = rwSetting(lastDismissed)
+        reviewedAtMock = rwSetting(reviewedAt)
+        every { settings.lastDismissed } returns lastDismissedMock
+        every { settings.reviewedAt } returns reviewedAtMock
+
+        val upgradeInfo = mockk<UpgradeRepo.Info>()
+        every { upgradeInfo.upgradedAt } returns upgradedAt
+        every { upgradeRepo.upgradeInfo } returns flowOf(upgradeInfo)
+
+        return GplayReviewTool(
+            appScope = backgroundScope,
+            settings = settings,
+            manager = manager,
+            upgradeRepo = upgradeRepo,
+        ).apply { probeRetryDelay = Duration.ofSeconds(1) }
+    }
+
+    private fun reviewInfo(canShow: Boolean = true): ReviewInfo {
+        val info = mockk<ReviewInfo>()
+        // There is no public accessor for the isNoOp flag, the tool sniffs the toString().
+        every { info.toString() } returns when {
+            canShow -> "ReviewInfo{pendingIntent=PendingIntent{1}, isNoOp=false}"
+            else -> "ReviewInfo{pendingIntent=null, isNoOp=true}"
+        }
+        return info
+    }
+
+    private fun activity(finishing: Boolean = false, destroyed: Boolean = false) = mockk<Activity>().apply {
+        every { isFinishing } returns finishing
+        every { isDestroyed } returns destroyed
+    }
+
+    private fun launchOk(): Task<Void?> = Tasks.forResult(null)
+
+    // The `onStart` seed is not a computed state, every assertion has to await the first real one.
+    private suspend fun GplayReviewTool.computedState() = state.drop(1).first()
+
+    @Test fun `an eligible user is asked for a review`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+
+        tool().computedState().apply {
+            shouldAskForReview shouldBe true
+            hasReviewed shouldBe false
+        }
+    }
+
+    @Test fun `a user who has not paid for pro long enough is never probed`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+
+        tool(upgradedAt = Instant.now().minus(Duration.ofDays(3)))
+            .computedState().shouldAskForReview shouldBe false
+
+        // Eligibility is decided locally first: Play's request quota is only spent on candidates.
+        verify(exactly = 0) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `a recently dismissed card is not shown again`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+
+        tool(lastDismissed = Instant.now().minus(Duration.ofDays(3)))
+            .computedState().shouldAskForReview shouldBe false
+
+        verify(exactly = 0) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `reviewNow launches with a freshly requested ReviewInfo`() = runTest2 {
+        // ReviewInfo is short lived, the token used for the launch must not be the one the
+        // availability probe obtained (potentially hours) earlier.
+        val probeInfo = reviewInfo()
+        val freshInfo = reviewInfo()
+        every { manager.requestReviewFlow() } returnsMany listOf(
+            Tasks.forResult(probeInfo),
+            Tasks.forResult(freshInfo),
+        )
+        every { manager.launchReviewFlow(any(), any()) } returns launchOk()
+        val tool = tool()
+        val activity = activity()
+
+        tool.computedState().shouldAskForReview shouldBe true
+        tool.reviewNow(activity)
+
+        verify(exactly = 2) { manager.requestReviewFlow() }
+        verify(exactly = 1) { manager.launchReviewFlow(activity, freshInfo) }
+        verify(exactly = 0) { manager.launchReviewFlow(activity, probeInfo) }
+    }
+
+    @Test fun `a failed fresh request keeps the card and persists nothing`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forException(RuntimeException("Play unavailable"))
+        val tool = tool()
+
+        tool.reviewNow(activity())
+
+        verify(exactly = 0) { manager.launchReviewFlow(any(), any()) }
+        // A transient failure is not user intent, the next tap has to be able to retry.
+        coVerify(exactly = 0) { lastDismissedMock.value(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.value(any()) }
+    }
+
+    @Test fun `a fresh isNoOp answer snoozes the card`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo(canShow = false))
+        val tool = tool()
+
+        tool.reviewNow(activity())
+
+        verify(exactly = 0) { manager.launchReviewFlow(any(), any()) }
+        // isNoOp is Play's quota verdict, asking again right away would be pointless.
+        coVerify(exactly = 1) { lastDismissedMock.value(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.value(any()) }
+    }
+
+    @Test fun `a failed launch persists nothing and does not escape`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        every { manager.launchReviewFlow(any(), any()) } returns Tasks.forException(RuntimeException("launch failed"))
+        val tool = tool()
+
+        tool.reviewNow(activity())
+
+        coVerify(exactly = 0) { lastDismissedMock.value(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.value(any()) }
+    }
+
+    @Test fun `a dead activity aborts the launch without persisting`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        every { manager.launchReviewFlow(any(), any()) } returns launchOk()
+        val tool = tool()
+
+        // The fresh request is a Play round-trip, the activity can be gone by the time it returns.
+        tool.reviewNow(activity(finishing = true))
+
+        verify(exactly = 0) { manager.launchReviewFlow(any(), any()) }
+        coVerify(exactly = 0) { lastDismissedMock.value(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.value(any()) }
+    }
+
+    @Test fun `overlapping reviewNow calls launch the flow only once`() = runTest2 {
+        // Park the first call on an unresolved Play request, so the second genuinely overlaps it.
+        val successListener = slot<OnSuccessListener<in ReviewInfo>>()
+        val pendingRequest = mockk<Task<ReviewInfo>>().apply {
+            every { isComplete } returns false
+            every { addOnSuccessListener(capture(successListener)) } returns this
+            every { addOnFailureListener(any<OnFailureListener>()) } returns this
+        }
+        every { manager.requestReviewFlow() } returnsMany listOf(
+            pendingRequest,
+            // A second request would resolve instantly, so a broken guard shows up as a launch.
+            Tasks.forResult(reviewInfo()),
+        )
+        every { manager.launchReviewFlow(any(), any()) } returns launchOk()
+        val tool = tool()
+        val activity = activity()
+
+        val first = launch { tool.reviewNow(activity) }
+        advanceUntilIdle()
+
+        tool.reviewNow(activity)
+
+        successListener.captured.onSuccess(reviewInfo())
+        first.join()
+
+        // Without the single-flight guard the second tap would run its own request+launch, and
+        // Play's flow would pop up again the moment the user returned from the first one.
+        verify(exactly = 1) { manager.requestReviewFlow() }
+        verify(exactly = 1) { manager.launchReviewFlow(any(), any()) }
+    }
+
+    @Test fun `a probe that fails once still resolves within the retry budget`() = runTest2 {
+        every { manager.requestReviewFlow() } returnsMany listOf(
+            Tasks.forException(RuntimeException("Play unavailable")),
+            Tasks.forResult(reviewInfo()),
+        )
+
+        tool().computedState().shouldAskForReview shouldBe true
+
+        verify(exactly = 2) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `a probe that keeps failing hides the card`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forException(RuntimeException("Play unavailable"))
+
+        tool().computedState().shouldAskForReview shouldBe false
+
+        verify(exactly = 3) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `cancellation during reviewNow is not swallowed`() = runTest2 {
+        every { manager.requestReviewFlow() } throws CancellationException("scope died")
+        val tool = tool()
+
+        shouldThrow<CancellationException> { tool.reviewNow(activity()) }
+
+        // A cancelled coroutine is not a Play failure: no launch, no bookkeeping.
+        verify(exactly = 0) { manager.launchReviewFlow(any(), any()) }
+        coVerify(exactly = 0) { lastDismissedMock.value(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.value(any()) }
+    }
+
+    @Test fun `cancellation during the probe is not swallowed into the retry path`() = runTest2 {
+        every { manager.requestReviewFlow() } throws CancellationException("scope died")
+        val tool = tool()
+
+        // Cancellation takes the probe down with its scope, no verdict is ever computed (virtual
+        // time, so the timeout costs nothing).
+        val computed = withTimeoutOrNull(Duration.ofMinutes(1).toMillis()) { tool.computedState() }
+
+        computed shouldBe null
+        // The general failure path would have burned all 3 attempts and settled on "unavailable".
+        verify(exactly = 1) { manager.requestReviewFlow() }
+    }
+}

--- a/app/src/testGplay/java/eu/darken/myperm/common/review/ReviewSettingsTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/review/ReviewSettingsTest.kt
@@ -1,0 +1,118 @@
+package eu.darken.myperm.common.review
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.test.core.app.ApplicationProvider
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelper.BaseTest
+import testhelpers.TestApplication
+import java.time.Instant
+import java.time.format.DateTimeParseException
+
+/**
+ * Real DataStore, no mocks: the injected [Json] carries no serializers module, so the timestamps are
+ * wired to the ISO serializer by hand — an encode/decode mismatch would only show up on the first
+ * real write.
+ *
+ * One [ReviewSettings] per test method: the production settings object is a `@Singleton` whose
+ * DataStore scope is never cancelled, and a second instance on the same file fails DataStore's
+ * multi-instance check. What a fresh process would read is covered by going through the raw
+ * preference entry instead — writes are asserted on the stored string, reads are fed one.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class ReviewSettingsTest : BaseTest() {
+
+    private val json = Json {
+        encodeDefaults = true
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
+
+    private fun settings() = ReviewSettings(ApplicationProvider.getApplicationContext<Context>(), json)
+
+    private val dismissedKey = stringPreferencesKey("review.dismissedAt")
+
+    @Test
+    fun `an unwritten timestamp reads as null`() = runTest {
+        withContext(Dispatchers.IO) {
+            val settings = settings()
+
+            settings.lastDismissed.value() shouldBe null
+            settings.reviewedAt.value() shouldBe null
+        }
+    }
+
+    @Test
+    fun `a written timestamp is stored as an ISO string`() = runTest {
+        withContext(Dispatchers.IO) {
+            val settings = settings()
+            val stamp = Instant.parse("2026-08-05T12:34:56.789Z")
+
+            settings.lastDismissed.value(stamp)
+
+            settings.lastDismissed.value() shouldBe stamp
+            // What a fresh process would find on disk: the ISO text, not a numeric epoch.
+            settings.dataStore.data.first()[dismissedKey] shouldBe "\"2026-08-05T12:34:56.789Z\""
+            // The two keys are independent.
+            settings.reviewedAt.value() shouldBe null
+        }
+    }
+
+    @Test
+    fun `a stored ISO string is read back as an Instant`() = runTest {
+        withContext(Dispatchers.IO) {
+            val settings = settings()
+            // What a previous process left behind.
+            settings.dataStore.edit { it[dismissedKey] = "\"2026-08-05T12:34:56.789Z\"" }
+
+            settings.lastDismissed.value() shouldBe Instant.parse("2026-08-05T12:34:56.789Z")
+        }
+    }
+
+    @Test
+    fun `a value written back over an existing one replaces it`() = runTest {
+        withContext(Dispatchers.IO) {
+            val settings = settings()
+
+            settings.reviewedAt.value(Instant.parse("2026-01-01T00:00:00Z"))
+            settings.reviewedAt.value(Instant.parse("2026-02-02T00:00:00Z"))
+
+            settings.reviewedAt.value() shouldBe Instant.parse("2026-02-02T00:00:00Z")
+        }
+    }
+
+    @Test
+    fun `an unparsable stored string fails the read`() = runTest {
+        withContext(Dispatchers.IO) {
+            val settings = settings()
+            settings.dataStore.edit { it[dismissedKey] = "not-even-json" }
+
+            // Deliberately not a fallback-to-default: a timestamp we cannot read is not the same as
+            // "never dismissed", and defaulting would silently re-ask the user forever.
+            shouldThrow<SerializationException> { settings.lastDismissed.value() }
+        }
+    }
+
+    @Test
+    fun `a stored string that is not a timestamp fails the read`() = runTest {
+        withContext(Dispatchers.IO) {
+            val settings = settings()
+            settings.dataStore.edit { it[dismissedKey] = "\"yesterday\"" }
+
+            shouldThrow<DateTimeParseException> { settings.lastDismissed.value() }
+        }
+    }
+}


### PR DESCRIPTION
## What changed

Permission Pilot can now ask satisfied Pro users for a Play Store review. Users who have been Pro for more than 3 weeks may see a small card on the overview (with the mascot) asking for a review — only while the screen shows no errors. "Review" opens Google Play's own in-app review sheet, "Maybe later" hides the card for two weeks, and once a review was left the card never returns. FOSS builds are unaffected.

## Technical Context

- Port of SD Maid SE's review-prompt design (the fleet's canonical implementation): `ReviewTool` interface with a FOSS no-op and a gplay implementation; the donor's `throttleLatest` flow util comes along into `FlowExtensions.kt`.
- Eligibility is computed locally first; Play is only probed for eligible users (quota-friendly), and the launch always requests a fresh `ReviewInfo`.
- Review timestamps persist as ISO strings through the app's `InstantSerializer` wired via the explicit reader/writer `createValue` overload — the project `Json` has no serializers module, so the reified path would fail on the first write (caught in plan review; pinned by a real-DataStore round-trip test).
- Hardened beyond the donor: corrupt review preferences used to terminate the shared state flow inside the app scope (a process crash no downstream `catch` can intercept — reproduced in a regression test); the tool now fails closed upstream of `replayingShare`. This fix is scheduled for backport to the donor.
- Test note: the donor test suite's write verifications target `update()`, which is vacuous here because this repo's `DataStoreValue.value()` is a member (not an extension) — the ported tests verify `value()` instead.
- Strings are English-only for now and join the next translation pass. On the release carrying this, every Pro user past the 21-day mark becomes eligible at once — a one-time wave of review cards is expected.
