### PR TITLE
General: Update translations from Crowdin

### DIFF
--- a/app/src/foss/res/values-fr/strings.xml
+++ b/app/src/foss/res/values-fr/strings.xml
@@ -21,5 +21,6 @@
     <string name="upgrade_screen_title">Soutenir Permission Pilot</string>
     <string name="upgrade_screen_why_title">Avantages de la mise à niveau</string>
     <string name="upgrade_screen_how_title">Comment aider</string>
+    <string name="upgrade_screen_how_body">Devenez mécène et soutenez le développement. Touchez le bouton ci-dessous pour activer toutes les fonctions supplémentaires et ouvrir mon profil GitHub Sponsors.</string>
     <string name="upgrade_screen_thanks_toast">Merci de soutenir le développement des logiciels libres ❤️</string>
 </resources>

--- a/app/src/foss/res/values-ro/strings.xml
+++ b/app/src/foss/res/values-ro/strings.xml
@@ -21,5 +21,6 @@
     <string name="upgrade_screen_title">Susțineți Permission Pilot</string>
     <string name="upgrade_screen_why_title">Beneficiile upgrade-ului</string>
     <string name="upgrade_screen_how_title">Cum să ajuți</string>
+    <string name="upgrade_screen_how_body">Devino patron și sponsorizează dezvoltarea! Apasă butonul de mai jos pentru a activa toate caracteristicile suplimentare și deschide profilul meu GitHub Sponsors.</string>
     <string name="upgrade_screen_thanks_toast">Mulțumim pentru susținerea dezvoltării open-source ❤️</string>
 </resources>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -74,7 +74,7 @@
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">El Permission Pilot no es pot connectar al Google Play. El Google Play està instal·lat i actualitzat? Heu iniciat la sessió al vostre compte de Google? Proveu d\'esborrar la memòria cau de l\'aplicació Google Play i reinicieu el dispositiu.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
-    <string name="upgrades_gplay_not_installed_message">No s\'ha pogut obrir Google Play. Pot ser que manqui, estigui desactivat o restringit en aquest dispositiu.</string>
+    <string name="upgrades_gplay_not_installed_message">No s\'ha pogut obrir el Google Play. Pot ser que no estigui disponible, estigui desactivat o restringit en aquest dispositiu.</string>
     <string name="upgrades_gplay_billing_error_label">Problema del Google Play</string>
     <string name="upgrades_gplay_billing_error_description">S\'ha produït un problema amb el Google Play. Torneu-ho a provar més tard o reinicieu el dispositiu.\n\nDetalls: %s</string>
     <string name="upgrades_gplay_internal_error_title">Error del Google Play</string>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -74,7 +74,7 @@
     <!-- Billing error descriptions -->
     <string name="upgrades_gplay_unavailable_error_description">Pilot uprawnień nie może połączyć się z Google Play. Czy Google Play jest zainstalowany i aktualny? Czy Twoje konto Google jest zalogowane? Spróbuj wyczyścić pamięć podręczną aplikacji Google Play i zrestartować urządzenie.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
-    <string name="upgrades_gplay_not_installed_message">Nie można otworzyć Google Play. Aplikacja może być niedostępna, wyłączona lub ograniczona na tym urządzeniu.</string>
+    <string name="upgrades_gplay_not_installed_message">Nie można otworzyć Sklepu Google Play. Aplikacja może być niedostępna, wyłączona lub ograniczona na tym urządzeniu.</string>
     <string name="upgrades_gplay_billing_error_label">Problem z Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Wystąpił problem z Google Play. Spróbuj ponownie później lub zrestartuj urządzenie.\n\nSzczegóły: %s</string>
     <string name="upgrades_gplay_internal_error_title">Błąd Google Play</string>

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -741,4 +741,7 @@
         <item quantity="other">Gratis weergawe is beperk tot %d items en Markdown-formaat. Gradeer op vir onbeperkte uitvoere en alle formate.</item>
     </plurals>
     <string name="export_upgrade_action">Opgradeer</string>
+    <string name="review_app_body">Wil jy Permission Pilot \'n resensie gee? ❤️</string>
+    <string name="review_app_review_action">Hersien</string>
+    <string name="review_app_dismiss_action">Miskien later</string>
 </resources>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -741,4 +741,7 @@
         <item quantity="other">ነፃ ስሪት ወደ %d ንጥሎች እና Markdown ቅርጸት ብቻ የተወሰነ ነው። ያልተወሰነ ወደ ውጭ መላክ እና ሁሉም ቅርጸቶች ለማግኘት ያሻሽሉ።</item>
     </plurals>
     <string name="export_upgrade_action">አሻሽል</string>
+    <string name="review_app_body">Permission Pilot ላይ ገምገም ሊተወት ይፈልጋሉ? ❤️</string>
+    <string name="review_app_review_action">ግምገማ</string>
+    <string name="review_app_dismiss_action">ምናልባት በኋላ</string>
 </resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -885,4 +885,7 @@
         <item quantity="other">النسخة المجانية محدودة بـ %d عنصر وتنسيق Markdown. قم بالترقية للحصول على صادرات غير محدودة وجميع التنسيقات.</item>
     </plurals>
     <string name="export_upgrade_action">ترقية</string>
+    <string name="review_app_body">هل تود ترك تقييم لـ Permission Pilot؟ ❤️</string>
+    <string name="review_app_review_action">مراجعة</string>
+    <string name="review_app_dismiss_action">ربما لاحقًا</string>
 </resources>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -741,4 +741,7 @@
         <item quantity="other">Pulsuz versiya %d elementlə və Markdown formatı ilə məhdudlaşır. Limitsiz ixrac və bütün formatlar üçün yüksəldin.</item>
     </plurals>
     <string name="export_upgrade_action">Yüksəlt</string>
+    <string name="review_app_body">Permission Pilot\'a bir rəy yazmaq istər misin? ❤️</string>
+    <string name="review_app_review_action">Baxış</string>
+    <string name="review_app_dismiss_action">Bəlkə sonra</string>
 </resources>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -813,4 +813,7 @@
         <item quantity="other">Бясплатная версія абмежавана %d элементамі і фарматам Markdown. Абновіцеся для неабмежаванага экспарту і ўсіх фарматаў.</item>
     </plurals>
     <string name="export_upgrade_action">Абнавіць</string>
+    <string name="review_app_body">Ты б хацел пакінуць рэцэнзію для Permission Pilot? ❤️</string>
+    <string name="review_app_review_action">Водгук</string>
+    <string name="review_app_dismiss_action">Магчыма пазней</string>
 </resources>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -741,4 +741,7 @@
         <item quantity="other">Безплатната версия е ограничена до %d елемента и формат Markdown. Надградете за неограничен брой експортирания и всички формати.</item>
     </plurals>
     <string name="export_upgrade_action">Надграждане</string>
+    <string name="review_app_body">Искате ли да оставите отзив на Permission Pilot? ❤️</string>
+    <string name="review_app_review_action">Преглед</string>
+    <string name="review_app_dismiss_action">Може би по-късно</string>
 </resources>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -741,4 +741,7 @@
         <item quantity="other">বিনামূল্যে সংস্করণ %d আইটেমে এবং Markdown ফরম্যাটে সীমাবদ্ধ। সীমাহীন এক্সপোর্ট এবং সব ফরম্যাটের জন্য আপগ্রেড করুন।</item>
     </plurals>
     <string name="export_upgrade_action">আপগ্রেড করুন</string>
+    <string name="review_app_body">আপনি কি Permission Pilot কে একটি রিভিউ দিতে চান? ❤️</string>
+    <string name="review_app_review_action">পর্যালোচনা করুন</string>
+    <string name="review_app_dismiss_action">হয়তো পরে</string>
 </resources>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -741,4 +741,7 @@
         <item quantity="other">La versió gratuïta està limitada a %d elements i al format Markdown. Actualitzeu per a exportacions il·limitades i tots els formats.</item>
     </plurals>
     <string name="export_upgrade_action">Millora</string>
+    <string name="review_app_body">T\'agradaria deixar una ressenya de Permission Pilot? ❤️</string>
+    <string name="review_app_review_action">Revisió</string>
+    <string name="review_app_dismiss_action">Potser més tard</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -813,4 +813,7 @@
         <item quantity="other">Bezplatná verze je omezena na %d položek a formát Markdown. Upgradujte pro neomezený export a všechny formáty.</item>
     </plurals>
     <string name="export_upgrade_action">Upgradovat</string>
+    <string name="review_app_body">Chceš napsat recenzi na Permission Pilot? ❤️</string>
+    <string name="review_app_review_action">Ohodnotit</string>
+    <string name="review_app_dismiss_action">Možná později</string>
 </resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -741,4 +741,7 @@
         <item quantity="other">Gratisversionen er begrænset til %d elementer og Markdown-format. Opgrader for ubegrænsede eksporter og alle formater.</item>
     </plurals>
     <string name="export_upgrade_action">Opgrader</string>
+    <string name="review_app_body">Vil du gerne give Permission Pilot en anmeldelse? ❤️</string>
+    <string name="review_app_review_action">Bedøm</string>
+    <string name="review_app_dismiss_action">Måske senere</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -741,4 +741,7 @@
         <item quantity="other">Die kostenlose Version ist auf %d Elemente und das Markdown-Format beschränkt. Upgrade für unbegrenzte Exporte und alle Formate.</item>
     </plurals>
     <string name="export_upgrade_action">Upgrade</string>
+    <string name="review_app_body">Möchtest du Permission Pilot bewerten? ❤️</string>
+    <string name="review_app_review_action">Bewerten</string>
+    <string name="review_app_dismiss_action">Vielleicht später</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -562,6 +562,7 @@
     <string name="upgrade_benefit_monitoring">Παρακολούθηση αδειών</string>
     <string name="upgrade_benefit_support">Υποστήριξη του δημιουργού</string>
     <string name="upgrade_benefit_manifest_viewer">Περιήγηση σε raw manifests εφαρμογών</string>
+    <string name="general_navigate_up_action">Πάνω</string>
     <string name="general_progress_loading">Φόρτωση…</string>
     <string name="general_upgrade_action">Αναβάθμιση</string>
     <string name="general_copy_action">Αντιγραφή</string>
@@ -740,4 +741,7 @@
         <item quantity="other">Η δωρεάν έκδοση περιορίζεται σε %d στοιχεία και μορφή Markdown. Αναβαθμίστε για απεριόριστες εξαγωγές και όλες τις μορφές.</item>
     </plurals>
     <string name="export_upgrade_action">Αναβάθμιση</string>
+    <string name="review_app_body">Θα ήθελες να αφήσεις μια κριτική στο Permission Pilot? ❤️</string>
+    <string name="review_app_review_action">Αξιολόγηση</string>
+    <string name="review_app_dismiss_action">Ίσως αργότερα</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -741,4 +741,7 @@
         <item quantity="other">La versión gratuita está limitada a %d elementos y formato Markdown. Actualiza para exportaciones ilimitadas y todos los formatos.</item>
     </plurals>
     <string name="export_upgrade_action">Actualizar</string>
+    <string name="review_app_body">¿Te gustaría dejar una reseña de Permission Pilot? ❤️</string>
+    <string name="review_app_review_action">Revisar</string>
+    <string name="review_app_dismiss_action">Quizás más tarde</string>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -741,4 +741,7 @@
         <item quantity="other">Ilmainen versio on rajoitettu %d kohteeseen ja Markdown-muotoon. Päivitä rajoittamattomiin vienteihin ja kaikkiin muotoihin.</item>
     </plurals>
     <string name="export_upgrade_action">Päivitä</string>
+    <string name="review_app_body">Haluaisitko jättää arvostelun Permission Pilotille? ❤️</string>
+    <string name="review_app_review_action">Arvostele</string>
+    <string name="review_app_dismiss_action">Ehkä myöhemmin</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -742,4 +742,7 @@
         <item quantity="other">La version gratuite est limitée à %d éléments et au format Markdown. Passez à la version supérieure pour des exportations illimitées et tous les formats.</item>
     </plurals>
     <string name="export_upgrade_action">Passer Pro</string>
+    <string name="review_app_body">Aimerais-tu laisser un avis pour Permission Pilot ? ❤️</string>
+    <string name="review_app_review_action">Évaluation</string>
+    <string name="review_app_dismiss_action">Plus tard, peut-être</string>
 </resources>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -741,4 +741,7 @@
         <item quantity="other">निःशुल्क संस्करण %d आइटम और Markdown फ़ॉर्मेट तक सीमित है। असीमित निर्यात और सभी फ़ॉर्मेट के लिए अपग्रेड करें।</item>
     </plurals>
     <string name="export_upgrade_action">उन्नत करें</string>
+    <string name="review_app_body">क्या आप Permission Pilot को एक समीक्षा देना चाहेंगे? ❤️</string>
+    <string name="review_app_review_action">समीक्षा करें</string>
+    <string name="review_app_dismiss_action">शायद बाद में</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -777,4 +777,7 @@
         <item quantity="other">Besplatna verzija ograničena je na %d stavki i Markdown format. Nadogradite za neograničeni izvoz i sve formate.</item>
     </plurals>
     <string name="export_upgrade_action">Nadogradnja</string>
+    <string name="review_app_body">Želiš li ostaviti recenziju za Permission Pilot? ❤️</string>
+    <string name="review_app_review_action">Ocijeni</string>
+    <string name="review_app_dismiss_action">Možda kasnije</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -741,4 +741,7 @@
         <item quantity="other">Az ingyenes verzió %d elemre és Markdown formátumra korlátozott. Frissítsen a korlátlan exportálásért és az összes formátumért.</item>
     </plurals>
     <string name="export_upgrade_action">Frissítés</string>
+    <string name="review_app_body">Szeretnél-e értékelést írni a Permission Pilotnak? ❤️</string>
+    <string name="review_app_review_action">Értékelés</string>
+    <string name="review_app_dismiss_action">Talán később</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -741,4 +741,7 @@
         <item quantity="other">La versione gratuita è limitata a %d elementi e al formato Markdown. Esegui l\'upgrade per esportazioni illimitate e tutti i formati.</item>
     </plurals>
     <string name="export_upgrade_action">Aggiorna</string>
+    <string name="review_app_body">Ti piacerebbe lasciare una recensione a Permission Pilot? ❤️</string>
+    <string name="review_app_review_action">Recensione</string>
+    <string name="review_app_dismiss_action">Forse più tardi</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -813,4 +813,7 @@
         <item quantity="other">הגרסה החינמית מוגבלת ל‑%d פריטים ולפורמט Markdown. שדרג לייצוא ללא הגבלה ולכל הפורמטים.</item>
     </plurals>
     <string name="export_upgrade_action">שדרוג</string>
+    <string name="review_app_body">רוצה להשאיר ביקורת ל-Permission Pilot? ❤️</string>
+    <string name="review_app_review_action">סקירה</string>
+    <string name="review_app_dismiss_action">אולי מאוחר יותר</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -705,4 +705,7 @@
         <item quantity="other">無料版は %d 件とMarkdown形式に制限されています。無制限のエクスポートとすべての形式にアップグレードしてください。</item>
     </plurals>
     <string name="export_upgrade_action">アップグレード</string>
+    <string name="review_app_body">Permission Pilotにレビューを書いてもらえますか？❤️</string>
+    <string name="review_app_review_action">レビュー</string>
+    <string name="review_app_dismiss_action">また後で</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -705,4 +705,7 @@
         <item quantity="other">무료 버전은 %d개 항목과 Markdown 형식으로 제한됩니다. 무제한 내보내기 및 모든 형식을 위해 업그레이드하세요.</item>
     </plurals>
     <string name="export_upgrade_action">업그레이드</string>
+    <string name="review_app_body">Permission Pilot에 리뷰를 남겨주시겠어요? ❤️</string>
+    <string name="review_app_review_action">리뷰</string>
+    <string name="review_app_dismiss_action">다음에 해요</string>
 </resources>

--- a/app/src/main/res/values-ku-rTR/strings.xml
+++ b/app/src/main/res/values-ku-rTR/strings.xml
@@ -741,4 +741,7 @@
         <item quantity="other">Guhertoya belaş bi %d babetan û formata Markdown sînordar e. Ji bo hinardekirin bê sînor û hemû formatan nûve bikin.</item>
     </plurals>
     <string name="export_upgrade_action">Jortir biçin</string>
+    <string name="review_app_body">Tu dixwazî Permission Pilot-ê nirxandî? ❤️</string>
+    <string name="review_app_review_action">Nirxandin</string>
+    <string name="review_app_dismiss_action">Dibe ku paşê</string>
 </resources>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -741,4 +741,7 @@
         <item quantity="other">Gratisversjonen er begrenset til %d elementer og Markdown-format. Oppgrader for ubegrensede eksporter og alle formater.</item>
     </plurals>
     <string name="export_upgrade_action">Oppgrader</string>
+    <string name="review_app_body">Vil du skrive en anmeldelse av Permission Pilot? ❤️</string>
+    <string name="review_app_review_action">Anmeldelse</string>
+    <string name="review_app_dismiss_action">Kanskje senere</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -566,6 +566,7 @@
     <string name="general_progress_loading">Bezig met laden…</string>
     <string name="general_upgrade_action">Upgraden</string>
     <string name="general_copy_action">Kopiëren</string>
+    <string name="general_copied_to_clipboard_msg">Gekopieerd naar klembord</string>
     <string name="general_view_details_for_x_action">Details weergeven voor %1$s</string>
     <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
@@ -740,4 +741,7 @@
         <item quantity="other">De gratis versie is beperkt tot %d items en Markdown-indeling. Upgrade voor onbeperkte exports en alle indelingen.</item>
     </plurals>
     <string name="export_upgrade_action">Upgraden</string>
+    <string name="review_app_body">Wil je Permission Pilot een review geven? ❤️</string>
+    <string name="review_app_review_action">Beoordeling</string>
+    <string name="review_app_dismiss_action">Misschien later</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -813,4 +813,7 @@
         <item quantity="other">Darmowa wersja jest ograniczona do %d elementu i formatu Markdown. Uaktualnij, aby uzyskać nieograniczone eksporty i wszystkie formaty.</item>
     </plurals>
     <string name="export_upgrade_action">Uaktualnij</string>
+    <string name="review_app_body">Wystawisz opinię dla Pilot Uprawnień? ❤️</string>
+    <string name="review_app_review_action">Oceń</string>
+    <string name="review_app_dismiss_action">Może później</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -741,4 +741,7 @@
         <item quantity="other">A versão gratuita é limitada a %d itens e formato Markdown. Faça upgrade para exportações ilimitadas e todos os formatos.</item>
     </plurals>
     <string name="export_upgrade_action">Atualizar</string>
+    <string name="review_app_body">Gostaria de deixar uma avaliação no Permission Pilot? ❤️</string>
+    <string name="review_app_review_action">Avaliar</string>
+    <string name="review_app_dismiss_action">Talvez depois</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -741,4 +741,7 @@
         <item quantity="other">A versão gratuita está limitada a %d itens e ao formato Markdown. Atualize para exportações ilimitadas e todos os formatos.</item>
     </plurals>
     <string name="export_upgrade_action">Atualizar</string>
+    <string name="review_app_body">Gostarias de deixar uma avaliação a Permission Pilot? ❤️</string>
+    <string name="review_app_review_action">Avaliar</string>
+    <string name="review_app_dismiss_action">Talvez mais tarde</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -777,4 +777,7 @@
         <item quantity="other">Versiunea gratuită este limitată la %d de elemente și formatul Markdown. Treceți la versiunea premium pentru exportări nelimitate și toate formatele.</item>
     </plurals>
     <string name="export_upgrade_action">Actualizează</string>
+    <string name="review_app_body">Ai vrea să lași Permission Pilot o recenzie? ❤️</string>
+    <string name="review_app_review_action">Recenzie</string>
+    <string name="review_app_dismiss_action">Poate mai târziu</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -813,4 +813,7 @@
         <item quantity="other">Бесплатная версия ограничена %d элементами и форматом Markdown. Перейдите на полную версию для неограниченного экспорта и всех форматов.</item>
     </plurals>
     <string name="export_upgrade_action">Обновить</string>
+    <string name="review_app_body">Хочешь оставить отзыв Permission Pilot? ❤️</string>
+    <string name="review_app_review_action">Отзыв</string>
+    <string name="review_app_dismiss_action">Возможно, позже</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -813,4 +813,7 @@
         <item quantity="other">Bezplatná verzia je limitovaná na %d položiek a formát Markdown. Upgradzujte na neobmedzené exporty a všetky formáty.</item>
     </plurals>
     <string name="export_upgrade_action">Inovovať</string>
+    <string name="review_app_body">Chceš zanechať recenziu pre Permission Pilot? ❤️</string>
+    <string name="review_app_review_action">Ohodnotiť</string>
+    <string name="review_app_dismiss_action">Možno neskôr</string>
 </resources>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -777,4 +777,7 @@
         <item quantity="other">Бесплатна верзија је ограничена на %d ставки и Markdown формат. Надоградите за неограничен извоз и све формате.</item>
     </plurals>
     <string name="export_upgrade_action">Надогради</string>
+    <string name="review_app_body">Желиш ли да оставиш преглед за Permission Pilot? ❤️</string>
+    <string name="review_app_review_action">Оцени</string>
+    <string name="review_app_dismiss_action">Можда касније</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -741,4 +741,7 @@
         <item quantity="other">Gratisversionen är begränsad till %d objekt och Markdown-format. Uppgradera för obegränsad export och alla format.</item>
     </plurals>
     <string name="export_upgrade_action">Uppgradera</string>
+    <string name="review_app_body">Vill du lämna Permission Pilot en recension? ❤️</string>
+    <string name="review_app_review_action">Recensera</string>
+    <string name="review_app_dismiss_action">Kanske senare</string>
 </resources>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -705,4 +705,7 @@
         <item quantity="other">เวอร์ชันฟรีจำกัดที่ %d รายการและรูปแบบ Markdown อัปเกรดเพื่อส่งออกไม่จำกัดและรูปแบบทั้งหมด</item>
     </plurals>
     <string name="export_upgrade_action">อัปเกรด</string>
+    <string name="review_app_body">คุณอยากให้รีวิว Permission Pilot ไหม? ❤️</string>
+    <string name="review_app_review_action">รีวิว</string>
+    <string name="review_app_dismiss_action">อาจในคราวหน้า</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -741,4 +741,7 @@
         <item quantity="other">Ücretsiz sürüm %d öğeyle ve Markdown formatıyla sınırlıdır. Sınırsız dışa aktarma ve tüm formatlar için yükseltin.</item>
     </plurals>
     <string name="export_upgrade_action">Yükselt</string>
+    <string name="review_app_body">Permission Pilot\'u değerlendirmek ister misin? ❤️</string>
+    <string name="review_app_review_action">Değerlendir</string>
+    <string name="review_app_dismiss_action">Belki daha sonra</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -813,4 +813,7 @@
         <item quantity="other">Безкоштовна версія обмежена %d елементами та форматом Markdown. Оновіть для необмеженого експорту та всіх форматів.</item>
     </plurals>
     <string name="export_upgrade_action">Оновити</string>
+    <string name="review_app_body">Хочеш залишити відгук для Permission Pilot? ❤️</string>
+    <string name="review_app_review_action">Огляд</string>
+    <string name="review_app_dismiss_action">Можливо пізніше</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -705,4 +705,7 @@
         <item quantity="other">Phiên bản miễn phí bị giới hạn ở %d mục và định dạng Markdown. Nâng cấp để xuất không giới hạn và tất cả các định dạng.</item>
     </plurals>
     <string name="export_upgrade_action">Nâng cấp</string>
+    <string name="review_app_body">Bạn có muốn đánh giá Permission Pilot không? ❤️</string>
+    <string name="review_app_review_action">Đánh giá</string>
+    <string name="review_app_dismiss_action">Để sau</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -705,4 +705,7 @@
         <item quantity="other">免费版限制为 %d 个项目和 Markdown 格式。升级以获得无限制导出和所有格式。</item>
     </plurals>
     <string name="export_upgrade_action">升级</string>
+    <string name="review_app_body">想为 Permission Pilot 留个评价吗？❤️</string>
+    <string name="review_app_review_action">评论</string>
+    <string name="review_app_dismiss_action">稍后再说</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -705,4 +705,7 @@
         <item quantity="other">免費版限制為 %d 個項目和 Markdown 格式。升級可享無限匯出及所有格式。</item>
     </plurals>
     <string name="export_upgrade_action">升級</string>
+    <string name="review_app_body">你想為 Permission Pilot 留下評論嗎？❤️</string>
+    <string name="review_app_review_action">評論</string>
+    <string name="review_app_dismiss_action">稍後再說</string>
 </resources>


### PR DESCRIPTION
## What changed

App text has been refreshed with the latest translations from Crowdin, covering 39 languages. This includes the new in-app review prompt — the message, the review button and the "maybe later" button — along with the "Copied to clipboard" confirmation.

Five of those translations were fixed before this update landed. In Czech, Hungarian and Romanian the review button had come through meaning "overview", "revise" or "assess" instead of leaving a store review; the Slovak "maybe later" used a non-standard spelling; and the Dutch clipboard message used a word that isn't Dutch. All five now read correctly.

## Technical Context

- 43 files across the `main`, `foss` and `gplay` source sets.
- **Root cause of the five bad entries:** Crowdin auto-applied Translation Memory matches the moment the new source strings were uploaded (`provider: "tm"`, `isPreTranslated: true`, timestamped seconds after string creation). The English source for the review button is the bare word "Review", which TM resolved to the "examine" sense rather than the app-store sense. They were deleted and retranslated upstream, then pulled.
- **Not fully fixed at the source.** Five defective segments still live in a shared TM that this project pre-translates against: "Review" for cs/ru/fr/pt-PT and "Maybe later" for sk. They are latent — a TM match only applies to a string with no translation, and every affected string now holds a value — but they will re-apply if any of these strings is ever cleared or added fresh. Worth resolving in the Crowdin project settings rather than here.
- Every changed file passed per-locale validation for escaping, placeholders and encoding; `assembleDebug` passes for both flavors.
