### PR TITLE
General: Show clearer errors when Google Play offers can't load

### DIFF
--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/billing/GplayServiceUnavailableException.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/billing/GplayServiceUnavailableException.kt
@@ -1,12 +1,10 @@
 package eu.darken.myperm.common.upgrade.core.billing
 
-import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
-import android.widget.Toast
 import eu.darken.myperm.R
 import eu.darken.myperm.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.myperm.common.debug.logging.log
@@ -34,18 +32,23 @@ class GplayServiceUnavailableException(cause: Throwable) :
             try {
                 activity.startActivity(intent)
             } catch (e: ActivityNotFoundException) {
-                onLaunchFailed(activity, e)
+                onLaunchFailed(e)
+                throw e
             } catch (e: SecurityException) {
                 // Play can be installed but unreachable: disabled app, work/restricted profile or a
                 // ROM that guards the settings screen. The launch is denied, not unresolvable.
-                onLaunchFailed(activity, e)
+                onLaunchFailed(e)
+                throw e
             }
         },
+        // The failure is not presented here: it propagates to the dialog, which renders this inline.
+        // A Toast caps at 2 lines and clipped this message (in French mid-word, dropping a whole
+        // condition), so the container was the defect, not the wording.
+        fixActionErrorMessage = context.getString(R.string.upgrades_gplay_not_installed_message),
     )
 
-    private fun onLaunchFailed(activity: Activity, e: Exception) {
+    private fun onLaunchFailed(e: Exception) {
         log(ERROR) { "Can't launch settings intent for Google Play: $e" }
-        Toast.makeText(activity, R.string.upgrades_gplay_not_installed_message, Toast.LENGTH_SHORT).show()
     }
 
     companion object {

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModel.kt
@@ -18,6 +18,7 @@ import eu.darken.myperm.common.uix.ViewModel4
 import eu.darken.myperm.common.upgrade.core.OurSku
 import eu.darken.myperm.common.upgrade.core.UpgradeRepoGplay
 import eu.darken.myperm.common.upgrade.core.billing.GplayServiceUnavailableException
+import eu.darken.myperm.common.upgrade.core.billing.OfferUnavailableBillingException
 import eu.darken.myperm.common.upgrade.core.billing.Sku
 import eu.darken.myperm.common.upgrade.core.billing.SkuDetails
 import kotlinx.coroutines.CancellationException
@@ -186,9 +187,22 @@ class UpgradeViewModel @Inject constructor(
 
         if (done != null) {
             if (iap == null && sub == null) {
-                val serviceUnavailableError = GplayServiceUnavailableException(
-                    done.iap.exceptionOrNull() ?: RuntimeException("IAP and SUB data request failed.")
-                )
+                val iapCause = done.iap.exceptionOrNull()
+                val subCause = done.sub.exceptionOrNull()
+                // Play answered fine and simply has nothing to sell here (region, account
+                // eligibility, pulled product): reporting that as a connectivity failure sends the
+                // user chasing futile advice (clear Play's cache, reboot). Only when BOTH causes
+                // are merchandising — a single connectivity failure can't rule out a real Play
+                // problem, so the conservative "can't reach Play" copy stays correct.
+                val queryError = if (
+                    iapCause is OfferUnavailableBillingException && subCause is OfferUnavailableBillingException
+                ) {
+                    iapCause
+                } else {
+                    GplayServiceUnavailableException(
+                        iapCause ?: RuntimeException("IAP and SUB data request failed.")
+                    )
+                }
                 // Grace users and owners are excluded: during an outage (exactly when grace
                 // matters) they must keep the Loaded presentation with their status/grace card,
                 // not an acquisition-style error state or dialog.
@@ -197,9 +211,9 @@ class UpgradeViewModel @Inject constructor(
                     // toggling) — emit once per failure episode, not once per recombination.
                     if (!hasShownServiceUnavailableError) {
                         hasShownServiceUnavailableError = true
-                        errorEvents.tryEmit(serviceUnavailableError)
+                        errorEvents.tryEmit(queryError)
                     }
-                    return@combine GplayUpgradeUiState.Unavailable(serviceUnavailableError)
+                    return@combine GplayUpgradeUiState.Unavailable(queryError)
                 }
             } else {
                 hasShownServiceUnavailableError = false

--- a/app/src/main/java/eu/darken/myperm/common/error/ErrorEventHandler.kt
+++ b/app/src/main/java/eu/darken/myperm/common/error/ErrorEventHandler.kt
@@ -1,6 +1,10 @@
 package eu.darken.myperm.common.error
 
+import android.app.Activity
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -9,8 +13,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import eu.darken.myperm.R
 import eu.darken.myperm.common.compose.findActivity
 import eu.darken.myperm.common.debug.logging.Logging.Priority.ERROR
@@ -50,24 +56,57 @@ private fun ComposeErrorDialog(
     // acknowledge-only shape. The activity is required to launch the fix.
     val hasFix = localizedError.fixAction != null && activity != null
 
+    // Keyed on the throwable, not the LocalizedError: the latter is rebuilt (with fresh action
+    // lambdas, so never equal) on every recomposition, which would wipe the message immediately.
+    var actionError by remember(throwable) { mutableStateOf<String?>(null) }
+
+    // errorMessage is per-dispatch, NOT read from localizedError: fixActionErrorMessage describes
+    // only the fix action's failure, so any future dispatch site (an info/details action) passes
+    // its own copy or none, and can never surface another one's message.
+    fun dispatchAndDismiss(
+        action: (Activity) -> Unit,
+        errorMessage: String? = null,
+    ) {
+        // Fix actions are arbitrary code (e.g. intent launches): a throw here would crash the UI
+        // thread from inside a click handler, and skipping onDismiss() would leave the dialog
+        // latched on the current error with no way out.
+        try {
+            action(activity!!)
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "Error action failed: ${e.asLog()}" }
+            // A dispatch that ships its own failure copy keeps the dialog open and shows it inline
+            // (no length cap, unlike a Toast). Never latched: the Close button stays available.
+            errorMessage?.let {
+                actionError = it
+                return
+            }
+        }
+        onDismiss()
+    }
+
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(text = localizedError.label) },
-        text = { Text(text = localizedError.description) },
+        text = {
+            Column {
+                Text(text = localizedError.description)
+                actionError?.let {
+                    Text(
+                        text = it,
+                        color = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.padding(top = 8.dp),
+                    )
+                }
+            }
+        },
         confirmButton = {
             if (hasFix) {
                 TextButton(
                     onClick = {
-                        // Fix actions are arbitrary code (e.g. intent launches): a throw here would
-                        // crash the UI thread from inside a click handler, and skipping onDismiss()
-                        // would leave the dialog latched on the current error with no way out.
-                        try {
-                            localizedError.fixAction!!.invoke(activity!!)
-                        } catch (e: Exception) {
-                            log(TAG, ERROR) { "Error action failed: ${e.asLog()}" }
-                        } finally {
-                            onDismiss()
-                        }
+                        dispatchAndDismiss(
+                            action = localizedError.fixAction!!,
+                            errorMessage = localizedError.fixActionErrorMessage,
+                        )
                     },
                 ) {
                     Text(text = localizedError.fixActionLabel ?: stringResource(android.R.string.ok))

--- a/app/src/main/java/eu/darken/myperm/common/error/LocalizedError.kt
+++ b/app/src/main/java/eu/darken/myperm/common/error/LocalizedError.kt
@@ -14,6 +14,8 @@ data class LocalizedError(
     val description: String,
     val fixActionLabel: String? = null,
     val fixAction: ((Activity) -> Unit)? = null,
+    /** Shown inline in the error dialog if the fix action fails, instead of a length-capped toast. */
+    val fixActionErrorMessage: String? = null,
 ) {
     fun asText() = "$label:\n$description"
 }

--- a/app/src/test/java/eu/darken/myperm/common/error/ComposeErrorDialogGuardTest.kt
+++ b/app/src/test/java/eu/darken/myperm/common/error/ComposeErrorDialogGuardTest.kt
@@ -2,9 +2,12 @@ package eu.darken.myperm.common.error
 
 import android.content.Context
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.myperm.R
 import eu.darken.myperm.common.compose.PreviewWrapper
 import eu.darken.myperm.common.flow.SingleEventFlow
 import io.kotest.matchers.shouldBe
@@ -22,8 +25,10 @@ class ComposeErrorDialogGuardTest : BaseComposeRobolectricTest() {
         override val errorEvents = SingleEventFlow<Throwable>()
     }
 
-    private class ThrowingFixError(private val onFixDispatched: () -> Unit) :
-        Exception(ERROR_BODY), HasLocalizedError {
+    private class ThrowingFixError(
+        private val fixErrorMessage: String? = null,
+        private val onFixDispatched: () -> Unit = {},
+    ) : Exception(ERROR_BODY), HasLocalizedError {
 
         override fun getLocalizedError(context: Context): LocalizedError = LocalizedError(
             throwable = this,
@@ -36,6 +41,7 @@ class ComposeErrorDialogGuardTest : BaseComposeRobolectricTest() {
                 onFixDispatched()
                 throw IllegalStateException("fix action exploded")
             },
+            fixActionErrorMessage = fixErrorMessage,
         )
     }
 
@@ -52,9 +58,11 @@ class ComposeErrorDialogGuardTest : BaseComposeRobolectricTest() {
     }
 
     @Test
-    fun `a throwing fix action still dismisses the dialog`() {
+    fun `a throwing fix action without its own message still dismisses the dialog`() {
+        // The other half of the per-dispatch contract: a dispatch that ships NO failure copy keeps
+        // the plain log-then-dismiss behaviour and can never pick up someone else's message.
         var invoked = false
-        showError(ThrowingFixError { invoked = true })
+        showError(ThrowingFixError(onFixDispatched = { invoked = true }))
 
         composeRule.onNodeWithText(FIX_LABEL).performClick()
         composeRule.waitForIdle()
@@ -64,8 +72,28 @@ class ComposeErrorDialogGuardTest : BaseComposeRobolectricTest() {
         // dismissal that closes the dialog.
         composeRule.onAllNodesWithText(FIX_LABEL).assertCountEquals(0)
     }
+
+    @Test
+    fun `a throwing fix action with its own message keeps the dialog open and shows it inline`() {
+        // A Toast caps at 2 lines and clipped this kind of message; the dialog body has no cap.
+        showError(ThrowingFixError(fixErrorMessage = FIX_ERROR_MESSAGE))
+
+        composeRule.onNodeWithText(FIX_LABEL).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(FIX_ERROR_MESSAGE).assertIsDisplayed()
+        composeRule.onNodeWithText(FIX_LABEL).assertExists()
+        // Not latched: the way out stays available while the message is shown.
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        composeRule.onNodeWithText(context.getString(R.string.general_close_action)).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onAllNodesWithText(FIX_LABEL).assertCountEquals(0)
+        composeRule.onAllNodesWithText(FIX_ERROR_MESSAGE).assertCountEquals(0)
+    }
 }
 
 private const val ERROR_TITLE = "Test error title"
 private const val ERROR_BODY = "Test error description"
 private const val FIX_LABEL = "Fix it"
+private const val FIX_ERROR_MESSAGE = "Fixing it did not work"

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/billing/GplayFixActionTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/billing/GplayFixActionTest.kt
@@ -5,6 +5,7 @@ import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import eu.darken.myperm.R
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import org.junit.Test
@@ -18,7 +19,8 @@ import testhelpers.TestApplication
 
 /**
  * The error dialog's "Google Play" button runs on an activity context: a device where the launch is
- * refused must get a toast, not a crash. The intent shape of a successful launch is pinned by
+ * refused must get the failure reported through the dialog (which can render the full message), not
+ * a clipped toast and not a crash. The intent shape of a successful launch is pinned by
  * ComposeErrorDialogTest, which drives the same action through the dialog.
  */
 @RunWith(RobolectricTestRunner::class)
@@ -41,20 +43,32 @@ class GplayFixActionTest : BaseTest() {
 
     private fun <T : Activity> activityOf(clazz: Class<T>): T = Robolectric.buildActivity(clazz).setup().get()
 
-    private fun assertToastInsteadOfCrash(activity: Activity) {
-        fixActionOf(activity).invoke(activity)
+    @Test
+    fun `a denied launch reports through the dialog instead of a toast`() {
+        val activity = activityOf(DeniedLaunchActivity::class.java)
 
-        ShadowToast.getTextOfLatestToast() shouldBe
+        shouldThrow<SecurityException> { fixActionOf(activity).invoke(activity) }
+
+        // A toast caps at 2 lines and clipped this message (French lost a whole condition
+        // mid-word) — the dialog renders it inline instead.
+        ShadowToast.getLatestToast() shouldBe null
+    }
+
+    @Test
+    fun `an unresolvable launch reports through the dialog instead of a toast`() {
+        val activity = activityOf(MissingPlayActivity::class.java)
+
+        shouldThrow<ActivityNotFoundException> { fixActionOf(activity).invoke(activity) }
+
+        ShadowToast.getLatestToast() shouldBe null
+    }
+
+    @Test
+    fun `the failure message travels with the error for the dialog to show`() {
+        val activity = activityOf(Activity::class.java)
+
+        GplayServiceUnavailableException(RuntimeException("Play hiccup"))
+            .getLocalizedError(activity).fixActionErrorMessage shouldBe
             activity.getString(R.string.upgrades_gplay_not_installed_message)
-    }
-
-    @Test
-    fun `a denied launch shows the not-installed toast instead of crashing`() {
-        assertToastInsteadOfCrash(activityOf(DeniedLaunchActivity::class.java))
-    }
-
-    @Test
-    fun `an unresolvable launch shows the not-installed toast instead of crashing`() {
-        assertToastInsteadOfCrash(activityOf(MissingPlayActivity::class.java))
     }
 }

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/GplayUpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/GplayUpgradeViewModelTest.kt
@@ -10,6 +10,7 @@ import eu.darken.myperm.common.upgrade.core.OurSku
 import eu.darken.myperm.common.upgrade.core.UpgradeRepoGplay
 import eu.darken.myperm.common.upgrade.core.billing.BillingData
 import eu.darken.myperm.common.upgrade.core.billing.GplayServiceUnavailableException
+import eu.darken.myperm.common.upgrade.core.billing.OfferUnavailableBillingException
 import eu.darken.myperm.common.upgrade.core.billing.Sku
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldBeEmpty
@@ -178,6 +179,67 @@ class GplayUpgradeViewModelTest : BaseTest() {
         advanceUntilIdle()
 
         coVerify(exactly = 2) { repo.querySkus(any()) }
+    }
+
+    @Test
+    fun `both product types unavailable surfaces the merchandising error, not a connectivity one`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // Play answered OK and simply has no sellable offer here (region, account eligibility,
+        // pulled product). Reporting that as "can't connect to Google Play" tells the user to
+        // clear Play's cache and reboot, which cannot help.
+        val repo = mockRepo()
+        coEvery { repo.querySkus(OurSku.Iap.PRO_UPGRADE) } throws
+            OfferUnavailableBillingException(OurSku.Iap.PRO_UPGRADE, null)
+        coEvery { repo.querySkus(OurSku.Sub.PRO_UPGRADE) } throws
+            OfferUnavailableBillingException(OurSku.Sub.PRO_UPGRADE, null)
+        val vm = buildVm(repo)
+
+        val unavailableState = async { vm.state.first { it is GplayUpgradeUiState.Unavailable } }
+        val forwardedError = async { vm.errorEvents.first() }
+        advanceUntilIdle()
+
+        forwardedError.await().shouldBeInstanceOf<OfferUnavailableBillingException>()
+        val state = unavailableState.await().shouldBeInstanceOf<GplayUpgradeUiState.Unavailable>()
+        state.error.shouldBeInstanceOf<OfferUnavailableBillingException>()
+    }
+
+    @Test
+    fun `a mixed failure keeps the conservative connectivity error`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // One sku failed for a non-merchandising reason: a real Play problem can't be ruled out,
+        // so the conservative "can't reach Play" copy stays.
+        val repo = mockRepo()
+        coEvery { repo.querySkus(OurSku.Iap.PRO_UPGRADE) } throws
+            OfferUnavailableBillingException(OurSku.Iap.PRO_UPGRADE, null)
+        coEvery { repo.querySkus(OurSku.Sub.PRO_UPGRADE) } throws IllegalStateException("Play unavailable")
+        val vm = buildVm(repo)
+
+        val unavailableState = async { vm.state.first { it is GplayUpgradeUiState.Unavailable } }
+        val forwardedError = async { vm.errorEvents.first() }
+        advanceUntilIdle()
+
+        forwardedError.await().shouldBeInstanceOf<GplayServiceUnavailableException>()
+        val state = unavailableState.await().shouldBeInstanceOf<GplayUpgradeUiState.Unavailable>()
+        state.error.shouldBeInstanceOf<GplayServiceUnavailableException>()
+    }
+
+    @Test
+    fun `a connectivity failure on both product types stays a connectivity error`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val repo = mockRepo()
+        coEvery { repo.querySkus(any()) } throws IllegalStateException("Play unavailable")
+        val vm = buildVm(repo)
+
+        val unavailableState = async { vm.state.first { it is GplayUpgradeUiState.Unavailable } }
+        val forwardedError = async { vm.errorEvents.first() }
+        advanceUntilIdle()
+
+        forwardedError.await().shouldBeInstanceOf<GplayServiceUnavailableException>()
+        val state = unavailableState.await().shouldBeInstanceOf<GplayUpgradeUiState.Unavailable>()
+        state.error.shouldBeInstanceOf<GplayServiceUnavailableException>()
     }
 
     @Test


### PR DESCRIPTION
## What changed

Two fixes to how the upgrade screen reports Google Play problems, both found during a device QA pass.

**The app no longer blames your connection when Google Play simply has nothing to offer.** If Play answers normally but returns no purchasable products — because there is no pricing for your region, a product was withdrawn, or your account isn't eligible — the app used to say it "can't connect to Google Play" and suggest clearing the Play Store cache and rebooting. That advice couldn't help, because nothing was wrong with the device or with Play. Those cases now show the existing "offer unavailable" message instead. A genuine connection problem still reports as one.

**Error messages are no longer cut off.** When the "Google Play" button on an error dialog couldn't open the Play Store page, the explanation was shown as a toast — and Android limits toasts to two lines. The end of the sentence was clipped in English, and in translated languages an entire clause could disappear: a French user saw "it may be missing, disabled or r…" and never learned that *restricted* was one of the possible causes. The message now appears inside the dialog itself, where it fits at any length, and the dialog stays open so the wording is readable.

## Technical Context

- The billing layer already threw a typed `OfferUnavailableBillingException` for the merchandising case, specifically so it would surface as user copy rather than a bug report. The upgrade ViewModel discarded that typing, wrapping *any* both-queries-failed outcome into `GplayServiceUnavailableException`. It now inspects both causes and only downgrades to the merchandising error when **both** are merchandising — a single connectivity failure can't rule out a real Play problem, so the conservative copy stays correct in mixed cases.
- The failure message moved out of `Toast` and into the error dialog. `LocalizedError` gained an optional `fixActionErrorMessage`; the exception now logs and rethrows instead of presenting, and the dialog renders the message inline and skips its dismiss.
- The dialog's dispatch helper takes the message **per dispatch** rather than reading it off the error. That helper serves both the fix and the info buttons, so reading it off the error would let a failing info action surface the fix action's copy. Call sites use named arguments so any future third dispatch site has to make that choice explicitly.
- Review guidance: the inline-message state is keyed on the *throwable*, not the `LocalizedError` — the latter is rebuilt with fresh action lambdas on every recomposition, so equality never holds and the message would be wiped the instant it was set.
- Unchanged on purpose: the once-per-failure-episode emission guard, the carve-out that keeps owners and grace-period users on their normal presentation during an outage, and the wording of the message itself.
