### PR TITLE
General: Notify about permissions when a new app is installed

### DIFF
--- a/app/src/main/java/eu/darken/myperm/watcher/core/WatcherDiffRunner.kt
+++ b/app/src/main/java/eu/darken/myperm/watcher/core/WatcherDiffRunner.kt
@@ -198,9 +198,15 @@ class WatcherDiffRunner @Inject constructor(
                     eventType = WatcherEventType.INSTALL
                     val requested = newPermsAll.requested[key] ?: emptyList()
                     val declared = newPermsAll.declared[key] ?: emptyList()
-                    diff = PermissionDiff(
-                        addedPermissions = requested.map { it.permissionId },
-                        addedDeclared = declared.map { it.permissionId },
+                    // Diffed against an empty baseline so gainedCount reflects the permissions the
+                    // app already holds on arrival, not just the ones it declares
+                    diff = snapshotDiffer.diff(
+                        previousPerms = emptyList(),
+                        previousDeclared = emptyList(),
+                        currentPerms = requested.map {
+                            SnapshotDiffer.CurrentPermission(it.permissionId, UsesPermission.Status.valueOf(it.status))
+                        },
+                        currentDeclared = declared.map { it.permissionId },
                     )
                 }
                 oldPkg != null && newPkg == null -> {

--- a/app/src/test/java/eu/darken/myperm/watcher/core/WatcherDiffRunnerTest.kt
+++ b/app/src/test/java/eu/darken/myperm/watcher/core/WatcherDiffRunnerTest.kt
@@ -246,6 +246,52 @@ class WatcherDiffRunnerTest : BaseTest() {
     }
 
     @Test
+    fun `new install counts already granted permissions as gained`() = runTest {
+        setupSinglePairChain(
+            oldPkgs = emptyList(),
+            newPkgs = listOf(pkg("snap-new", "com.new.app")),
+            newPermsRequested = listOf(
+                perm("snap-new", "com.new.app", "android.permission.INTERNET", "GRANTED"),
+                perm("snap-new", "com.new.app", "android.permission.ACCESS_NETWORK_STATE", "GRANTED"),
+                perm("snap-new", "com.new.app", "android.permission.POST_NOTIFICATIONS", "DENIED"),
+            ),
+        )
+
+        createRunner().processNewSnapshots() shouldBe 1
+
+        // gainedCount is what "Only notify on permissions gained" gates on — zero here silently
+        // dropped the notification for every newly installed app
+        val notified = slot<PermissionDiff>()
+        coVerify { watcherNotifications.postChangeNotification(any(), any(), any(), capture(notified)) }
+        notified.captured.gainedCount shouldBe 2
+        notified.captured.lostCount shouldBe 0
+
+        val stored = slot<PermissionChangeEntity>()
+        coVerify { changeDao.insert(capture(stored)) }
+        json.decodeFromString<PermissionDiff>(stored.captured.changesJson).gainedCount shouldBe 2
+    }
+
+    @Test
+    fun `new install with only denied permissions counts no gain`() = runTest {
+        setupSinglePairChain(
+            oldPkgs = emptyList(),
+            newPkgs = listOf(pkg("snap-new", "com.new.app")),
+            newPermsRequested = listOf(
+                perm("snap-new", "com.new.app", "android.permission.CAMERA", "DENIED"),
+                perm("snap-new", "com.new.app", "android.permission.POST_NOTIFICATIONS", "DENIED"),
+            ),
+            newPermsDeclared = listOf(declaredPerm("snap-new", "com.new.app", "com.new.app.MY_PERM")),
+        )
+
+        createRunner().processNewSnapshots() shouldBe 1
+
+        val notified = slot<PermissionDiff>()
+        coVerify { watcherNotifications.postChangeNotification(any(), any(), any(), capture(notified)) }
+        notified.captured.addedPermissions.size shouldBe 2
+        notified.captured.gainedCount shouldBe 0
+    }
+
+    @Test
     fun `update with permission changes creates UPDATE report`() = runTest {
         setupSinglePairChain(
             oldPkgs = listOf(pkg("snap-old", "com.existing.app")),


### PR DESCRIPTION
## What changed

Fixed the watcher staying silent when a newly installed app requests permissions.

With the default "Only notify on permissions gained" setting enabled, installing a new app produced a report but no notification — even though the app had just been granted several permissions. Since being told about a newly installed app's permissions is the main reason to run the watcher, this made the feature look broken on default settings.

## Technical Context

- Root cause is a routing bug, not the notification filter and not the setting's semantics. The INSTALL branch of the diff runner never called the differ; it hand-built the diff with `requested.map { it.permissionId }`, which discards each permission's granted/denied status. `gainedCount` therefore fell back to its default of `0`, and the gained-only filter dropped the notification. The UPDATE branch used the differ correctly all along.
- The differ itself was already right, and already had a passing first-sighting test asserting `gainedCount shouldBe 2` for a previous snapshot that is empty. The fix simply routes INSTALL through it, so no existing test needed changing — a good indication this restores intended behaviour rather than redefining it.
- The anti-spam intent of the setting is preserved: only `GRANTED`/`GRANTED_IN_USE` count, so an app installed with all its runtime permissions denied still yields `gainedCount = 0` and is still suppressed.
- Deliberately out of scope: the REMOVED branch has the same hand-built shape and leaves `lostCount = 0`. It does not affect notifications (an uninstall is not a gain) and the dashboard's "has lost permissions" filter reads `removedPermissions` rather than `lostCount`, so the only visible effect of changing it would be adding a count badge to every uninstall — a display choice with no evidence it is wrong.
- Verified by stashing the fix and re-running: the new test fails with `expected:<2> but was:<0>`, reproducing the device symptom exactly.
