### PR TITLE
General: Compose the branded app title from a translated template

### DIFF
--- a/app/proguard/proguard-rules.pro
+++ b/app/proguard/proguard-rules.pro
@@ -1,1 +1,4 @@
 -dontobfuscate
+
+# Play Core KTX references this compile-time-only GMS annotation not on the runtime classpath
+-dontwarn com.google.android.gms.common.annotation.NoNullnessRewrite

--- a/app/src/foss/res/values-af-rZA/strings.xml
+++ b/app/src/foss/res/values-af-rZA/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">Word \'n borgskappe</string>
     <string name="upgrade_foss_sponsor_subtitle">Maak GitHub-borge oop</string>
     <string name="upgrade_foss_sponsor_returned_early">Neem asseblief \'n oomblik om die borgblad te besoek!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Vrye weergawe</string>
     <string name="upgrade_screen_status_free_body">U gebruik die vrye, oopbronkode-weergawe. Ondersteun die ontwikkeling om die Pro-funksies te ontsluit.</string>

--- a/app/src/foss/res/values-am/strings.xml
+++ b/app/src/foss/res/values-am/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">የግል አስነሯ</string>
     <string name="upgrade_foss_sponsor_subtitle">የ GitHub Sponsors ይዘርቹ</string>
     <string name="upgrade_foss_sponsor_returned_early">የግል ቃኩልን አክበ ለመከፈት የጓል ደቁወቢ።</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">ነጻ ስሪት</string>
     <string name="upgrade_screen_status_free_body">የነጻ፣ ከተመረቀ ምንጭ ግንባታ እየተጠቀሙ ነው። Pro ባህሪያትን ለመክፈት ልማትን ይደግፉ።</string>

--- a/app/src/foss/res/values-ar/strings.xml
+++ b/app/src/foss/res/values-ar/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">كن راعياً</string>
     <string name="upgrade_foss_sponsor_subtitle">يفتح GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">يُرجى تخصيص لحظة للاطلاع على صفحة الراعيين!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">النسخة المجانية</string>
     <string name="upgrade_screen_status_free_body">أنت تستخدم الإصدار المجاني مفتوح المصدر. ادعم التطوير لفتح ميزات Pro.</string>

--- a/app/src/foss/res/values-az/strings.xml
+++ b/app/src/foss/res/values-az/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">Sponsor ol</string>
     <string name="upgrade_foss_sponsor_subtitle">GitHub Sponsors açır</string>
     <string name="upgrade_foss_sponsor_returned_early">Zəhmət olmasa sponsor səhifəsinə bir baxın!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Pulsuz versiya</string>
     <string name="upgrade_screen_status_free_body">Siz pulsuz, açıq mənbəli versiyadan istifadə edirsiniz. Pro funksiyalarını aktivləşdirmək üçün inkişafı dəstəkləyin.</string>

--- a/app/src/foss/res/values-be/strings.xml
+++ b/app/src/foss/res/values-be/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">Стаць спонсарам</string>
     <string name="upgrade_foss_sponsor_subtitle">Адкрывае GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Калі ласка, зазірніце на старонку спонсараў!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Бясплатная версія</string>
     <string name="upgrade_screen_status_free_body">Вы карыстаецеся бясплатнай зборкай з адкрытым зыходным кодам. Падтрымайце распрацоўку, каб адкрыць функцыі Pro.</string>

--- a/app/src/foss/res/values-bg/strings.xml
+++ b/app/src/foss/res/values-bg/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">Станете спонсор</string>
     <string name="upgrade_foss_sponsor_subtitle">Отваря GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Моля, отделете момент да разгледате страницата на спонсорите!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Безплатна версия</string>
     <string name="upgrade_screen_status_free_body">Използвате безплатната версия с отворен код. Подкрепете разработката, за да отключите Pro функциите.</string>

--- a/app/src/foss/res/values-bn-rBD/strings.xml
+++ b/app/src/foss/res/values-bn-rBD/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">স্পনসর হন</string>
     <string name="upgrade_foss_sponsor_subtitle">GitHub Sponsors খুলবে</string>
     <string name="upgrade_foss_sponsor_returned_early">দয়া করে স্পনসর পেজটি দেখুন!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">বিনামূল্যে সংস্করণ</string>
     <string name="upgrade_screen_status_free_body">আপনি বিনামূল্যের, ওপেন-সোর্স বিল্ড ব্যবহার করছেন। প্রো বৈশিষ্ট্যগুলি আনলক করতে উন্নয়নকে সমর্থন করুন।</string>

--- a/app/src/foss/res/values-ca/strings.xml
+++ b/app/src/foss/res/values-ca/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">Convertiu-vos en patrocinador</string>
     <string name="upgrade_foss_sponsor_subtitle">Obre els patrocinadors del GitHub</string>
     <string name="upgrade_foss_sponsor_returned_early">Dediqueu un moment a consultar la pàgina del patrocinador!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Versió gratuïta</string>
     <string name="upgrade_screen_status_free_body">Esteu utilitzant la compilació gratuïta i de codi obert. Doneu suport al desenvolupament per desbloquejar les funcions Pro.</string>

--- a/app/src/foss/res/values-cs/strings.xml
+++ b/app/src/foss/res/values-cs/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">Stát se sponzorem</string>
     <string name="upgrade_foss_sponsor_subtitle">Otevře GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Prosím, věnujte chvíli prohlédnutí stránky sponzorů!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Bezplatná verze</string>
     <string name="upgrade_screen_status_free_body">Používáte bezplatnou verzi s otevřeným zdrojovým kódem. Podpořte vývoj a odemkněte funkce Pro.</string>

--- a/app/src/foss/res/values-da/strings.xml
+++ b/app/src/foss/res/values-da/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">Bliv sponsor</string>
     <string name="upgrade_foss_sponsor_subtitle">Åbner GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Tag et øjeblik til at kigge på sponsorsiden!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Gratis version</string>
     <string name="upgrade_screen_status_free_body">Du bruger den gratis open-source-udgave. Støt udviklingen for at låse Pro-funktionerne op.</string>

--- a/app/src/foss/res/values-de/strings.xml
+++ b/app/src/foss/res/values-de/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">Sponsor werden</string>
     <string name="upgrade_foss_sponsor_subtitle">Öffnet GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Bitte nimm dir einen Moment, um die Sponsor-Seite zu besuchen!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Kostenlose Version</string>
     <string name="upgrade_screen_status_free_body">Sie verwenden den kostenlosen Open-Source-Build. Unterstützen Sie die Entwicklung, um die Pro-Funktionen freizuschalten.</string>

--- a/app/src/foss/res/values-el/strings.xml
+++ b/app/src/foss/res/values-el/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">Γίνετε Χορηγός</string>
     <string name="upgrade_foss_sponsor_subtitle">Ανοίγει το GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Αφιερώστε λίγο χρόνο για να δείτε τη σελίδα χορηγών!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Δωρεάν έκδοση</string>
     <string name="upgrade_screen_status_free_body">Χρησιμοποιείτε την δωρεάν, ανοιχτού κώδικα έκδοση. Υποστηρίξτε την ανάπτυξη για να ξεκλειδώσετε τις Pro δυνατότητες.</string>

--- a/app/src/foss/res/values-es/strings.xml
+++ b/app/src/foss/res/values-es/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">Conviértete en patrocinador</string>
     <string name="upgrade_foss_sponsor_subtitle">Abre GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">¡Por favor, tómate un momento para visitar la página de patrocinadores!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Versión gratuita</string>
     <string name="upgrade_screen_status_free_body">Estás usando la compilación gratuita de código abierto. Apoya el desarrollo para desbloquear las funciones Pro.</string>

--- a/app/src/foss/res/values-fi/strings.xml
+++ b/app/src/foss/res/values-fi/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">Tule sponsoriksi</string>
     <string name="upgrade_foss_sponsor_subtitle">Avaa GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Käy katsomassa sponsorointisivua!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Ilmainen versio</string>
     <string name="upgrade_screen_status_free_body">Käytät ilmaista, avoimen lähdekoodin versiota. Tue kehitystä vapauttaaksesi Pro-ominaisuudet.</string>

--- a/app/src/foss/res/values-fr/strings.xml
+++ b/app/src/foss/res/values-fr/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">Devenir sponsor</string>
     <string name="upgrade_foss_sponsor_subtitle">Ouvre GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Prenez un moment pour consulter la page des sponsors !</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Version gratuite</string>
     <string name="upgrade_screen_status_free_body">Vous utilisez la version libre et open-source. Soutenez le développement pour débloquer les fonctionnalités Pro.</string>

--- a/app/src/foss/res/values-hi-rIN/strings.xml
+++ b/app/src/foss/res/values-hi-rIN/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">स्पॉन्सर बनें</string>
     <string name="upgrade_foss_sponsor_subtitle">GitHub Sponsors खोलता है</string>
     <string name="upgrade_foss_sponsor_returned_early">कृपया स्पॉन्सर पेज एक बार जरूर देखें!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">मुफ्त संस्करण</string>
     <string name="upgrade_screen_status_free_body">आप मुफ्त, ओपन-सोर्स संस्करण का उपयोग कर रहे हैं। प्रो सुविधाओं को अनलॉक करने के लिए विकास का समर्थन करें।</string>

--- a/app/src/foss/res/values-hr/strings.xml
+++ b/app/src/foss/res/values-hr/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">Postani sponzor</string>
     <string name="upgrade_foss_sponsor_subtitle">Otvara GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Molim odvojite trenutak i pogledajte stranicu sponzora!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Besplatna verzija</string>
     <string name="upgrade_screen_status_free_body">Koristite besplatnu inačicu otvorenog koda. Podržite razvoj da otključate Pro značajke.</string>

--- a/app/src/foss/res/values-hu/strings.xml
+++ b/app/src/foss/res/values-hu/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">Legyen szponzor</string>
     <string name="upgrade_foss_sponsor_subtitle">GitHub Sponsors megnyitása</string>
     <string name="upgrade_foss_sponsor_returned_early">Kérlek, szánj egy pillanatot a szponzor oldal megtekintésére!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Ingyenes verzió</string>
     <string name="upgrade_screen_status_free_body">Az ingyenes, nyílt forráskódú verziót használod. Támogasd a fejlesztést a Pro funkciók feloldásához.</string>

--- a/app/src/foss/res/values-it/strings.xml
+++ b/app/src/foss/res/values-it/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">Diventa uno sponsor</string>
     <string name="upgrade_foss_sponsor_subtitle">Apre GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Per favore, prenditi un momento per visitare la pagina degli sponsor!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Versione gratuita</string>
     <string name="upgrade_screen_status_free_body">Stai usando la versione gratuita e open-source. Sostieni lo sviluppo per sbloccare le funzionalità Pro.</string>

--- a/app/src/foss/res/values-iw/strings.xml
+++ b/app/src/foss/res/values-iw/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">הפוך לספונסר</string>
     <string name="upgrade_foss_sponsor_subtitle">פותח את GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">אנא קדישי רגע לבדוק את דף הספונסרים!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">גרסה חינמית</string>
     <string name="upgrade_screen_status_free_body">אתה משתמש בבנייה חינמית וקוד פתוח. תמוך בפיתוח כדי לפתוח את תכונות Pro.</string>

--- a/app/src/foss/res/values-ja/strings.xml
+++ b/app/src/foss/res/values-ja/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">スポンサーになる</string>
     <string name="upgrade_foss_sponsor_subtitle">GitHub Sponsorsを開く</string>
     <string name="upgrade_foss_sponsor_returned_early">スポンサーページをご覧ください！</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">無料版</string>
     <string name="upgrade_screen_status_free_body">無料のオープンソースビルドを使用しています。開発を支援して Pro 機能をロック解除してください。</string>

--- a/app/src/foss/res/values-ko/strings.xml
+++ b/app/src/foss/res/values-ko/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">스폰서 되기</string>
     <string name="upgrade_foss_sponsor_subtitle">GitHub Sponsors 열기</string>
     <string name="upgrade_foss_sponsor_returned_early">스폰서 페이지를 일찍 확인해 주세요!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">무료 버전</string>
     <string name="upgrade_screen_status_free_body">무료 오픈소스 빌드를 사용 중입니다. 개발을 지원하여 Pro 기능을 잠금 해제하세요.</string>

--- a/app/src/foss/res/values-ku-rTR/strings.xml
+++ b/app/src/foss/res/values-ku-rTR/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">بوونهەڵبەستكەری بھە</string>
     <string name="upgrade_foss_sponsor_subtitle">کرانەوەی GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">تکایە کاتێک لەبەر دووری بخوێنەوە بۆ پەڕەی سپۆنسەرەکان!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Guhertoya azad</string>
     <string name="upgrade_screen_status_free_body">Tu guhertoya azad û open-source ya bikar tînî. Pêşve tînana vê sepê piştgirî bike ji bo der kirina taybetmendiyên Pro.</string>

--- a/app/src/foss/res/values-nb/strings.xml
+++ b/app/src/foss/res/values-nb/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">Bli sponsor</string>
     <string name="upgrade_foss_sponsor_subtitle">Åpner GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Ta et øyeblikk til å sjekke ut sponsorsiden!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Gratis versjon</string>
     <string name="upgrade_screen_status_free_body">Du bruker den gratis, åpen kildekode-versjonen. Støtt utviklingen for å låse opp Pro-funksjonene.</string>

--- a/app/src/foss/res/values-nl/strings.xml
+++ b/app/src/foss/res/values-nl/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">Word sponsor</string>
     <string name="upgrade_foss_sponsor_subtitle">Opent GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Neem even een moment om de sponsorpagina te bekijken!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Gratis versie</string>
     <string name="upgrade_screen_status_free_body">Je gebruikt de gratis, opensource-versie. Ondersteun de ontwikkeling om de Pro-functies te ontgrendelen.</string>

--- a/app/src/foss/res/values-pl/strings.xml
+++ b/app/src/foss/res/values-pl/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">Zostań sponsorem</string>
     <string name="upgrade_foss_sponsor_subtitle">Otwieranie strony sponsorów GitHub</string>
     <string name="upgrade_foss_sponsor_returned_early">Poświęć chwilę na odwiedzenie strony sponsorów!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Pilot Uprawnień Foss</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Wersja darmowa</string>
     <string name="upgrade_screen_status_free_body">Korzystasz z bezpłatnej wersji otwarto-źródłowej. Wesprzyj rozwój, aby odblokować funkcje wersji Pro.</string>

--- a/app/src/foss/res/values-pt-rBR/strings.xml
+++ b/app/src/foss/res/values-pt-rBR/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">Torne-se um patrocinador</string>
     <string name="upgrade_foss_sponsor_subtitle">Abre o GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Por favor, reserve um momento para visitar a página de patrocinadores!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Versão gratuita</string>
     <string name="upgrade_screen_status_free_body">Você está usando a versão gratuita e de código aberto. Apoie o desenvolvimento para desbloquear os recursos Pro.</string>

--- a/app/src/foss/res/values-pt/strings.xml
+++ b/app/src/foss/res/values-pt/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">Tornar-se Patrocinador</string>
     <string name="upgrade_foss_sponsor_subtitle">Abre os Patrocinadores do GitHub</string>
     <string name="upgrade_foss_sponsor_returned_early">Por favor reserve um momento para visitar a página de patrocinadores!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Versão gratuita</string>
     <string name="upgrade_screen_status_free_body">Está a usar a versão gratuita e de código aberto. Apoie o desenvolvimento para desbloquear as funcionalidades Pro.</string>

--- a/app/src/foss/res/values-ro/strings.xml
+++ b/app/src/foss/res/values-ro/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">Devino sponsor</string>
     <string name="upgrade_foss_sponsor_subtitle">Deschide GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Te rugăm să arunci o privire la pagina de sponsori!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Versiunea gratuită</string>
     <string name="upgrade_screen_status_free_body">Folosești versiunea gratuită, cu sursă deschisă. Sprijină dezvoltarea pentru a debloca funcțiile Pro.</string>

--- a/app/src/foss/res/values-ru/strings.xml
+++ b/app/src/foss/res/values-ru/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">Стать спонсором</string>
     <string name="upgrade_foss_sponsor_subtitle">Открывает GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Пожалуйста, уделите момент и посетите страницу спонсора!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Бесплатная версия</string>
     <string name="upgrade_screen_status_free_body">Вы используете бесплатную, открытую версию. Поддержите разработку, чтобы разблокировать функции Pro.</string>

--- a/app/src/foss/res/values-sk/strings.xml
+++ b/app/src/foss/res/values-sk/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">Stať sa sponzorom</string>
     <string name="upgrade_foss_sponsor_subtitle">Otvorí GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Prosím, ven\'te chvíľu na prezrenie stránky sponzorov!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Bezplatná verzia</string>
     <string name="upgrade_screen_status_free_body">Používate bezplatnú, otvorenú verziu. Podporte vývoj a odomknite funkcie Pro.</string>

--- a/app/src/foss/res/values-sr/strings.xml
+++ b/app/src/foss/res/values-sr/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">Постаните спонзор</string>
     <string name="upgrade_foss_sponsor_subtitle">Отвара GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Посветите тренутак да погледате страницу спонзора!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Бесплатна верзија</string>
     <string name="upgrade_screen_status_free_body">Користите бесплатну верзију отвореног кода. Подржите развој да откључате Pro функције.</string>

--- a/app/src/foss/res/values-sv/strings.xml
+++ b/app/src/foss/res/values-sv/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">Bli sponsor</string>
     <string name="upgrade_foss_sponsor_subtitle">Öppnar GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Ta gärna en stund att kolla in sponsorsidan!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Gratis version</string>
     <string name="upgrade_screen_status_free_body">Du använder den kostnadsfria, öppen källkods-versionen. Stöd utvecklingen för att låsa upp Pro-funktionerna.</string>

--- a/app/src/foss/res/values-th/strings.xml
+++ b/app/src/foss/res/values-th/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">เป็นผู้สนับสนุน</string>
     <string name="upgrade_foss_sponsor_subtitle">เปิด GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">โปรดใช้เวลาสักครู่เช็คหน้าผู้สนับสนุน!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">เวอร์ชันฟรี</string>
     <string name="upgrade_screen_status_free_body">คุณใช้บิลด์ฟรีและโอเพนซอร์ส สนับสนุนการพัฒนาเพื่อปลดล็อคฟีเจอร์ Pro</string>

--- a/app/src/foss/res/values-tr/strings.xml
+++ b/app/src/foss/res/values-tr/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">Sponsor Ol</string>
     <string name="upgrade_foss_sponsor_subtitle">GitHub Sponsors\'u açar</string>
     <string name="upgrade_foss_sponsor_returned_early">Lütfen bir dakikanızı ayırıp sponsor sayfasına göz atın!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Ücretsiz sürüm</string>
     <string name="upgrade_screen_status_free_body">Ücretsiz, açık kaynaklı sürümü kullanıyorsunuz. Pro özelliklerinin kilidini açmak için geliştirmeyi destekleyin.</string>

--- a/app/src/foss/res/values-uk/strings.xml
+++ b/app/src/foss/res/values-uk/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">Стати спонсором</string>
     <string name="upgrade_foss_sponsor_subtitle">Відкриває сторінку GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Будь ласка, ознайомтеся зі сторінкою спонсора!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Безплатна версія</string>
     <string name="upgrade_screen_status_free_body">Ви використовуєте безплатну версію з відкритим кодом. Підтримайте розробку, щоб розблокувати функції Pro.</string>

--- a/app/src/foss/res/values-vi/strings.xml
+++ b/app/src/foss/res/values-vi/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">Trở thành nhà tài trợ</string>
     <string name="upgrade_foss_sponsor_subtitle">Mở GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">Vui lòng dành chút thời gian ghé thăm trang nhà tài trợ!</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Phiên bản miễn phí</string>
     <string name="upgrade_screen_status_free_body">Bạn đang dùng phiên bản miễn phí, mã nguồn mở. Hỗ trợ phát triển để mở khóa tính năng Pro.</string>

--- a/app/src/foss/res/values-zh-rCN/strings.xml
+++ b/app/src/foss/res/values-zh-rCN/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">成为赞助者</string>
     <string name="upgrade_foss_sponsor_subtitle">打开 GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">请花点时间查看赞助页面！</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">免费版本</string>
     <string name="upgrade_screen_status_free_body">您正在使用免费的开源版本。支持开发以解锁 Pro 功能。</string>

--- a/app/src/foss/res/values-zh-rTW/strings.xml
+++ b/app/src/foss/res/values-zh-rTW/strings.xml
@@ -4,8 +4,6 @@
     <string name="upgrade_foss_sponsor_action">成為贊助者</string>
     <string name="upgrade_foss_sponsor_subtitle">開啟 GitHub Sponsors</string>
     <string name="upgrade_foss_sponsor_returned_early">請花一點時間查看贊助頁面！</string>
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">免費版本</string>
     <string name="upgrade_screen_status_free_body">您正在使用免費的開源版本。請支持開發以解鎖 Pro 功能。</string>

--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -6,8 +6,6 @@
     <string name="upgrade_foss_sponsor_returned_early">Please take a moment to check out the sponsor page!</string>
     <string name="upgrade_title_suffix" translatable="false">FOSS</string>
 
-    <!-- Settings entry title (FOSS flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot FOSS</string>
 
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Free version</string>

--- a/app/src/gplay/res/values-af-rZA/strings.xml
+++ b/app/src/gplay/res/values-af-rZA/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">Dit lyk asof u hierdie toestel reeds na Pro opgegradering gedoen het. Herstel u aankoop om dit weer te ontgrendel.</string>
     <string name="upgrade_screen_options_description">Intekeninge vernuwe outomaties. Jy kan enige tyd kanselleer.</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">U is Pro — dankie!</string>
     <string name="upgrade_screen_owned_hero_iap_body">U eenmalige Pro-aankoop ontsluit alle Pro-funksies, voorgoed.</string>

--- a/app/src/gplay/res/values-am/strings.xml
+++ b/app/src/gplay/res/values-am/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">በዚህ መሣሪያ ላይ በፊት Pro ገዝተዋል ይመስላል። ዳግም ለመክፈት ግዢዎን ወደ ነበር ሆኑ።</string>
     <string name="upgrade_screen_options_description">ኰይዘቶች በርስ ይተያያኳሉ። በአንደም መቀሰል ይቻላሉ።</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Pro ነዎ — አመሰግናለሁ!</string>
     <string name="upgrade_screen_owned_hero_iap_body">የአንድ ጊዜ Pro ግዢ ሁሉንም Pro ባህሪ ለዘላለም ይከፍታል።</string>

--- a/app/src/gplay/res/values-ar/strings.xml
+++ b/app/src/gplay/res/values-ar/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">يبدو أنك ترقيت إلى Pro على هذا الجهاز من قبل. استعد شراءك لفتح قفله مرة أخرى.</string>
     <string name="upgrade_screen_options_description">تتجدد الاشتراكات تلقائياً. يمكنك الإلغاء في أي وقت.</string>
     <string name="upgrade_title_suffix">احترافي</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">أنت Pro الآن - شكراً لك!</string>
     <string name="upgrade_screen_owned_hero_iap_body">شراء Pro لمرة واحدة يفتح كل ميزة Pro إلى الأبد.</string>

--- a/app/src/gplay/res/values-az/strings.xml
+++ b/app/src/gplay/res/values-az/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">Görünür ki, siz bu cihazda əvvəllər Pro-ya yüksəltdiniz. Bunu yenidən aktivləşdirmək üçün satın almağı bərpa edin.</string>
     <string name="upgrade_screen_options_description">Abunəliklər avtomatik olaraq yenilinər. Hər zaman ldö bilərsiniz.</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Siz Pro istifadəçisisiniz — təşəkkür edirik!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Sizin tek seferlik Pro alımı hər Pro xüsusiyyətini əbədi açır.</string>

--- a/app/src/gplay/res/values-be/strings.xml
+++ b/app/src/gplay/res/values-be/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">Выглядае, што вы раней купілі Pro на гэтым прыладзе. Аднавіце сваю пакупку, каб адблакаваць яе яшчэ раз.</string>
     <string name="upgrade_screen_options_description">Падпіскі аўтаматычна абнаўляюцца. Вы можаце адмяніць іх у любы час.</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Вы маеце Pro — дзякуй!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Ваша аднаразовая пакупка Pro адкрывае ўсе функцыі Pro назаўжды.</string>

--- a/app/src/gplay/res/values-bg/strings.xml
+++ b/app/src/gplay/res/values-bg/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">Изглежда, че преди сте надстроили към Pro на това устройство. Възстановете покупката си, за да я отключите отново.</string>
     <string name="upgrade_screen_options_description">Абонаментите се поднавят автоматично. Можете да откажете по всяко време.</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Вие сте Pro — благодаря!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Вашата еднократна Pro покупка отключва всяка Pro функция, завинаги.</string>

--- a/app/src/gplay/res/values-bn-rBD/strings.xml
+++ b/app/src/gplay/res/values-bn-rBD/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">মনে হচ্ছে আপনি এই ডিভাইসে আগে Pro-তে আপগ্রেড করেছেন। এটি আবার আনলক করতে আপনার ক্রয় পুনরুদ্ধার করুন।</string>
     <string name="upgrade_screen_options_description">সাবস্ক্রিপশন স্বয়ংক্রিয়ভাবে নবায়ন হয়। যেকোনো সময় বাতিল করতে পারেন।</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">আপনি Pro ব্যবহারকারী — ধন্যবাদ!</string>
     <string name="upgrade_screen_owned_hero_iap_body">আপনার একবারের Pro ক্রয় প্রতিটি Pro বৈশিষ্ট্য চিরকালের জন্য আনলক করে।</string>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">Sembla que ja vau actualitzar al Pro en aquest dispositiu abans. Restaureu la vostra compra per tornar-la a desbloquejar.</string>
     <string name="upgrade_screen_options_description">Les subscripcions es renoven automàticament. Podeu cancel·lar-les en qualsevol moment.</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Sou Pro, gràcies!</string>
     <string name="upgrade_screen_owned_hero_iap_body">La vostra compra única desbloqueja totes les funcions de Pro, per sempre.</string>

--- a/app/src/gplay/res/values-cs/strings.xml
+++ b/app/src/gplay/res/values-cs/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">Vypadá to, že jste již dříve upgradovali na Pro na tomto zařízení. Obnovte svůj nákup a odemkněte jej znovu.</string>
     <string name="upgrade_screen_options_description">Předplatné se obnovuje automaticky. Můžete je kdykoliv zrušit.</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Jste Pro — děkujeme!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Váš jednorázový nákup Pro odemyká každou funkci Pro navždy.</string>

--- a/app/src/gplay/res/values-da/strings.xml
+++ b/app/src/gplay/res/values-da/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">Det ser ud til, at du allerede har opgraderet til Pro på denne enhed. Gendan dit køb for at låse det op igen.</string>
     <string name="upgrade_screen_options_description">Abonnementer fornyes automatisk. Du kan annullere når som helst.</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Du er Pro – tak!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Dit engangs Pro-køb låser op for alle Pro-funktioner, for evigt.</string>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">Es sieht so aus, als hättest du auf diesem Gerät schon einmal ein Upgrade auf Pro durchgeführt. Stelle deinen Kauf wieder her, um es erneut freizuschalten.</string>
     <string name="upgrade_screen_options_description">Abonnements verlängern sich automatisch. Du kannst jederzeit kündigen.</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Sie haben Pro – vielen Dank!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Ihr einmaliger Pro-Kauf entsperrt alle Pro-Funktionen für immer.</string>

--- a/app/src/gplay/res/values-el/strings.xml
+++ b/app/src/gplay/res/values-el/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">Φαίνεται ότι κάνατε αναβάθμιση σε Pro σε αυτήν τη συσκευή στο παρελθόν. Επαναφέρετε την αγορά σας για να το ξεκλειδώσετε ξανά.</string>
     <string name="upgrade_screen_options_description">Οι συνδρομές ανανεώνονται αυτόματα. Μπορείτε να ακυρώσετε ανά πάσα στιγμή.</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Είστε Pro — ευχαριστούμε!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Η ενιαία αγορά Pro ξεκλειδώνει κάθε λειτουργία Pro, για πάντα.</string>

--- a/app/src/gplay/res/values-es/strings.xml
+++ b/app/src/gplay/res/values-es/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">Parece que ya actualizaste a Pro en este dispositivo antes. Restaura tu compra para desbloquearlo de nuevo.</string>
     <string name="upgrade_screen_options_description">Las suscripciones se renuevan automáticamente. Puedes cancelar en cualquier momento.</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">¡Eres Pro — gracias!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Tu compra única de Pro desbloquea todas las funciones Pro, para siempre.</string>

--- a/app/src/gplay/res/values-fi/strings.xml
+++ b/app/src/gplay/res/values-fi/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">Näyttää siltä, että olet päivittänyt Pro-versioon tällä laitteella aiemmin. Palauta ostoksesi avataksesi sen uudelleen.</string>
     <string name="upgrade_screen_options_description">Tilaukset uusiutuvat automaattisesti. Voit peruuttaa milloin tahansa.</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Olet Pro – kiitos!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Kertaluonteinen Pro-ostos avaa kaikki Pro-ominaisuudet ikuisesti.</string>

--- a/app/src/gplay/res/values-fr/strings.xml
+++ b/app/src/gplay/res/values-fr/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">Il semble que vous ayez déjà fait la mise à niveau vers Pro sur cet appareil. Restaurez votre achat pour le déverrouiller à nouveau.</string>
     <string name="upgrade_screen_options_description">Les abonnements se renouvellent automatiquement. Vous pouvez annuler à tout moment.</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Vous êtes Pro — merci !</string>
     <string name="upgrade_screen_owned_hero_iap_body">Votre achat Pro unique déverrouille toutes les fonctionnalités Pro, pour toujours.</string>

--- a/app/src/gplay/res/values-hi-rIN/strings.xml
+++ b/app/src/gplay/res/values-hi-rIN/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">ऐसा लगता है कि आप इस डिवाइस पर पहले Pro पर अपग्रेड कर चुके हैं। इसे फिर से अनलॉक करने के लिए अपनी खरीद को पुनः स्थापित करें।</string>
     <string name="upgrade_screen_options_description">सदस्यता स्वचालित रूप से नवीनीकृत होती है। आप कभी भी रद्द कर सकते हैं।</string>
     <string name="upgrade_title_suffix">प्रो</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">आप Pro हैं — धन्यवाद!</string>
     <string name="upgrade_screen_owned_hero_iap_body">आपकी एक बार की Pro खरीद हमेशा के लिए हर Pro सुविधा को अनलॉक करती है।</string>

--- a/app/src/gplay/res/values-hr/strings.xml
+++ b/app/src/gplay/res/values-hr/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">Čini se da ste se prije na ovom uređaju nadogradili na Pro. Vratite vašu kupnju da je ponovno otključate.</string>
     <string name="upgrade_screen_options_description">Pretplate se automatski obnavljaju. Možete otkazati u bilo koje vrijeme.</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Sada ste Pro — hvala!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Vaša jednokratna Pro kupnja otključava sve Pro značajke zauvijek.</string>

--- a/app/src/gplay/res/values-hu/strings.xml
+++ b/app/src/gplay/res/values-hu/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">Úgy tűnik, korábban már Pro-ra frissítettél ezen az eszközön. Állítsd vissza a vásárlást, hogy újra feloldhasd.</string>
     <string name="upgrade_screen_options_description">Az előfizetések automatikusan megújulnak. Bármikor lemondhatod.</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Pro vagy – köszönjük!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Az egyszeri Pro vásárlásod minden Pro funkciót feloldja, örökre.</string>

--- a/app/src/gplay/res/values-it/strings.xml
+++ b/app/src/gplay/res/values-it/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">Sembra che tu abbia già acquistato Pro su questo dispositivo. Ripristina il tuo acquisto per sbloccarlo di nuovo.</string>
     <string name="upgrade_screen_options_description">Gli abbonamenti si rinnovano automaticamente. Puoi annullare in qualsiasi momento.</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Sei Pro — grazie!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Il tuo acquisto unico di Pro sblocca ogni funzione Pro, per sempre.</string>

--- a/app/src/gplay/res/values-iw/strings.xml
+++ b/app/src/gplay/res/values-iw/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">נראה שהשדרגת ל-Pro בעבר בהתקן זה. השחזר את הרכישה שלך כדי לפתוח אותה שוב.</string>
     <string name="upgrade_screen_options_description">מנויים מתחדשים אוטומטית. ניתן לבטל בכל עת.</string>
     <string name="upgrade_title_suffix">פרו</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">אתה Pro — תודה!</string>
     <string name="upgrade_screen_owned_hero_iap_body">הרכישה החד-פעמית של Pro שלך פותחת את כל תכונות Pro, לנצח.</string>

--- a/app/src/gplay/res/values-ja/strings.xml
+++ b/app/src/gplay/res/values-ja/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">以前このデバイスで Pro にアップグレードしたようです。購入を復元して Pro をもう一度ロック解除してください。</string>
     <string name="upgrade_screen_options_description">サブスクリプションは自動更新されます。いつでもキャンセルできます。</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Pro のご利用ありがとうございます！</string>
     <string name="upgrade_screen_owned_hero_iap_body">Pro のワンタイム購入により、すべての Pro 機能が永久にロック解除されます。</string>

--- a/app/src/gplay/res/values-ko/strings.xml
+++ b/app/src/gplay/res/values-ko/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">이 기기에서 이전에 Pro로 업그레이드했던 것 같습니다. 구매를 복구하여 Pro를 다시 사용하세요.</string>
     <string name="upgrade_screen_options_description">구독은 자동으로 갱신됩니다. 언제든지 취소할 수 있습니다.</string>
     <string name="upgrade_title_suffix">프로</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Pro 이용 중이시네요 — 감사합니다!</string>
     <string name="upgrade_screen_owned_hero_iap_body">일회성 Pro 구매로 모든 Pro 기능을 영원히 사용할 수 있습니다.</string>

--- a/app/src/gplay/res/values-ku-rTR/strings.xml
+++ b/app/src/gplay/res/values-ku-rTR/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">Xuya dike ku tu berê li vî amûrî veguhastî Pro. Beşdarkirina xwe venîştin da ku cara dî vê vekin.</string>
     <string name="upgrade_screen_options_description">بوونهەڵبەستەکان بە خۆدیکەوە نوێكردرەوەن. دەتوانیت ھەر کاتیک لاببکەیت.</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Tu Pro yî — spas!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Kirîna Pro-ya yek-car hemû taybetmendiyên Pro derxîne, sedemzî.</string>

--- a/app/src/gplay/res/values-nb/strings.xml
+++ b/app/src/gplay/res/values-nb/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">Det ser ut til at du oppgraderte til Pro på denne enheten før. Gjenopprett kjøpet ditt for å låse det opp igjen.</string>
     <string name="upgrade_screen_options_description">Abonnementer fornyes automatisk. Du kan avbryte når som helst.</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Du er Pro – takk!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Ditt engangs Pro-kjøp låser opp hver Pro-funksjon, for alltid.</string>

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">Het lijkt erop dat je op dit apparaat eerder naar Pro bent geüpgraded. Herstel je aankoop om het opnieuw in te schakelen.</string>
     <string name="upgrade_screen_options_description">Abonnementen verlengen automatisch. Je kunt op elk moment opzeggen.</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Je bent Pro — dank je wel!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Je eenmalige Pro-aankoop ontgrendelt elk Pro-onderdeel voor altijd.</string>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">Wygląda na to, że na tym urządzeniu dokonałeś już wcześniej aktualizacji do wersji Pro. Przywróć zakup, aby ją ponownie odblokować.</string>
     <string name="upgrade_screen_options_description">Subskrypcje odnawiają się automatycznie. Możesz anulować w dowolnym momencie.</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Pilot Uprawnień Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Jesteś Pro - dziękuję!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Twój jednorazowy zakup Pro odblokowuje każdą funkcję Pro na zawsze.</string>

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">Parece que você atualizou para Pro neste dispositivo antes. Restaure sua compra para desbloqueá-lo novamente.</string>
     <string name="upgrade_screen_options_description">As assinaturas são renovadas automaticamente. Você pode cancelar a qualquer momento.</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Você é Pro — obrigado!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Sua compra única do Pro desbloqueia todos os recursos Pro, para sempre.</string>

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">Parece que já atualizou para Pro neste dispositivo. Restaure a compra para o desbloquear novamente.</string>
     <string name="upgrade_screen_options_description">As subscrições renovam automaticamente. Pode cancelar a qualquer momento.</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Tem o Pro — obrigado!</string>
     <string name="upgrade_screen_owned_hero_iap_body">A sua compra única do Pro desbloqueia todas as funcionalidades Pro, para sempre.</string>

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">Se pare că ai cumpărat versiunea Pro pe acest dispozitiv anterior. Restaurează achiziția pentru a o debloca din nou.</string>
     <string name="upgrade_screen_options_description">Abonamentele se reînnoiesc automat. Poți anula oricând.</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Ești Pro — mulțumim!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Achiziția ta Pro de o singură dată deblochează fiecare caracteristică Pro, pentru totdeauna.</string>

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">Похоже, что Вы уже обновились до Pro на этом устройстве. Восстановите свою покупку, чтобы разблокировать его снова.</string>
     <string name="upgrade_screen_options_description">Подписки обновляются автоматически. Вы можете отменить в любое время.</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Вы Pro — спасибо!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Ваша единоразовая покупка Pro разблокирует все функции Pro навсегда.</string>

--- a/app/src/gplay/res/values-sk/strings.xml
+++ b/app/src/gplay/res/values-sk/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">Vyzerá to, že ste na tomto zariadení predtým upgradovali na Pro. Obnovte si nákup a odomknite ho znova.</string>
     <string name="upgrade_screen_options_description">Predplatné sa obnovia automaticky. Môžete ich kedykoľvek zrušiť.</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Ste Pro — ďakujeme!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Váš jednorazový nákup Pro odomyká všetky funkcie Pro. Navždy.</string>

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">Изгледа да сте раније купили Pro на овом уређају. Вратите куповину да откључате Pro.</string>
     <string name="upgrade_screen_options_description">Претплате се аутоматски обнављају. Можете отказати када хоћете.</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Ви сте Pro — хвала!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Ваша једнократна куповина Pro откључава све Pro функције заувек.</string>

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">Det verkar som om du redan uppgraderade till Pro på den här enheten tidigare. Återställ ditt köp för att låsa upp det igen.</string>
     <string name="upgrade_screen_options_description">Prenumerationer förnyas automatiskt. Du kan avsluta när som helst.</string>
     <string name="upgrade_title_suffix">Expert</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Du är Pro – tack!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Ditt engångköp av Pro låser upp alla Pro-funktioner för alltid.</string>

--- a/app/src/gplay/res/values-th/strings.xml
+++ b/app/src/gplay/res/values-th/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">ดูเหมือนว่าคุณได้อัปเกรดเป็น Pro บนอุปกรณ์นี้มาแล้ว คืนค่าการซื้อของคุณเพื่อปลดล็อคอีกครั้ง</string>
     <string name="upgrade_screen_options_description">สมาชิกภาพจะต่ออายุโดยอัตโนมัติ คุณยกเลิกได้เมื่อใดก็ได้</string>
     <string name="upgrade_title_suffix">โปร</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">คุณเป็น Pro — ขอบคุณ!</string>
     <string name="upgrade_screen_owned_hero_iap_body">การซื้อ Pro ครั้งเดียวของคุณปลดล็อคฟีเจอร์ Pro ทั้งหมดเป็นการถาวร</string>

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">Bu cihazda daha önce Pro\'ya yükseltme yaptığınız görülüyor. Satın almayı geri yükleyin ve kilidi açın.</string>
     <string name="upgrade_screen_options_description">Abonelikler otomatik olarak yenilenir. İstediğiniz zaman iptal edebilirsiniz.</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Pro\'sunuz — teşekkür ederiz!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Bir defaya mahsus Pro satın alımınız tüm Pro özelliklerini sonsuza kadar açar.</string>

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">Схоже, раніше ви оновили цей пристрій до Pro. Відновіть вашу покупку, щоб розблокувати його ще раз.</string>
     <string name="upgrade_screen_options_description">Підписки поновлюються автоматично. Скасувати можна будь-коли.</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Ви маєте Pro — дякуємо!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Ваша одноразова покупка Pro розблокує всі функції Pro навічно.</string>

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">Có vẻ như bạn đã nâng cấp lên Pro trên thiết bị này trước đó. Khôi phục mua hàng của bạn để mở khóa lại.</string>
     <string name="upgrade_screen_options_description">Đăng ký sẽ tự động gia hạn. Bạn có thể hủy bất kỳ lúc nào.</string>
     <string name="upgrade_title_suffix">Pro</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">Bạn là Pro — cảm ơn bạn!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Mua hàng Pro một lần của bạn mở khóa mọi tính năng Pro, mãi mãi.</string>

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">看起来您之前在此设备上升级到 Pro。恢复您的购买以再次解锁。</string>
     <string name="upgrade_screen_options_description">订阅自动续费，可随时取消。</string>
     <string name="upgrade_title_suffix">专业版</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">您是 Pro 用户，感谢您！</string>
     <string name="upgrade_screen_owned_hero_iap_body">您的一次性 Pro 购买永久解锁所有 Pro 功能。</string>

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -18,8 +18,6 @@
     <string name="upgrade_screen_restore_banner_body">看起來您之前在此裝置上升級至 Pro。復原您的購買以重新解鎖。</string>
     <string name="upgrade_screen_options_description">訂閱自動續費。您可隨時取消。</string>
     <string name="upgrade_title_suffix">專業版</string>
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">您已升級至 Pro——感謝您！</string>
     <string name="upgrade_screen_owned_hero_iap_body">您的一次性 Pro 購買解鎖所有 Pro 功能，永久有效。</string>

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -20,8 +20,6 @@
     <string name="upgrade_screen_options_description">Subscriptions renew automatically. You can cancel anytime.</string>
     <string name="upgrade_title_suffix">Pro</string>
 
-    <!-- Settings entry title (Play flavor) -->
-    <string name="settings_upgrade_status_title">Permission Pilot Pro</string>
 
     <!-- Ownership / status -->
     <string name="upgrade_screen_owned_hero_title">You\'re Pro — thank you!</string>

--- a/app/src/main/java/eu/darken/myperm/common/upgrade/ui/UpgradeContent.kt
+++ b/app/src/main/java/eu/darken/myperm/common/upgrade/ui/UpgradeContent.kt
@@ -91,30 +91,66 @@ internal object UpgradeScreenTags {
     const val HERO = "upgrade_hero"
 }
 
+// The branded app title: a name plus the flavor's tier qualifier ("Pro" / "FOSS"), arranged by the
+// translated template so word order and punctuation belong to the language rather than to this
+// code. The qualifier is highlighted in the upgraded color while Pro is active.
+//
+// [nameRes] is the caller's choice of brand source, and the two callers deliberately differ: the
+// dashboard and settings pass app_name (translated in every locale), the upgrade screen passes
+// upgrade_title_prefix. The two are not locale-equivalent (es: "Piloto de los permisos" vs
+// "Permission Pilot"), so the dashboard must not borrow the prefix — its title would switch
+// LANGUAGE the moment the entitlement landed.
+@Composable
+internal fun brandTitle(
+    @StringRes nameRes: Int,
+    includeQualifier: Boolean,
+    highlightQualifier: Boolean,
+): AnnotatedString {
+    val name = AnnotatedString(stringResource(nameRes))
+    if (!includeQualifier) return name
+
+    val highlight = MaterialTheme.colorScheme.tertiary
+    val qualifier = buildAnnotatedString {
+        if (highlightQualifier) pushStyle(SpanStyle(color = highlight))
+        append(stringResource(R.string.upgrade_title_suffix))
+        if (highlightQualifier) pop()
+    }
+    return spliceTitleTemplate(
+        formatted = stringResource(
+            R.string.app_name_upgraded_template,
+            BRAND_TITLE_MARKER,
+            BRAND_QUALIFIER_MARKER,
+        ),
+        name = name,
+        qualifier = qualifier,
+    )
+}
+
+// Same composition for call sites that need a plain String (the settings components take String,
+// not AnnotatedString). Routed through brandTitle so the two forms cannot drift apart.
+@Composable
+internal fun brandTitleText(@StringRes nameRes: Int, includeQualifier: Boolean): String =
+    brandTitle(nameRes = nameRes, includeQualifier = includeQualifier, highlightQualifier = false).text
+
 // Composed app title with the flavor suffix highlighted in the upgraded color while Pro is
 // active — the same treatment the dashboard title gives itself for supporters.
 @Composable
-internal fun upgradeScreenTitle(upgraded: Boolean): AnnotatedString {
-    // PP already ships the title as a translated prefix + flavor-overridden suffix pair, which is
-    // exactly the shape the canonical highlight needs. Note the dashboard composes the same
-    // highlight from app_name instead of this prefix — deliberate: only app_name is translated in
-    // every locale, so the dashboard title keeps its language when the entitlement lands.
-    val highlight = MaterialTheme.colorScheme.tertiary
-    val prefix = stringResource(R.string.upgrade_title_prefix)
-    val suffix = stringResource(R.string.upgrade_title_suffix)
-    return buildAnnotatedString {
-        append(prefix)
-        append(" ")
-        if (upgraded) pushStyle(SpanStyle(color = highlight))
-        append(suffix)
-        if (upgraded) pop()
-    }
-}
+internal fun upgradeScreenTitle(upgraded: Boolean): AnnotatedString = brandTitle(
+    nameRes = R.string.upgrade_title_prefix,
+    // Unconditional: this title names the flavor even when the screen shows the free state.
+    includeQualifier = true,
+    highlightQualifier = upgraded,
+)
 
 // Marker char for brand-title splicing: formatted into the translated pattern via the normal
 // Android format path (so %1$s vs %s, argument reordering, and %% all behave), then replaced
 // with the styled brand. U+FFFC (object replacement) cannot occur in a real translation.
 internal const val BRAND_TITLE_MARKER = "￼"
+
+// The title template's second slot. U+FFF9 (interlinear annotation anchor) is likewise absent from
+// real translations, and being distinct from BRAND_TITLE_MARKER is what lets the splice tell the
+// two slots apart after the formatter has reordered them.
+internal const val BRAND_QUALIFIER_MARKER = "￹"
 
 internal fun spliceBrandTitle(formatted: String, brand: AnnotatedString): AnnotatedString = buildAnnotatedString {
     var rest = formatted
@@ -132,6 +168,45 @@ internal fun spliceBrandTitle(formatted: String, brand: AnnotatedString): Annota
         // Defensive: a translation that lost its placeholder still shows the brand.
         append(" ")
         append(brand)
+    }
+}
+
+// Splices the two title slots into an already-formatted template. Stricter than spliceBrandTitle on
+// purpose: that one splices a brand into a *sentence*, where a repeated marker is a legitimate (if
+// odd) translation. A *title* template has exactly two slots, so anything else is damage — and once
+// a slot is missing or doubled the template can no longer tell us the intended order or
+// punctuation, which is the whole reason it exists. So a broken template is discarded whole and the
+// default title is rebuilt from the parts; patching it up piecewise would emit a title no
+// translator wrote.
+internal fun spliceTitleTemplate(
+    formatted: String,
+    name: AnnotatedString,
+    qualifier: AnnotatedString,
+): AnnotatedString {
+    val slots = listOf(
+        BRAND_TITLE_MARKER to name,
+        BRAND_QUALIFIER_MARKER to qualifier,
+    ).map { (marker, value) -> Triple(formatted.indexOf(marker), marker, value) }
+
+    val intact = slots.all { (index, marker, _) ->
+        index >= 0 && formatted.indexOf(marker, index + marker.length) < 0
+    }
+    if (!intact) {
+        return buildAnnotatedString {
+            append(name)
+            append(" ")
+            append(qualifier)
+        }
+    }
+
+    return buildAnnotatedString {
+        var cursor = 0
+        slots.sortedBy { it.first }.forEach { (index, marker, value) ->
+            append(formatted.substring(cursor, index))
+            append(value)
+            cursor = index + marker.length
+        }
+        append(formatted.substring(cursor))
     }
 }
 

--- a/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewScreen.kt
@@ -58,8 +58,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.activity.compose.LocalActivity
@@ -75,6 +73,7 @@ import eu.darken.myperm.common.compose.Preview2
 import eu.darken.myperm.common.compose.PreviewWrapper
 import eu.darken.myperm.common.error.ErrorEventHandler
 import eu.darken.myperm.common.navigation.NavigationEventHandler
+import eu.darken.myperm.common.upgrade.ui.brandTitle
 import eu.darken.myperm.main.ui.overview.OverviewViewModel.SummaryCategory
 
 @Composable
@@ -107,18 +106,11 @@ fun OverviewScreenHost(vm: OverviewViewModel = hiltViewModel()) {
 // permisos" vs "Permission Pilot"), so reusing the prefix would switch the title's LANGUAGE the
 // moment the entitlement lands.
 @Composable
-private fun proBrandTitle(): AnnotatedString {
-    val highlight = MaterialTheme.colorScheme.tertiary
-    val appName = stringResource(R.string.app_name)
-    val suffix = stringResource(R.string.upgrade_title_suffix)
-    return buildAnnotatedString {
-        append(appName)
-        append(" ")
-        pushStyle(SpanStyle(color = highlight))
-        append(suffix)
-        pop()
-    }
-}
+private fun dashboardTitle(pro: Boolean): AnnotatedString = brandTitle(
+    nameRes = R.string.app_name,
+    includeQualifier = pro,
+    highlightQualifier = pro,
+)
 
 @Composable
 fun OverviewScreen(
@@ -158,14 +150,14 @@ fun OverviewScreen(
                     Column {
                         if (state.upgradeInfo?.isPro == true) {
                             Text(
-                                text = proBrandTitle(),
+                                text = dashboardTitle(pro = true),
                                 // The branded title is longer than the plain one: at narrow widths
                                 // or large font it would wrap over the version line below it.
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis,
                             )
                         } else {
-                            Text(text = stringResource(R.string.app_name))
+                            Text(text = dashboardTitle(pro = false))
                         }
                         Text(
                             text = state.versionDesc,

--- a/app/src/main/java/eu/darken/myperm/settings/ui/index/SettingsIndexScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/settings/ui/index/SettingsIndexScreen.kt
@@ -32,6 +32,7 @@ import eu.darken.myperm.common.navigation.Nav
 import eu.darken.myperm.common.settings.SettingsBaseItem
 import eu.darken.myperm.common.settings.SettingsCategoryHeader
 import eu.darken.myperm.common.settings.SettingsDivider
+import eu.darken.myperm.common.upgrade.ui.brandTitleText
 
 @Composable
 fun SettingsIndexScreenHost() {
@@ -97,7 +98,9 @@ fun SettingsIndexScreen(
             SettingsCategoryHeader(text = stringResource(R.string.settings_category_other_label))
 
             SettingsBaseItem(
-                title = stringResource(R.string.settings_upgrade_status_title),
+                // Composed from the same parts as the dashboard title rather than from a second,
+                // separately translated copy of the brand — the two used to drift apart.
+                title = brandTitleText(nameRes = R.string.app_name, includeQualifier = true),
                 subtitle = stringResource(R.string.settings_upgrade_description),
                 icon = Icons.TwoTone.Stars,
                 onClick = onUpgradeStatus,

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Hulp</string>
     <string name="general_error_label">Fout</string>
     <string name="general_load_error_title">Kon nie data laai nie</string>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">ፍቃድ ፓይሎት</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">እርዳታ</string>
     <string name="general_error_label">ስህተት</string>
     <string name="general_load_error_title">ውሂብ ሊጫን አልቻለም</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">بايلوت الأذونات</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">مساعدة</string>
     <string name="general_error_label">خطأ</string>
     <string name="general_load_error_title">لم يتمكن من تحميل البيانات</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">İcazə Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Kömək</string>
     <string name="general_error_label">Səhv</string>
     <string name="general_load_error_title">Məlumatlar yüklənə bilmədi</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Дазвол Пілот</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Дапамога</string>
     <string name="general_error_label">Памылка</string>
     <string name="general_load_error_title">Не ўдалося загрузіць дадзеныя</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Помощ</string>
     <string name="general_error_label">Грешка</string>
     <string name="general_load_error_title">Неуспешно зареждане на данни</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">সাহায্য</string>
     <string name="general_error_label">ত্রুটি</string>
     <string name="general_load_error_title">ডেটা লোড করা যায়নি</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Ajuda</string>
     <string name="general_error_label">Error</string>
     <string name="general_load_error_title">No s\'han pogut carregar les dades</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Nápověda</string>
     <string name="general_error_label">Chyba</string>
     <string name="general_load_error_title">Nepodařilo se načíst data</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Hjælp</string>
     <string name="general_error_label">Fejl</string>
     <string name="general_load_error_title">Kunne ikke indlæse data</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Hilfe</string>
     <string name="general_error_label">Fehler</string>
     <string name="general_load_error_title">Daten konnten nicht geladen werden</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Βοήθεια</string>
     <string name="general_error_label">Σφάλμα</string>
     <string name="general_load_error_title">Δεν ήταν δυνατό να φορτωθούν τα δεδομένα</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Piloto de los permisos</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Ayuda</string>
     <string name="general_error_label">Error</string>
     <string name="general_load_error_title">No se pudieron cargar los datos</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Ohje</string>
     <string name="general_error_label">Virhe</string>
     <string name="general_load_error_title">Tietoja ei voitu ladata</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Aide</string>
     <string name="general_error_label">Erreur</string>
     <string name="general_load_error_title">Impossible de charger les données</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">सहायता</string>
     <string name="general_error_label">त्रुटि</string>
     <string name="general_load_error_title">डेटा लोड नहीं कर सके</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Pomoć</string>
     <string name="general_error_label">Greška</string>
     <string name="general_load_error_title">Nije moguće učitati podatke</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Segitseg</string>
     <string name="general_error_label">Hiba</string>
     <string name="general_load_error_title">Nem sikerült az adatok betöltése</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Aiuto</string>
     <string name="general_error_label">Errore</string>
     <string name="general_load_error_title">Impossibile caricare i dati</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">עזרה</string>
     <string name="general_error_label">שגיאה</string>
     <string name="general_load_error_title">לא ניתן היה לטעון נתונים</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">ヘルプ</string>
     <string name="general_error_label">エラー</string>
     <string name="general_load_error_title">データを読み込めませんでした</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">도움말</string>
     <string name="general_error_label">오류</string>
     <string name="general_load_error_title">데이터를 불러올 수 없습니다</string>

--- a/app/src/main/res/values-ku-rTR/strings.xml
+++ b/app/src/main/res/values-ku-rTR/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Alîkarî</string>
     <string name="general_error_label">Çewtî</string>
     <string name="general_load_error_title">Daneyê barkirî nûket</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Hjelp</string>
     <string name="general_error_label">Feil</string>
     <string name="general_load_error_title">Kunne ikke laste data</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Help</string>
     <string name="general_error_label">Fout</string>
     <string name="general_load_error_title">Gegevens konden niet worden geladen</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Pilot Uprawnień</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Pomoc</string>
     <string name="general_error_label">Błąd</string>
     <string name="general_load_error_title">Nie można załadować danych</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
-    <string name="app_name">Pilot Uprawnień </string>
+    <string name="app_name">Pilot Uprawnień</string>
     <string name="label_help">Pomoc</string>
     <string name="general_error_label">Błąd</string>
     <string name="general_load_error_title">Nie można załadować danych</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Ajuda</string>
     <string name="general_error_label">Erro</string>
     <string name="general_load_error_title">Não foi possível carregar os dados</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Ajuda</string>
     <string name="general_error_label">Erro</string>
     <string name="general_load_error_title">Não foi possível carregar dados</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Ajutor</string>
     <string name="general_error_label">Eroare</string>
     <string name="general_load_error_title">Nu s-au putut încărca datele</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Помощь</string>
     <string name="general_error_label">Ошибка</string>
     <string name="general_load_error_title">Не удалось загрузить данные</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Pomocník</string>
     <string name="general_error_label">Chyba</string>
     <string name="general_load_error_title">Nepodarilo sa načítať údaje</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Помоћ</string>
     <string name="general_error_label">Грешка</string>
     <string name="general_load_error_title">Није могло учитати податке</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Hjälp</string>
     <string name="general_error_label">Fel</string>
     <string name="general_load_error_title">Kunde inte läsa in data</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">ช่วยเหลือ</string>
     <string name="general_error_label">ข้อผิดพลาด</string>
     <string name="general_load_error_title">ไม่สามารถโหลดข้อมูล</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Yardım</string>
     <string name="general_error_label">Hata</string>
     <string name="general_load_error_title">Veriler yüklenemedi</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Допомога</string>
     <string name="general_error_label">Помилка</string>
     <string name="general_load_error_title">Не вдалося завантажити дані</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Trợ giúp</string>
     <string name="general_error_label">Lỗi</string>
     <string name="general_load_error_title">Không thể tải dữ liệu</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">帮助</string>
     <string name="general_error_label">错误</string>
     <string name="general_load_error_title">无法加载数据</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">幫助</string>
     <string name="general_error_label">錯誤</string>
     <string name="general_load_error_title">無法載入資料</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,8 @@
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">Permission Pilot</string>
+    <!-- Arrangement of the branded app title. %1$s is the app name, %2$s the tier qualifier
+         ("Pro" / "FOSS"). Reorder or repunctuate freely to suit the language. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="label_help">Help</string>
 
     <string name="general_error_label">Error</string>

--- a/app/src/test/java/eu/darken/myperm/common/upgrade/ui/TitleTemplateSpliceTest.kt
+++ b/app/src/test/java/eu/darken/myperm/common/upgrade/ui/TitleTemplateSpliceTest.kt
@@ -1,0 +1,155 @@
+package eu.darken.myperm.common.upgrade.ui
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelper.BaseTest
+
+/**
+ * The title template lets translators own word order and punctuation, so the styled qualifier has
+ * to land on the right offsets wherever they put it. Assertions are on span boundaries, not just on
+ * the concatenated text: the failure this guards against renders the correct characters with the
+ * highlight sitting on the wrong word.
+ */
+class TitleTemplateSpliceTest : BaseTest() {
+
+    private val qualifierColor = Color.Red
+
+    private val name = AnnotatedString("Permission Pilot")
+
+    private val qualifier: AnnotatedString = buildAnnotatedString {
+        pushStyle(SpanStyle(color = qualifierColor))
+        append("Pro")
+        pop()
+    }
+
+    private fun template(pattern: String) = pattern
+        .replace("%1\$s", BRAND_TITLE_MARKER)
+        .replace("%2\$s", BRAND_QUALIFIER_MARKER)
+
+    @Test
+    fun `the default order highlights the trailing qualifier`() {
+        val result = spliceTitleTemplate(template("%1\$s %2\$s"), name, qualifier)
+
+        result.text shouldBe "Permission Pilot Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().item.color shouldBe qualifierColor
+        result.spanStyles.single().start shouldBe 17
+        result.spanStyles.single().end shouldBe 20
+        result.text.substring(17, 20) shouldBe "Pro"
+    }
+
+    @Test
+    fun `a reordered template highlights the leading qualifier`() {
+        val result = spliceTitleTemplate(template("%2\$s %1\$s"), name, qualifier)
+
+        result.text shouldBe "Pro Permission Pilot"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 0
+        result.spanStyles.single().end shouldBe 3
+        result.text.substring(0, 3) shouldBe "Pro"
+    }
+
+    @Test
+    fun `a custom separator shifts the qualifier without entering the span`() {
+        val result = spliceTitleTemplate(template("%1\$s – %2\$s"), name, qualifier)
+
+        result.text shouldBe "Permission Pilot – Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 19
+        result.spanStyles.single().end shouldBe 22
+        result.text.substring(19, 22) shouldBe "Pro"
+    }
+
+    @Test
+    fun `a multi-word qualifier is highlighted whole`() {
+        val multiWord = buildAnnotatedString {
+            pushStyle(SpanStyle(color = qualifierColor))
+            append("النسخة الاحترافية")
+            pop()
+        }
+
+        val result = spliceTitleTemplate(template("%1\$s – %2\$s"), AnnotatedString("بايلوت الأذونات"), multiWord)
+
+        result.text shouldBe "بايلوت الأذونات – النسخة الاحترافية"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 18
+        result.spanStyles.single().end shouldBe 35
+        result.text.substring(18, 35) shouldBe "النسخة الاحترافية"
+    }
+
+    // Span offsets are UTF-16 indices, so a supplementary character ahead of a slot shifts it by
+    // two. Pins that the splice arithmetic counts code units and not code points.
+    @Test
+    fun `a supplementary character before the slots shifts the span by two`() {
+        val result = spliceTitleTemplate(template("🛡 %1\$s %2\$s"), name, qualifier)
+
+        result.text shouldBe "🛡 Permission Pilot Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 20
+        result.spanStyles.single().end shouldBe 23
+        result.text.substring(20, 23) shouldBe "Pro"
+    }
+
+    @Test
+    fun `a duplicated name marker falls back to the complete default title`() {
+        val result = spliceTitleTemplate(
+            "$BRAND_TITLE_MARKER $BRAND_TITLE_MARKER $BRAND_QUALIFIER_MARKER",
+            name,
+            qualifier,
+        )
+
+        result.text shouldBe "Permission Pilot Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 17
+        result.spanStyles.single().end shouldBe 20
+    }
+
+    @Test
+    fun `a duplicated qualifier marker falls back to the complete default title`() {
+        val result = spliceTitleTemplate(
+            "$BRAND_TITLE_MARKER $BRAND_QUALIFIER_MARKER $BRAND_QUALIFIER_MARKER",
+            name,
+            qualifier,
+        )
+
+        result.text shouldBe "Permission Pilot Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 17
+        result.spanStyles.single().end shouldBe 20
+    }
+
+    @Test
+    fun `a missing name marker falls back rather than rendering the qualifier alone`() {
+        val result = spliceTitleTemplate("Get $BRAND_QUALIFIER_MARKER", name, qualifier)
+
+        result.text shouldBe "Permission Pilot Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 17
+        result.spanStyles.single().end shouldBe 20
+    }
+
+    @Test
+    fun `a missing qualifier marker falls back rather than dropping the tier`() {
+        val result = spliceTitleTemplate("Get $BRAND_TITLE_MARKER", name, qualifier)
+
+        result.text shouldBe "Permission Pilot Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 17
+        result.spanStyles.single().end shouldBe 20
+    }
+
+    @Test
+    fun `a template with neither marker falls back to the complete default title`() {
+        val result = spliceTitleTemplate("Permission Pilot Pro", name, qualifier)
+
+        result.text shouldBe "Permission Pilot Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().item.color shouldBe qualifierColor
+        result.spanStyles.single().start shouldBe 17
+        result.spanStyles.single().end shouldBe 20
+    }
+}

--- a/app/src/test/java/eu/darken/myperm/main/ui/overview/OverviewScreenTitleTest.kt
+++ b/app/src/test/java/eu/darken/myperm/main/ui/overview/OverviewScreenTitleTest.kt
@@ -20,6 +20,9 @@ import io.mockk.mockk
 import org.junit.Test
 import org.robolectric.annotation.Config
 import testhelpers.compose.BaseComposeRobolectricTest
+import testhelpers.compose.brandQualifier
+import testhelpers.compose.brandTitleFor
+import testhelpers.compose.shouldHighlightOnlyQualifier
 
 /**
  * The dashboard titles itself with the branded app name while Pro is active. Composed from
@@ -35,10 +38,12 @@ class OverviewScreenTitleTest : BaseComposeRobolectricTest() {
         get() = context.getString(R.string.app_name)
 
     private val suffix: String
-        get() = context.getString(R.string.upgrade_title_suffix)
+        get() = context.brandQualifier
 
+    // Derived from the resolved template, never spelled as "$appName $suffix": arrangement is the
+    // translator's, so a locale that reorders or repunctuates is intended behaviour, not a failure.
     private val brandedTitle: String
-        get() = "$appName $suffix"
+        get() = context.brandTitleFor(R.string.app_name)
 
     private fun proInfo(): UpgradeRepo.Info = mockk<UpgradeRepo.Info>(relaxed = true).also {
         every { it.isPro } returns true
@@ -95,13 +100,7 @@ class OverviewScreenTitleTest : BaseComposeRobolectricTest() {
             .single()
 
         rendered.text shouldBe brandedTitle
-        rendered.spanStyles.size shouldBe 1
-        val span = rendered.spanStyles.single()
-        span.item.color shouldBe expectedTertiary
-        rendered.text.substring(span.start, span.end) shouldBe suffix
-        // Pins the range rather than just its content: only one candidate position exists.
-        rendered.text.indexOf(suffix) shouldBe span.start
-        rendered.text.lastIndexOf(suffix) shouldBe span.start
+        rendered.shouldHighlightOnlyQualifier(suffix, expectedTertiary)
     }
 
     @Test
@@ -159,7 +158,7 @@ class OverviewScreenTitleTest : BaseComposeRobolectricTest() {
         appName shouldBe "Piloto de los permisos"
         composeRule.onAllNodesWithText(brandedTitle).assertCountEquals(1)
         composeRule.onAllNodesWithText(
-            "${context.getString(R.string.upgrade_title_prefix)} $suffix"
+            context.brandTitleFor(R.string.upgrade_title_prefix)
         ).assertCountEquals(0)
     }
 }

--- a/app/src/test/java/eu/darken/myperm/settings/ui/index/SettingsIndexBrandTitleTest.kt
+++ b/app/src/test/java/eu/darken/myperm/settings/ui/index/SettingsIndexBrandTitleTest.kt
@@ -1,0 +1,75 @@
+package eu.darken.myperm.settings.ui.index
+
+import android.content.Context
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.myperm.R
+import eu.darken.myperm.common.compose.PreviewWrapper
+import org.junit.Test
+import org.robolectric.annotation.Config
+import testhelpers.compose.BaseComposeRobolectricTest
+import testhelpers.compose.brandTitleFor
+
+/**
+ * The settings entry names the same tier the dashboard does. It used to carry its own hardcoded
+ * translation of the composed brand, which drifted: in es/ar/am/az/be the dashboard rendered the
+ * localized app name while this row still said "Permission Pilot Pro". Composing both from the same
+ * parts is what makes them unable to disagree, so these tests assert the agreement itself rather
+ * than any particular string.
+ */
+class SettingsIndexBrandTitleTest : BaseComposeRobolectricTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private fun showScreen() {
+        composeRule.setContent {
+            PreviewWrapper {
+                SettingsIndexScreen(
+                    onBack = {},
+                    onChangelog = {},
+                    onSupport = {},
+                    onAcknowledgements = {},
+                    onPrivacyPolicy = {},
+                    versionSubtitle = "v1.2.3",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `the upgrade row carries the same composed brand as the dashboard`() {
+        showScreen()
+
+        composeRule.onAllNodesWithText(context.brandTitleFor(R.string.app_name)).assertCountEquals(1)
+    }
+
+    @Test
+    @Config(qualifiers = "es")
+    fun `the upgrade row is localized rather than pinned to English`() {
+        showScreen()
+
+        // Was "Permission Pilot Pro" here while the dashboard said "Piloto de los permisos Pro".
+        requireLocalizedAppName()
+        composeRule.onAllNodesWithText(context.brandTitleFor(R.string.app_name)).assertCountEquals(1)
+    }
+
+    @Test
+    @Config(qualifiers = "ar")
+    fun `the upgrade row is localized in arabic too`() {
+        showScreen()
+
+        requireLocalizedAppName()
+        composeRule.onAllNodesWithText(context.brandTitleFor(R.string.app_name)).assertCountEquals(1)
+    }
+
+    // Guards the guard: if app_name ever stopped being translated in these locales the assertions
+    // above would still pass while proving nothing.
+    private fun requireLocalizedAppName() {
+        val appName = context.getString(R.string.app_name)
+        check(appName != "Permission Pilot") {
+            "app_name is untranslated in this locale, so the localization assertion proves nothing"
+        }
+    }
+}

--- a/app/src/test/java/testhelpers/compose/BrandTitleExpectations.kt
+++ b/app/src/test/java/testhelpers/compose/BrandTitleExpectations.kt
@@ -1,0 +1,39 @@
+package testhelpers.compose
+
+import android.content.Context
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import eu.darken.myperm.R
+import io.kotest.matchers.shouldBe
+
+/**
+ * Arrangement of the branded title belongs to the translated template, so tests must not spell it
+ * as `"$name $qualifier"`: a locale that legitimately reorders or repunctuates would then fail CI
+ * on intended behaviour. These helpers resolve the real template for the locale under test and
+ * assert only the invariants — the qualifier appears exactly once, and the highlight covers
+ * exactly it, wherever the template put it.
+ */
+fun Context.brandTitleFor(nameRes: Int): String = getString(
+    R.string.app_name_upgraded_template,
+    getString(nameRes),
+    getString(R.string.upgrade_title_suffix),
+)
+
+/** The flavor's tier qualifier — "Pro" on gplay, "FOSS" on the FOSS build. */
+val Context.brandQualifier: String
+    get() = getString(R.string.upgrade_title_suffix)
+
+/**
+ * Asserts the styled run is exactly the qualifier: one span, the expected color, covering the
+ * qualifier's only occurrence. Pins the span *boundary*, not just the concatenated text — the
+ * failure worth guarding against renders the right characters with the highlight on the wrong word.
+ */
+fun AnnotatedString.shouldHighlightOnlyQualifier(qualifier: String, color: Color) {
+    spanStyles.size shouldBe 1
+    val span = spanStyles.single()
+    span.item.color shouldBe color
+    text.substring(span.start, span.end) shouldBe qualifier
+    // Only one candidate position may exist, else the boundary check above proves nothing.
+    text.indexOf(qualifier) shouldBe span.start
+    text.lastIndexOf(qualifier) shouldBe span.start
+}

--- a/app/src/testFoss/java/eu/darken/myperm/common/upgrade/ui/FossUpgradeScreenTest.kt
+++ b/app/src/testFoss/java/eu/darken/myperm/common/upgrade/ui/FossUpgradeScreenTest.kt
@@ -16,6 +16,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import testhelpers.compose.BaseComposeRobolectricTest
+import testhelpers.compose.brandTitleFor
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -70,7 +71,7 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
             UpgradeScreen(view = FossUpgradeView.STATUS_FREE)
         }
 
-        composeRule.onAllNodesWithText("${context.getString(R.string.upgrade_title_prefix)} ${context.getString(R.string.upgrade_title_suffix)}").assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.brandTitleFor(R.string.upgrade_title_prefix)).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_STATUS_FREE).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SHOW_OPTIONS).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SPONSOR).assertCountEquals(0)
@@ -105,7 +106,7 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
             UpgradeScreen(view = FossUpgradeView.STATUS_UPGRADED, supporterSince = since)
         }
 
-        composeRule.onAllNodesWithText("${context.getString(R.string.upgrade_title_prefix)} ${context.getString(R.string.upgrade_title_suffix)}").assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.brandTitleFor(R.string.upgrade_title_prefix)).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_STATUS_UPGRADED).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_status_upgraded_body))
             .assertCountEquals(1)

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/GplayUpgradeScreenTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/GplayUpgradeScreenTest.kt
@@ -26,15 +26,19 @@ import io.mockk.every
 import io.mockk.mockk
 import org.junit.Test
 import testhelpers.compose.BaseComposeRobolectricTest
+import testhelpers.compose.brandQualifier
+import testhelpers.compose.brandTitleFor
+import testhelpers.compose.shouldHighlightOnlyQualifier
 
 class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
 
     private val context: Context
         get() = ApplicationProvider.getApplicationContext()
 
-    // "Permission Pilot Pro" — the composed brand the screen renders for owners and grace users.
+    // The composed brand the screen renders for owners and grace users ("Permission Pilot Pro" in
+    // English). Derived from the resolved template, so a locale that reorders it still passes.
     private val appNameWithPostfix: String
-        get() = "${context.getString(R.string.upgrade_title_prefix)} ${context.getString(R.string.upgrade_title_suffix)}"
+        get() = context.brandTitleFor(R.string.upgrade_title_prefix)
 
     private fun appNameWithPostfixedHeroBody(bodyRes: Int): String = context.getString(
         bodyRes,
@@ -79,16 +83,8 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
             .fetchSemanticsNode()
             .config[SemanticsProperties.Text]
             .single()
-        val suffix = context.getString(R.string.upgrade_title_suffix)
-
         rendered.text shouldBe acquisitionTitle
-        rendered.spanStyles.size shouldBe 1
-        val span = rendered.spanStyles.single()
-        span.item.color shouldBe expectedTertiary
-        rendered.text.substring(span.start, span.end) shouldBe suffix
-        // Pins the range rather than just its content: only one candidate position exists.
-        rendered.text.indexOf(suffix) shouldBe span.start
-        rendered.text.lastIndexOf(suffix) shouldBe span.start
+        rendered.shouldHighlightOnlyQualifier(context.brandQualifier, expectedTertiary)
     }
 
     @Test
@@ -418,7 +414,7 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_MANAGE_SUB).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_SUBSCRIPTION).assertCountEquals(0)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_owned_sub_renewing_body)).assertCountEquals(1)
-        composeRule.onAllNodesWithText("${context.getString(R.string.upgrade_title_prefix)} ${context.getString(R.string.upgrade_title_suffix)}").assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.brandTitleFor(R.string.upgrade_title_prefix)).assertCountEquals(1)
         // The congrats hero names the variant.
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_OWNED_HERO).assertCountEquals(1)
         composeRule.onAllNodesWithText(appNameWithPostfixedHeroBody(R.string.upgrade_screen_owned_hero_sub_body))
@@ -526,7 +522,7 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         // must not undercut the calm quiet stage with its own restore CTA.
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_RESTORE).assertCountEquals(0)
         // Grace users are still Pro: neutral status title, not the acquisition pitch title.
-        composeRule.onAllNodesWithText("${context.getString(R.string.upgrade_title_prefix)} ${context.getString(R.string.upgrade_title_suffix)}").assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.brandTitleFor(R.string.upgrade_title_prefix)).assertCountEquals(1)
         // A young episode is treated as a blip: calm status only — no offers, no sales pitch.
         // The offers return with the aged (diagnostics) stage.
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_SUBSCRIPTION).assertCountEquals(0)


### PR DESCRIPTION
## What changed

The app's branded title ("Permission Pilot Pro" / "Permission Pilot FOSS") is now assembled from a
translatable arrangement template instead of being glued together in code, so translators own the
word order and punctuation of the title in their language.

This also fixes a live inconsistency: the Settings entry that opens the upgrade screen carried its
own separately translated copy of the brand, and that copy had drifted. In Amharic, Arabic,
Azerbaijani, Belarusian and Spanish the dashboard showed the localized app name while the Settings
row still read "Permission Pilot Pro", so the entry and the screen it opens named the same tier
differently. The row now composes from the same parts as the dashboard.

| locale | Settings row before | Settings row after (= dashboard) |
|---|---|---|
| es | Permission Pilot Pro | Piloto de los permisos Pro |
| ar | Permission Pilot Pro | بايلوت الأذونات احترافي |
| am | Permission Pilot Pro | ፍቃድ ፓይሎት Pro |
| az | Permission Pilot Pro | İcazə Pilot Pro |
| be | Permission Pilot Pro | Дазвол Пілот Pro |

The FOSS build had the same drift in those five locales, plus Polish, where the hardcoded row read
"Pilot Uprawnień Foss" against the pinned "FOSS" qualifier.

Also included: a stray trailing space removed from the Polish app name, and an unrelated release
build fix (see below).

## Technical Context

- `app_name_upgraded_template` (`%1$s %2$s`) lives in the **main** source set next to `app_name`,
  because arrangement varies by *language*. `upgrade_title_suffix` stays flavour-specific because it
  varies by *flavour* — foss pins `FOSS` with `translatable="false"`, gplay ships a translated `Pro`
  in 39 locales. That split is unchanged.
- `spliceTitleTemplate` is deliberately stricter than the existing `spliceBrandTitle`. The latter
  splices a brand into a *sentence*, where a repeated marker is a legitimate translation. A *title*
  has exactly two slots, so a missing or doubled marker means the template can no longer state the
  intended order or punctuation — it is discarded whole and the default title is rebuilt from the
  parts. Patching it piecewise would emit a title no translator wrote.
- Two distinct sentinel markers (U+FFFC, U+FFF9) are formatted in via the normal Android format
  path, so argument reordering happens in the formatter and the splice can still tell the slots
  apart afterwards.
- `brandTitle` takes a `nameRes` because the two brand sources are **not** unified here: the
  dashboard and Settings use `app_name`, the upgrade screen keeps `upgrade_title_prefix`. Those are
  not locale-equivalent (es: "Piloto de los permisos" vs "Permission Pilot"), so borrowing the
  prefix would switch the dashboard title's language the moment the entitlement landed. Consequence
  worth knowing: in the five locales above the upgrade screen still renders the English name, so it
  differs from the dashboard and Settings row there. Unifying them is a separate decision.
- The old `settings_upgrade_status_title` was retired across both flavours (base plus 39 locale
  overrides each) in a staged Crowdin migration — template added and translated first, key removed
  in a second pass — because removing and adding keys in one sync does not transfer translations.
- Tests: the existing title assertions built expected text as `"$prefix $suffix"`, which becomes
  unsound once arrangement is translatable — a legitimately reordered locale would fail CI on
  intended behaviour. They now derive expected text from the *resolved* template and assert
  invariants: the qualifier appears exactly once and the highlight span covers exactly it. Span
  boundaries are asserted, not just concatenated text, since the failure mode this guards against
  renders the right characters with the highlight on the wrong word.

### Unrelated build fix riding along

`5092acd` is not part of the title work. `review-ktx:2.0.2` references
`com.google.android.gms.common.annotation.NoNullnessRewrite`, a compile-time-only GMS annotation
absent from the runtime classpath, which fails R8 on `gplayRelease`. Release is the only minified
variant, so no PR check has ever caught it. The rule names the single class rather than a
`com.google.android.gms.**` wildcard, so a genuine missing-class error still surfaces. It is
committed separately so it can be reviewed on its own.
