### PR TITLE
General: Compose the upgrade screen title from app_name

### DIFF
--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -6,7 +6,6 @@
     <string name="upgrade_foss_sponsor_returned_early">Please take a moment to check out the sponsor page!</string>
     <string name="upgrade_title_suffix" translatable="false">FOSS</string>
 
-
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Free version</string>
     <string name="upgrade_screen_status_free_body">You\'re using the free, open-source build. Support development to unlock the Pro features.</string>

--- a/app/src/main/java/eu/darken/myperm/common/upgrade/ui/UpgradeContent.kt
+++ b/app/src/main/java/eu/darken/myperm/common/upgrade/ui/UpgradeContent.kt
@@ -91,22 +91,20 @@ internal object UpgradeScreenTags {
     const val HERO = "upgrade_hero"
 }
 
-// The branded app title: a name plus the flavor's tier qualifier ("Pro" / "FOSS"), arranged by the
-// translated template so word order and punctuation belong to the language rather than to this
+// The branded app title: app_name plus the flavor's tier qualifier ("Pro" / "FOSS"), arranged by
+// the translated template so word order and punctuation belong to the language rather than to this
 // code. The qualifier is highlighted in the upgraded color while Pro is active.
 //
-// [nameRes] is the caller's choice of brand source, and the two callers deliberately differ: the
-// dashboard and settings pass app_name (translated in every locale), the upgrade screen passes
-// upgrade_title_prefix. The two are not locale-equivalent (es: "Piloto de los permisos" vs
-// "Permission Pilot"), so the dashboard must not borrow the prefix — its title would switch
-// LANGUAGE the moment the entitlement landed.
+// app_name is the single brand source for every surface — dashboard, settings row and upgrade
+// screen. There is deliberately no way to pass a different one: the screens used to draw from two
+// separately translated copies of the brand, and the copies drifted, so the surfaces named the same
+// tier differently in any locale that translated one but not the other.
 @Composable
 internal fun brandTitle(
-    @StringRes nameRes: Int,
     includeQualifier: Boolean,
     highlightQualifier: Boolean,
 ): AnnotatedString {
-    val name = AnnotatedString(stringResource(nameRes))
+    val name = AnnotatedString(stringResource(R.string.app_name))
     if (!includeQualifier) return name
 
     val highlight = MaterialTheme.colorScheme.tertiary
@@ -129,14 +127,13 @@ internal fun brandTitle(
 // Same composition for call sites that need a plain String (the settings components take String,
 // not AnnotatedString). Routed through brandTitle so the two forms cannot drift apart.
 @Composable
-internal fun brandTitleText(@StringRes nameRes: Int, includeQualifier: Boolean): String =
-    brandTitle(nameRes = nameRes, includeQualifier = includeQualifier, highlightQualifier = false).text
+internal fun brandTitleText(includeQualifier: Boolean): String =
+    brandTitle(includeQualifier = includeQualifier, highlightQualifier = false).text
 
 // Composed app title with the flavor suffix highlighted in the upgraded color while Pro is
 // active — the same treatment the dashboard title gives itself for supporters.
 @Composable
 internal fun upgradeScreenTitle(upgraded: Boolean): AnnotatedString = brandTitle(
-    nameRes = R.string.upgrade_title_prefix,
     // Unconditional: this title names the flavor even when the screen shows the free state.
     includeQualifier = true,
     highlightQualifier = upgraded,

--- a/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/main/ui/overview/OverviewScreen.kt
@@ -101,13 +101,10 @@ fun OverviewScreenHost(vm: OverviewViewModel = hiltViewModel()) {
 }
 
 // The dashboard brands itself for supporters: the localized app name plus the flavor's upgrade
-// suffix ("Pro" on gplay, "FOSS" on the FOSS build) in the upgraded color. Composed from app_name,
-// NOT from the upgrade screen's title prefix: the two are not locale-equivalent (es: "Piloto de los
-// permisos" vs "Permission Pilot"), so reusing the prefix would switch the title's LANGUAGE the
-// moment the entitlement lands.
+// suffix ("Pro" on gplay, "FOSS" on the FOSS build) in the upgraded color. Shares one brand source
+// with the settings row and the upgrade screen, so the three cannot name the same tier differently.
 @Composable
 private fun dashboardTitle(pro: Boolean): AnnotatedString = brandTitle(
-    nameRes = R.string.app_name,
     includeQualifier = pro,
     highlightQualifier = pro,
 )

--- a/app/src/main/java/eu/darken/myperm/settings/ui/index/SettingsIndexScreen.kt
+++ b/app/src/main/java/eu/darken/myperm/settings/ui/index/SettingsIndexScreen.kt
@@ -100,7 +100,7 @@ fun SettingsIndexScreen(
             SettingsBaseItem(
                 // Composed from the same parts as the dashboard title rather than from a second,
                 // separately translated copy of the brand — the two used to drift apart.
-                title = brandTitleText(nameRes = R.string.app_name, includeQualifier = true),
+                title = brandTitleText(includeQualifier = true),
                 subtitle = stringResource(R.string.settings_upgrade_description),
                 icon = Icons.TwoTone.Stars,
                 onClick = onUpgradeStatus,

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -571,7 +571,6 @@
     <string name="general_copy_action">Kopieer</string>
     <string name="general_copied_to_clipboard_msg">Gekopieer na die Knipbord</string>
     <string name="general_view_details_for_x_action">Bekyk besonderhede vir %1$s</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Opgradering-status en opsies</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -571,7 +571,6 @@
     <string name="general_copy_action">ቅዳ</string>
     <string name="general_copied_to_clipboard_msg">ወደ ክሊፕቦርድ ተቅዱ</string>
     <string name="general_view_details_for_x_action">ለ%1$s ዝርዝር ይመልከቱ</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">ማሻሻያ ሁኔታ እና ምርጫ</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -663,7 +663,6 @@
     <string name="general_copy_action">نسخ</string>
     <string name="general_copied_to_clipboard_msg">نسخت إلى الحافظة</string>
     <string name="general_view_details_for_x_action">عرض التفاصيل عن %1$s</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">حالة الترقية والخيارات</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -571,7 +571,6 @@
     <string name="general_copy_action">Kopyala</string>
     <string name="general_copied_to_clipboard_msg">Lövhəyə kopyalandı</string>
     <string name="general_view_details_for_x_action">%1$s üçün detalları görün</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Yüksəltmə statusu və seçənəkləri</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -617,7 +617,6 @@
     <string name="general_copy_action">Скапіраваць</string>
     <string name="general_copied_to_clipboard_msg">Скапіявана ў буфер абмену</string>
     <string name="general_view_details_for_x_action">Прагледзець подробнасці %1$s</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Статус абнаўлення і варыянты</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -571,7 +571,6 @@
     <string name="general_copy_action">Копиране</string>
     <string name="general_copied_to_clipboard_msg">Копирано в буферната памет</string>
     <string name="general_view_details_for_x_action">Преглед на детайли за %1$s</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Статус на обновлението и опции</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -571,7 +571,6 @@
     <string name="general_copy_action">কপি বা অনুলিপি করুন</string>
     <string name="general_copied_to_clipboard_msg">ক্লিপবোর্ডে কপি করা হয়েছে</string>
     <string name="general_view_details_for_x_action">%1$s এর বিবরণ দেখুন</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">আপগ্রেড স্ট্যাটাস এবং বিকল্পসমূহ</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -571,7 +571,6 @@
     <string name="general_copy_action">Copia</string>
     <string name="general_copied_to_clipboard_msg">S\'ha copiat al porta-retalls</string>
     <string name="general_view_details_for_x_action">Mostra els detalls de %1$s</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Estat de l\'actualització i opcions</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -617,7 +617,6 @@
     <string name="general_copy_action">Kopírovat</string>
     <string name="general_copied_to_clipboard_msg">Zkopírováno do schránky</string>
     <string name="general_view_details_for_x_action">Zobrazit podrobnosti pro %1$s</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Stav upgradu a možnosti</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -571,7 +571,6 @@
     <string name="general_copy_action">Kopiér</string>
     <string name="general_copied_to_clipboard_msg">Kopieret til udklipsholderen</string>
     <string name="general_view_details_for_x_action">Vis detaljer for %1$s</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Opgraderingsstatus og indstillinger</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -571,7 +571,6 @@
     <string name="general_copy_action">Kopieren</string>
     <string name="general_copied_to_clipboard_msg">In die Zwischenablage kopiert</string>
     <string name="general_view_details_for_x_action">Details für %1$s anzeigen</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Upgrade-Status und Optionen</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -571,7 +571,6 @@
     <string name="general_copy_action">Αντιγραφή</string>
     <string name="general_copied_to_clipboard_msg">Αντιγράφηκε στο πρόχειρο</string>
     <string name="general_view_details_for_x_action">Προβολή λεπτομερειών για %1$s</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Κατάσταση αναβάθμισης και επιλογές</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -571,7 +571,6 @@
     <string name="general_copy_action">Copiar</string>
     <string name="general_copied_to_clipboard_msg">Copiado en el portapapeles</string>
     <string name="general_view_details_for_x_action">Ver detalles de %1$s</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Estado de actualización y opciones</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -571,7 +571,6 @@
     <string name="general_copy_action">Kopioi</string>
     <string name="general_copied_to_clipboard_msg">Kopioitu leikepöydälle</string>
     <string name="general_view_details_for_x_action">Näytä %1$s:n tiedot</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Päivityksen tila ja vaihtoehdot</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -572,7 +572,6 @@
     <string name="general_copy_action">Copier</string>
     <string name="general_copied_to_clipboard_msg">A été copié dans le presse-papiers</string>
     <string name="general_view_details_for_x_action">Afficher les détails de %1$s</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Statut de la mise à niveau et options</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -571,7 +571,6 @@
     <string name="general_copy_action">कॉपी करें</string>
     <string name="general_copied_to_clipboard_msg">क्लिपबोर्ड पर प्रतिलिपि बनाई गई</string>
     <string name="general_view_details_for_x_action">%1$s के लिए विवरण देखें</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">अपग्रेड की स्थिति और विकल्प</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -594,7 +594,6 @@
     <string name="general_copy_action">Kopiraj</string>
     <string name="general_copied_to_clipboard_msg">Kopirano u međuspremnik</string>
     <string name="general_view_details_for_x_action">Prikaži detalje za %1$s</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Stanje nadogradnje i mogućnosti</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -571,7 +571,6 @@
     <string name="general_copy_action">Másolás</string>
     <string name="general_copied_to_clipboard_msg">Vágólapra másolva</string>
     <string name="general_view_details_for_x_action">Tekintsd meg a részleteket: %1$s</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Frissítés állapota és lehetőségei</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -571,7 +571,6 @@
     <string name="general_copy_action">Copia</string>
     <string name="general_copied_to_clipboard_msg">Copiato negli appunti</string>
     <string name="general_view_details_for_x_action">Visualizza i dettagli per %1$s</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Stato dell’aggiornamento e opzioni</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -617,7 +617,6 @@
     <string name="general_copy_action">העתקה</string>
     <string name="general_copied_to_clipboard_msg">הועתק ללוח</string>
     <string name="general_view_details_for_x_action">הצג פרטים עבור %1$s</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">סטטוס השדרוג ואפשרויות</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -548,7 +548,6 @@
     <string name="general_copy_action">コピー</string>
     <string name="general_copied_to_clipboard_msg">クリップボードにコピーしました</string>
     <string name="general_view_details_for_x_action">%1$sの詳細を表示</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">アップグレード状態とオプション</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -548,7 +548,6 @@
     <string name="general_copy_action">복사</string>
     <string name="general_copied_to_clipboard_msg">클립보드로 복사됨</string>
     <string name="general_view_details_for_x_action">%1$s의 세부정보 보기</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">업그레이드 상태 및 옵션</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-ku-rTR/strings.xml
+++ b/app/src/main/res/values-ku-rTR/strings.xml
@@ -571,7 +571,6 @@
     <string name="general_copy_action">Kopî bike</string>
     <string name="general_copied_to_clipboard_msg">Copî kir</string>
     <string name="general_view_details_for_x_action">Hûrguşên %1$s bibîn</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Rewşa Bulaş û Vebijark</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -571,7 +571,6 @@
     <string name="general_copy_action">Kopier</string>
     <string name="general_copied_to_clipboard_msg">Kopiert til utklippstavlen</string>
     <string name="general_view_details_for_x_action">Vis detaljer for %1$s</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Oppgraderingsstatus og alternativer</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -571,7 +571,6 @@
     <string name="general_copy_action">Kopiëren</string>
     <string name="general_copied_to_clipboard_msg">Gekopieerd naar klembord</string>
     <string name="general_view_details_for_x_action">Details weergeven voor %1$s</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Upgradestatus en opties</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -617,7 +617,6 @@
     <string name="general_copy_action">Kopiuj</string>
     <string name="general_copied_to_clipboard_msg">Skopiowano do schowka</string>
     <string name="general_view_details_for_x_action">Wyświetl szczegóły dla %1$s</string>
-    <string name="upgrade_title_prefix">Pilot Uprawnień</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Status i opcje aktualizacji</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -571,7 +571,6 @@
     <string name="general_copy_action">Copiar</string>
     <string name="general_copied_to_clipboard_msg">Copiado para área de transferência</string>
     <string name="general_view_details_for_x_action">Ver detalhes de %1$s</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Status de atualização e opções</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -571,7 +571,6 @@
     <string name="general_copy_action">Copiar</string>
     <string name="general_copied_to_clipboard_msg">Copiado para a área de transferência</string>
     <string name="general_view_details_for_x_action">Ver detalhes de %1$s</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Estado e opções da atualização para Pro</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -594,7 +594,6 @@
     <string name="general_copy_action">Copiază</string>
     <string name="general_copied_to_clipboard_msg">Copiat în clipboard</string>
     <string name="general_view_details_for_x_action">Vizualizați detaliile pentru %1$s</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Status upgrade și opțiuni</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -617,7 +617,6 @@
     <string name="general_copy_action">Копировать</string>
     <string name="general_copied_to_clipboard_msg">Скопировано в буфер</string>
     <string name="general_view_details_for_x_action">Просмотреть сведения о %1$s</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Статус и параметры обновления</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -617,7 +617,6 @@
     <string name="general_copy_action">Kopírovať</string>
     <string name="general_copied_to_clipboard_msg">Skopírované do schránky</string>
     <string name="general_view_details_for_x_action">Zobraziť podrobnosti pre %1$s</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Stav upgradu a možnosti</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -594,7 +594,6 @@
     <string name="general_copy_action">Копирај</string>
     <string name="general_copied_to_clipboard_msg">Копирано у исечак</string>
     <string name="general_view_details_for_x_action">Погледај детаље за %1$s</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Статус унапређења и опције</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -571,7 +571,6 @@
     <string name="general_copy_action">Kopiera</string>
     <string name="general_copied_to_clipboard_msg">Kopierat till urklipp</string>
     <string name="general_view_details_for_x_action">Visa detaljer för %1$s</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Uppgraderingsstatus och alternativ</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -548,7 +548,6 @@
     <string name="general_copy_action">คัดลอก</string>
     <string name="general_copied_to_clipboard_msg">คัดลอกไปยังคลิปบอร์ด</string>
     <string name="general_view_details_for_x_action">ดูรายละเอียดสำหรับ %1$s</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">สถานะการอัปเกรดและตัวเลือก</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -571,7 +571,6 @@
     <string name="general_copy_action">Kopyala</string>
     <string name="general_copied_to_clipboard_msg">Panoya kopyalandı</string>
     <string name="general_view_details_for_x_action">%1$s için ayrıntıları görüntüle</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Yükseltme durumu ve seçenekleri</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -617,7 +617,6 @@
     <string name="general_copy_action">Копіювати</string>
     <string name="general_copied_to_clipboard_msg">Збережено у буфері</string>
     <string name="general_view_details_for_x_action">Переглянути деталі для %1$s</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Статус оновлення та параметри</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -548,7 +548,6 @@
     <string name="general_copy_action">Sao chép</string>
     <string name="general_copied_to_clipboard_msg">Chép vào bộ nhớ tạm</string>
     <string name="general_view_details_for_x_action">Xem chi tiết về %1$s</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Trạng thái nâng cấp và tùy chọn</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -548,7 +548,6 @@
     <string name="general_copy_action">复制</string>
     <string name="general_copied_to_clipboard_msg">已复制到剪切板</string>
     <string name="general_view_details_for_x_action">查看 %1$s 的详情</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">升级状态和选项</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -548,7 +548,6 @@
     <string name="general_copy_action">複製</string>
     <string name="general_copied_to_clipboard_msg">已複製到剪貼簿</string>
     <string name="general_view_details_for_x_action">檢視 %1$s 的詳細資訊</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">升級狀態與選項</string>
     <!-- Permission Watcher -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -609,7 +609,6 @@
     <string name="general_copy_action">Copy</string>
     <string name="general_copied_to_clipboard_msg">Copied to clipboard</string>
     <string name="general_view_details_for_x_action">View details for %1$s</string>
-    <string name="upgrade_title_prefix">Permission Pilot</string>
 
     <!-- Settings entry that opens the upgrade status/options screen (flavor-neutral) -->
     <string name="settings_upgrade_description">Upgrade status and options</string>

--- a/app/src/test/java/eu/darken/myperm/main/ui/overview/OverviewScreenTitleTest.kt
+++ b/app/src/test/java/eu/darken/myperm/main/ui/overview/OverviewScreenTitleTest.kt
@@ -21,7 +21,7 @@ import org.junit.Test
 import org.robolectric.annotation.Config
 import testhelpers.compose.BaseComposeRobolectricTest
 import testhelpers.compose.brandQualifier
-import testhelpers.compose.brandTitleFor
+import testhelpers.compose.expectedBrandTitle
 import testhelpers.compose.shouldHighlightOnlyQualifier
 
 /**
@@ -43,7 +43,7 @@ class OverviewScreenTitleTest : BaseComposeRobolectricTest() {
     // Derived from the resolved template, never spelled as "$appName $suffix": arrangement is the
     // translator's, so a locale that reorders or repunctuates is intended behaviour, not a failure.
     private val brandedTitle: String
-        get() = context.brandTitleFor(R.string.app_name)
+        get() = context.expectedBrandTitle
 
     private fun proInfo(): UpgradeRepo.Info = mockk<UpgradeRepo.Info>(relaxed = true).also {
         every { it.isPro } returns true
@@ -153,12 +153,10 @@ class OverviewScreenTitleTest : BaseComposeRobolectricTest() {
     fun `the branded title keeps the locale's app name`() {
         showState(proInfo())
 
-        // "Piloto de los permisos …", not the upgrade screen's untranslated "Permission Pilot":
-        // gaining Pro must not switch the dashboard title's language.
+        // Gaining Pro must not switch the title's language: the brand stays "Piloto de los
+        // permisos", never the untranslated "Permission Pilot".
         appName shouldBe "Piloto de los permisos"
         composeRule.onAllNodesWithText(brandedTitle).assertCountEquals(1)
-        composeRule.onAllNodesWithText(
-            context.brandTitleFor(R.string.upgrade_title_prefix)
-        ).assertCountEquals(0)
+        composeRule.onAllNodesWithText("Permission Pilot $suffix").assertCountEquals(0)
     }
 }

--- a/app/src/test/java/eu/darken/myperm/settings/ui/index/SettingsIndexBrandTitleTest.kt
+++ b/app/src/test/java/eu/darken/myperm/settings/ui/index/SettingsIndexBrandTitleTest.kt
@@ -9,7 +9,7 @@ import eu.darken.myperm.common.compose.PreviewWrapper
 import org.junit.Test
 import org.robolectric.annotation.Config
 import testhelpers.compose.BaseComposeRobolectricTest
-import testhelpers.compose.brandTitleFor
+import testhelpers.compose.expectedBrandTitle
 
 /**
  * The settings entry names the same tier the dashboard does. It used to carry its own hardcoded
@@ -42,7 +42,7 @@ class SettingsIndexBrandTitleTest : BaseComposeRobolectricTest() {
     fun `the upgrade row carries the same composed brand as the dashboard`() {
         showScreen()
 
-        composeRule.onAllNodesWithText(context.brandTitleFor(R.string.app_name)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.expectedBrandTitle).assertCountEquals(1)
     }
 
     @Test
@@ -52,7 +52,7 @@ class SettingsIndexBrandTitleTest : BaseComposeRobolectricTest() {
 
         // Was "Permission Pilot Pro" here while the dashboard said "Piloto de los permisos Pro".
         requireLocalizedAppName()
-        composeRule.onAllNodesWithText(context.brandTitleFor(R.string.app_name)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.expectedBrandTitle).assertCountEquals(1)
     }
 
     @Test
@@ -61,7 +61,7 @@ class SettingsIndexBrandTitleTest : BaseComposeRobolectricTest() {
         showScreen()
 
         requireLocalizedAppName()
-        composeRule.onAllNodesWithText(context.brandTitleFor(R.string.app_name)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.expectedBrandTitle).assertCountEquals(1)
     }
 
     // Guards the guard: if app_name ever stopped being translated in these locales the assertions

--- a/app/src/test/java/testhelpers/compose/BrandTitleExpectations.kt
+++ b/app/src/test/java/testhelpers/compose/BrandTitleExpectations.kt
@@ -13,11 +13,12 @@ import io.kotest.matchers.shouldBe
  * assert only the invariants — the qualifier appears exactly once, and the highlight covers
  * exactly it, wherever the template put it.
  */
-fun Context.brandTitleFor(nameRes: Int): String = getString(
-    R.string.app_name_upgraded_template,
-    getString(nameRes),
-    getString(R.string.upgrade_title_suffix),
-)
+val Context.expectedBrandTitle: String
+    get() = getString(
+        R.string.app_name_upgraded_template,
+        getString(R.string.app_name),
+        getString(R.string.upgrade_title_suffix),
+    )
 
 /** The flavor's tier qualifier — "Pro" on gplay, "FOSS" on the FOSS build. */
 val Context.brandQualifier: String

--- a/app/src/testFoss/java/eu/darken/myperm/common/upgrade/ui/FossUpgradeScreenTest.kt
+++ b/app/src/testFoss/java/eu/darken/myperm/common/upgrade/ui/FossUpgradeScreenTest.kt
@@ -15,8 +15,9 @@ import eu.darken.myperm.common.compose.PreviewWrapper
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.robolectric.annotation.Config
 import testhelpers.compose.BaseComposeRobolectricTest
-import testhelpers.compose.brandTitleFor
+import testhelpers.compose.expectedBrandTitle
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -71,7 +72,7 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
             UpgradeScreen(view = FossUpgradeView.STATUS_FREE)
         }
 
-        composeRule.onAllNodesWithText(context.brandTitleFor(R.string.upgrade_title_prefix)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.expectedBrandTitle).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_STATUS_FREE).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SHOW_OPTIONS).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SPONSOR).assertCountEquals(0)
@@ -106,7 +107,7 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
             UpgradeScreen(view = FossUpgradeView.STATUS_UPGRADED, supporterSince = since)
         }
 
-        composeRule.onAllNodesWithText(context.brandTitleFor(R.string.upgrade_title_prefix)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.expectedBrandTitle).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_STATUS_UPGRADED).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_status_upgraded_body))
             .assertCountEquals(1)
@@ -160,6 +161,52 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
             assertTrue(clicked)
             assertFalse(armed)
         }
+    }
+}
+
+/**
+ * The upgrade screen draws its brand from the same `app_name` the dashboard and settings row use.
+ * It used to have its own less-translated copy, so in these locales it showed the English brand
+ * while the dashboard showed the localized one. Pinned in a locale that translates `app_name`,
+ * because in English every candidate source resolves to the same text and proves nothing.
+ */
+class FossUpgradeScreenBrandTitleTest : BaseComposeRobolectricTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private fun showScreen() {
+        composeRule.setContent {
+            PreviewWrapper { UpgradeScreen(view = FossUpgradeView.STATUS_FREE) }
+        }
+    }
+
+    @Test
+    @Config(qualifiers = "es")
+    fun `the upgrade screen title matches the dashboard brand in spanish`() {
+        check(context.getString(R.string.app_name) != "Permission Pilot") {
+            "app_name is untranslated here, the assertion proves nothing"
+        }
+        showScreen()
+
+        composeRule.onAllNodesWithText(context.expectedBrandTitle).assertCountEquals(1)
+        composeRule.onAllNodesWithText(
+            "Permission Pilot ${context.getString(R.string.upgrade_title_suffix)}"
+        ).assertCountEquals(0)
+    }
+
+    @Test
+    @Config(qualifiers = "ar")
+    fun `the upgrade screen title matches the dashboard brand in arabic`() {
+        check(context.getString(R.string.app_name) != "Permission Pilot") {
+            "app_name is untranslated here, the assertion proves nothing"
+        }
+        showScreen()
+
+        composeRule.onAllNodesWithText(context.expectedBrandTitle).assertCountEquals(1)
+        composeRule.onAllNodesWithText(
+            "Permission Pilot ${context.getString(R.string.upgrade_title_suffix)}"
+        ).assertCountEquals(0)
     }
 }
 

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/GplayUpgradeScreenTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/GplayUpgradeScreenTest.kt
@@ -25,9 +25,10 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Test
+import org.robolectric.annotation.Config
 import testhelpers.compose.BaseComposeRobolectricTest
 import testhelpers.compose.brandQualifier
-import testhelpers.compose.brandTitleFor
+import testhelpers.compose.expectedBrandTitle
 import testhelpers.compose.shouldHighlightOnlyQualifier
 
 class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
@@ -38,7 +39,7 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
     // The composed brand the screen renders for owners and grace users ("Permission Pilot Pro" in
     // English). Derived from the resolved template, so a locale that reorders it still passes.
     private val appNameWithPostfix: String
-        get() = context.brandTitleFor(R.string.upgrade_title_prefix)
+        get() = context.expectedBrandTitle
 
     private fun appNameWithPostfixedHeroBody(bodyRes: Int): String = context.getString(
         bodyRes,
@@ -414,7 +415,7 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_MANAGE_SUB).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_SUBSCRIPTION).assertCountEquals(0)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_owned_sub_renewing_body)).assertCountEquals(1)
-        composeRule.onAllNodesWithText(context.brandTitleFor(R.string.upgrade_title_prefix)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.expectedBrandTitle).assertCountEquals(1)
         // The congrats hero names the variant.
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_OWNED_HERO).assertCountEquals(1)
         composeRule.onAllNodesWithText(appNameWithPostfixedHeroBody(R.string.upgrade_screen_owned_hero_sub_body))
@@ -522,7 +523,7 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         // must not undercut the calm quiet stage with its own restore CTA.
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_RESTORE).assertCountEquals(0)
         // Grace users are still Pro: neutral status title, not the acquisition pitch title.
-        composeRule.onAllNodesWithText(context.brandTitleFor(R.string.upgrade_title_prefix)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.expectedBrandTitle).assertCountEquals(1)
         // A young episode is treated as a blip: calm status only — no offers, no sales pitch.
         // The offers return with the aged (diagnostics) stage.
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_SUBSCRIPTION).assertCountEquals(0)
@@ -691,6 +692,57 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onNodeWithText(context.getString(R.string.contact_support_label)).performClick()
         composeRule.runOnIdle { supportTaps shouldBe 1 }
     }
+}
+
+/**
+ * The upgrade screen draws its brand from the same `app_name` the dashboard and settings row use.
+ * It used to have its own less-translated copy, so in these locales it showed the English brand
+ * while the dashboard showed the localized one — in Arabic that produced a mixed-language title,
+ * an English brand beside an Arabic qualifier. Pinned in locales that translate `app_name`, because
+ * in English every candidate source resolves to the same text and proves nothing.
+ */
+class GplayUpgradeScreenBrandTitleTest : BaseComposeRobolectricTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private fun showScreen() {
+        composeRule.setContent {
+            PreviewWrapper {
+                UpgradeScreen(
+                    uiState = GplayUpgradeUiState.Loaded(
+                        subscriptionAction = SubscriptionAction.UNAVAILABLE,
+                        subscriptionEnabled = false,
+                        subscriptionPrice = null,
+                        iapEnabled = false,
+                        iapPrice = "$24.99",
+                        ownership = Ownership(hasIap = true),
+                        busy = null,
+                    ),
+                )
+            }
+        }
+    }
+
+    private fun assertBrandAgrees() {
+        check(context.getString(R.string.app_name) != "Permission Pilot") {
+            "app_name is untranslated here, the assertion proves nothing"
+        }
+        showScreen()
+
+        composeRule.onAllNodesWithText(context.expectedBrandTitle).assertCountEquals(1)
+        composeRule.onAllNodesWithText(
+            "Permission Pilot ${context.getString(R.string.upgrade_title_suffix)}"
+        ).assertCountEquals(0)
+    }
+
+    @Test
+    @Config(qualifiers = "es")
+    fun `the upgrade screen title matches the dashboard brand in spanish`() = assertBrandAgrees()
+
+    @Test
+    @Config(qualifiers = "ar")
+    fun `the upgrade screen title matches the dashboard brand in arabic`() = assertBrandAgrees()
 }
 
 private fun ComposeContentTestRule.setUpgradeContent(


### PR DESCRIPTION
## What changed

The upgrade screen now shows the same app name as the dashboard and the Settings row. It used to
draw its title from a second, separately translated copy of the brand, and that copy was missing
translations the main one had — so in five languages the upgrade screen showed the English
"Permission Pilot" while the rest of the app showed the translated name. Arabic was the worst case:
an English brand sitting next to an Arabic qualifier in the same title.

| locale | upgrade screen before | upgrade screen after | dashboard + Settings (unchanged) |
|---|---|---|---|
| es | Permission Pilot Pro | Piloto de los permisos Pro | Piloto de los permisos Pro |
| ar | Permission Pilot احترافي | بايلوت الأذونات احترافي | بايلوت الأذونات احترافي |
| am | Permission Pilot Pro | ፍቃድ ፓይሎት Pro | ፍቃድ ፓይሎት Pro |
| az | Permission Pilot Pro | İcazə Pilot Pro | İcazə Pilot Pro |
| be | Permission Pilot Pro | Дазвол Пілот Pro | Дазвол Пілот Pro |

Polish is unchanged at "Pilot Uprawnień Pro" — its copy of the brand happened to be translated, so
all three surfaces already agreed there. The FOSS build gets the same fix with its own qualifier.

## Technical Context

- `upgrade_title_prefix` is retired from the base source set and all 39 locale overrides, and from
  Crowdin. It was the last duplicate copy of the brand in the app; every surface now composes from
  `app_name` through the existing translatable `app_name_upgraded_template`.
- `brandTitle`/`brandTitleText` lose their `nameRes` parameter. With the prefix gone it had exactly
  one possible argument at every call site, and leaving it would let a second brand source back in —
  which is the failure this change exists to remove. The signatures now match the rest of the fleet.
- Two comments claimed the two-key split was deliberate, on the grounds that the keys were not
  locale-equivalent. That described the symptom, not a reason: they differed only because one was
  translated in fewer locales. Both are rewritten rather than left contradicting the code.
- `upgrade_title_suffix` is deliberately untouched. It is the flavour-owned qualifier — FOSS pins
  "FOSS" with `translatable="false"`, gplay ships a translated "Pro" in 39 locales — and moving a
  flavour-differing key into `main` defeats the FOSS pin. It also keeps its current name; renaming
  to match the fleet would cost a Crowdin key migration for no behavioural gain.
- Retirement was staged across two Crowdin uploads so the key was not obsoleted before the pulled
  state had been verified. Unlike the previous round this change adds no new key, so there was
  nothing for the translate step to scope — every language was already at 100%.
- Tests: the assertions that referenced the prefix now derive expected text from the resolved
  template with `app_name`. One of them became a self-contradiction under the mechanical rename (it
  had asserted the prefix-composed title was *absent* while the app_name-composed one was present —
  the same string once the two collapsed) and was rewritten to pin the English brand explicitly.
  New `es`/`ar` tests in both flavours assert the upgrade screen renders the localized brand and not
  the English one; each guards itself with a check that `app_name` really is translated in that
  locale, since in English every candidate source resolves to the same text and would prove nothing.

Also tidies a stray double blank line left in the FOSS strings file by the previous change.
