### PR TITLE
General: Fix German upgrade screen translations

### DIFF
--- a/app/src/foss/res/values-de/strings.xml
+++ b/app/src/foss/res/values-de/strings.xml
@@ -6,14 +6,14 @@
     <string name="upgrade_foss_sponsor_returned_early">Bitte nimm dir einen Moment, um die Sponsor-Seite zu besuchen!</string>
     <!-- Free status -->
     <string name="upgrade_screen_status_free_title">Kostenlose Version</string>
-    <string name="upgrade_screen_status_free_body">Sie verwenden den kostenlosen Open-Source-Build. Unterstützen Sie die Entwicklung, um die Pro-Funktionen freizuschalten.</string>
+    <string name="upgrade_screen_status_free_body">Du verwendest den kostenlosen Open-Source-Build. Unterstütz die Entwicklung, um die Pro-Funktionen freizuschalten.</string>
     <string name="upgrade_screen_status_free_action">Sponsor werden</string>
     <!-- Supporter status -->
-    <string name="upgrade_screen_status_upgraded_title">Vielen Dank für Ihre Unterstützung!</string>
-    <string name="upgrade_screen_status_upgraded_body">Sie haben alle Pro-Funktionen freigeschaltet. Ihre Unterstützung hält Permission Pilot kostenlos und Open-Source.</string>
+    <string name="upgrade_screen_status_upgraded_title">Vielen Dank für deine Unterstützung!</string>
+    <string name="upgrade_screen_status_upgraded_body">Du hast alle Pro-Funktionen freigeschaltet. Deine Unterstützung hält Permission Pilot kostenlos und Open-Source.</string>
     <string name="upgrade_screen_supporter_since">Unterstützer seit %1$s</string>
     <string name="upgrade_screen_recurring_title">Erneut unterstützen</string>
-    <string name="upgrade_screen_recurring_body">Permission Pilot wird offen entwickelt. Ziehen Sie ein wiederkehrendes Sponsoring in Betracht, um es zu unterstützen.</string>
+    <string name="upgrade_screen_recurring_body">Permission Pilot wird offen entwickelt. Ziehe ein wiederkehrendes Sponsoring in Betracht, um es zu unterstützen.</string>
     <string name="upgrade_screen_recurring_action">GitHub Sponsors öffnen</string>
     <!-- Support pitch -->
     <string name="upgrade_screen_title">Permission Pilot unterstützen</string>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -3,7 +3,7 @@
     <string name="upgrades_gplay_unavailable_error">Google Play-Dienste sind nicht verfügbar.</string>
     <string name="upgrades_no_purchases_found_check_account">Keine Käufe gefunden. Verwendest du das richtige Konto?</string>
     <string name="upgrades_gplay_already_owned_title">Bereits gekauft</string>
-    <string name="upgrades_gplay_already_owned_error">Google Play meldet, dass Sie dieses Upgrade bereits besitzen, es konnte jedoch nicht wiederhergestellt werden. Stellen Sie sicher, dass Sie mit dem Google-Konto angemeldet sind, das für den ursprünglichen Kauf verwendet wurde, und versuchen Sie dann, den Kauf wiederherzustellen.</string>
+    <string name="upgrades_gplay_already_owned_error">Google Play meldet, dass du dieses Upgrade bereits besitzt, es konnte jedoch nicht wiederhergestellt werden. Stell sicher, dass du mit dem Google-Konto angemeldet bist, das für den ursprünglichen Kauf verwendet wurde, und versuch dann, den Kauf wiederherzustellen.</string>
     <string name="upgrade_screen_preamble">Permission Pilot ist werbefrei und respektiert deine Privatsphäre. Ein Upgrade unterstützt die weitere Entwicklung.</string>
     <string name="upgrade_screen_offers_unavailable_title">Preise nicht verfügbar</string>
     <string name="upgrade_screen_offers_unavailable_message">Die Preise konnten gerade nicht geladen werden. Überprüfe Google Play und versuche es gleich noch einmal.</string>
@@ -19,32 +19,32 @@
     <string name="upgrade_screen_options_description">Abonnements verlängern sich automatisch. Du kannst jederzeit kündigen.</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Sie haben Pro – vielen Dank!</string>
-    <string name="upgrade_screen_owned_hero_iap_body">Ihr einmaliger Pro-Kauf entsperrt alle Pro-Funktionen für immer.</string>
-    <string name="upgrade_screen_owned_hero_sub_body">Ihr Abonnement entsperrt alle Pro-Funktionen.</string>
-    <string name="upgrade_screen_owned_sub_title">Ihr Abonnement</string>
-    <string name="upgrade_screen_owned_sub_renewing_body">Ihr Abonnement ist aktiv und wird automatisch verlängert.</string>
-    <string name="upgrade_screen_owned_sub_not_renewing_body">Ihr Abonnement läuft aus und wird nicht verlängert. Sie behalten Pro bis zum Ende.</string>
-    <string name="upgrade_screen_owned_both_warning">Sie besitzen das einmalige Pro-Upgrade und haben auch ein aktives Abonnement. Sie benötigen nicht beides – kündigen Sie das Abonnement in Google Play, um weitere Gebühren zu vermeiden.</string>
+    <string name="upgrade_screen_owned_hero_title">Du hast Pro – vielen Dank!</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Dein einmaliger Pro-Kauf entsperrt alle Pro-Funktionen für immer.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Dein Abonnement entsperrt alle Pro-Funktionen.</string>
+    <string name="upgrade_screen_owned_sub_title">Dein Abonnement</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Dein Abonnement ist aktiv und wird automatisch verlängert.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Dein Abonnement läuft aus und wird nicht verlängert. Du behältst Pro bis zum Ende.</string>
+    <string name="upgrade_screen_owned_both_warning">Du besitzt das einmalige Pro-Upgrade und hast auch ein aktives Abonnement. Du brauchst nicht beides – kündige das Abonnement in Google Play, um weitere Gebühren zu vermeiden.</string>
     <string name="upgrade_screen_manage_subscription_action">Abo verwalten</string>
     <string name="upgrade_screen_owned_iap_title">Pro für immer</string>
-    <string name="upgrade_screen_owned_iap_body">Sie besitzen das einmalige Pro-Upgrade. Kein Abonnement, keine Verlängerungen.</string>
+    <string name="upgrade_screen_owned_iap_body">Du besitzt das einmalige Pro-Upgrade. Kein Abonnement, keine Verlängerungen.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Zum einmaligen Kauf wechseln</string>
-    <string name="upgrade_screen_switch_purchase_note">Ihr Abonnement wird nicht verlängert, daher können Sie jetzt zum permanenten einmaligen Pro-Kauf wechseln.</string>
-    <string name="upgrade_screen_switch_locked_note">Um zum einmaligen Kauf zu wechseln, kündigen Sie zunächst Ihr Abonnement in Google Play. Dieses Angebot wird freigegeben, sobald es nicht mehr verlängert wird.</string>
-    <string name="upgrade_screen_limitation_disclosure">Google Play überprüft nur das Konto, mit dem Sie gerade angemeldet sind. Der Einmalkauf ist unabhängig von Ihrem Abonnement.</string>
-    <string name="upgrade_screen_sub_still_renewing_message">Ihr Abonnement ist noch aktiv und wird erneuert. Kündigen Sie es zuerst in Google Play.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Ihr Abonnement konnte nicht bei Google Play überprüft werden. Bitte versuchen Sie es noch einmal.</string>
+    <string name="upgrade_screen_switch_purchase_note">Dein Abonnement wird nicht verlängert, daher kannst du jetzt zum permanenten einmaligen Pro-Kauf wechseln.</string>
+    <string name="upgrade_screen_switch_locked_note">Um zum einmaligen Kauf zu wechseln, kündige zunächst dein Abonnement in Google Play. Dieses Angebot wird freigegeben, sobald es nicht mehr verlängert wird.</string>
+    <string name="upgrade_screen_limitation_disclosure">Google Play überprüft nur das Konto, mit dem du gerade angemeldet bist. Der Einmalkauf ist unabhängig von deinem Abonnement.</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Dein Abonnement ist noch aktiv und wird erneuert. Kündige es zuerst in Google Play.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Dein Abonnement konnte nicht bei Google Play überprüft werden. Bitte versuche es noch einmal.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">Dein Kauf wird bestätigt</string>
-    <string name="upgrade_screen_grace_body">Warten auf erneute Bestätigung Ihres Pro-Kaufs durch Google Play. Dies löst sich normalerweise von selbst.</string>
-    <string name="upgrade_screen_grace_diagnostics_body">Wir können Ihren Pro-Kauf immer noch nicht bei Google Play erneut bestätigen. Wenn dies weiterhin geschieht, versuchen Sie, Ihren Kauf wiederherzustellen, oder kontaktieren Sie den Support.</string>
+    <string name="upgrade_screen_grace_body">Warten auf erneute Bestätigung deines Pro-Kaufs durch Google Play. Dies löst sich normalerweise von selbst.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">Wir können deinen Pro-Kauf immer noch nicht bei Google Play erneut bestätigen. Wenn dies weiterhin geschieht, versuche, deinen Kauf wiederherzustellen, oder kontaktiere den Support.</string>
     <!-- Restore -->
     <string name="upgrade_screen_restore_status_title">Status sieht falsch aus?</string>
-    <string name="upgrade_screen_restore_status_body">Wenn Sie Pro gekauft haben, es aber nicht angezeigt wird, führen Sie eine Live-Überprüfung bei Google Play durch.</string>
+    <string name="upgrade_screen_restore_status_body">Wenn du Pro gekauft hast, es aber nicht angezeigt wird, führe eine Live-Überprüfung bei Google Play durch.</string>
     <string name="upgrade_screen_restore_success_message">Kauf wiederhergestellt.</string>
-    <string name="upgrade_screen_restore_webinstall_hint">Stellen Sie sicher, dass Sie mit dem Google-Konto angemeldet sind, mit dem Sie gekauft haben. Eine Live-Überprüfung bei Google Play wurde gerade durchgeführt.</string>
+    <string name="upgrade_screen_restore_webinstall_hint">Stell sicher, dass du mit dem Google-Konto angemeldet bist, mit dem du gekauft hast. Eine Live-Überprüfung bei Google Play wurde gerade durchgeführt.</string>
     <!-- Upgrade options card -->
     <string name="upgrade_screen_offers_title">Upgrade-Möglichkeiten</string>
     <string name="upgrade_screen_offers_body">Gleiche Funktionen, nur unterschiedliche Preismodelle.</string>
@@ -59,7 +59,7 @@
     <!-- Failed-restore troubleshooting dialog -->
     <string name="upgrade_screen_restore_checked_message">Google Play wurde gerade überprüft, aber für das Konto, das es für diese App verwendet, konnte kein Pro-Kauf bestätigt werden.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Mehrere Konten können Google Play durcheinanderbringen. Die Installation der App über die Google Play-Website erzwingt die Zuordnung zu einem bestimmten Konto.</string>
-    <string name="upgrade_screen_restore_sync_patience_hint">Die Google Play-Synchronisierung kann eine Weile dauern. Versuchen Sie, das Gerät neu zu starten, den Google Play Store-Cache zu löschen oder einfach zu warten.</string>
+    <string name="upgrade_screen_restore_sync_patience_hint">Die Google Play-Synchronisierung kann eine Weile dauern. Versuche, das Gerät neu zu starten, den Google Play Store-Cache zu löschen oder einfach zu warten.</string>
     <string name="upgrade_screen_restore_contact_hint">Immer noch nicht weiter? Kontaktiere den Support von der E-Mail-Adresse aus, mit der der Kauf getätigt wurde, und gib deine Google-Play-Bestellnummer an.</string>
     <!-- Screen title shown while Pro is not active -->
     <!-- %1$s is the full localized brand ("Permission Pilot Pro", composed from the title prefix + suffix) — translate the sentence around it, keep the placeholder. -->


### PR DESCRIPTION
## What changed

German translations on the upgrade/subscription screens now consistently use the informal "du" address instead of a mix of formal "Sie" and informal phrasing, and two typos were fixed.

## Technical Context

- Source corrections were made on Crowdin first (Sie→Du unification, "behälst"→"behältst", "kkanst"→"kannst", and dropping an extraneous first-person self-reference in one string), then pulled down
- Scoped to `app/src/foss/res/values-de/strings.xml` and `app/src/gplay/res/values-de/strings.xml`
