### PR TITLE
General: Update app translations from Crowdin

### DIFF
--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -76,7 +76,7 @@
     <string name="upgrades_gplay_billing_error_label">Problem z Google Play</string>
     <string name="upgrades_gplay_billing_error_description">Wystąpił problem z Google Play. Spróbuj ponownie później lub zrestartuj urządzenie.\n\nSzczegóły: %s</string>
     <string name="upgrades_gplay_internal_error_title">Błąd Google Play</string>
-    <string name="upgrades_gplay_internal_error_description">Wystąpił wewnętrzny błąd Google Play. Spróbuj następujących czynności:\n\n• Zrestartuj urządzenie\n• Wyczyść pamięć podręczną Sklepu Google Play\n• Spróbuj ponownie później</string>
+    <string name="upgrades_gplay_internal_error_description">Wystąpił wewnętrzny błąd Sklepu Google Play. Spróbuj następujących czynności:\n\n• Zrestartuj urządzenie\n• Wyczyść pamięć podręczną Sklepu Google Play\n• Spróbuj ponownie później</string>
     <string name="upgrades_gplay_network_error_title">Błąd połączenia</string>
     <string name="upgrades_gplay_network_error_description">Nie udało się połączyć się z Google Play. Sprawdź swoje połączenie internetowe i spróbuj ponownie.</string>
     <string name="upgrades_gplay_offer_unavailable_title">Oferta niedostępna</string>

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -224,6 +224,7 @@
         <item quantity="other">%d verskaffer-vrae</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">Kan meeste laaibare programme ontdek</string>
     <string name="apps_details_manifest_hint_excessive">Soek na baie spesifieke programme</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">Manifest-kyker</string>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -224,6 +224,7 @@
         <item quantity="other">%d የአቅራቢ ጥያቄዎች</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">አብዛኛው ሊጀመር የሚችሉ መተግበሪያዎችን ማግኘት ይችላል</string>
     <string name="apps_details_manifest_hint_excessive">ለመተግበሪያዎች ካለደ኉ እየ቙ቱን ይነጋባል</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">ማኒፌስት ጨያይ</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -260,6 +260,7 @@
         <item quantity="other">%d استعلام مزود</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">يمكن اكتشاف معظم التطبيقات القابلة للتشغيل</string>
     <string name="apps_details_manifest_hint_excessive">يتحقق من وجود تطبيقات محددة كثيرة</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">عارض البيان</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -224,6 +224,7 @@
         <item quantity="other">%d provayder sorğusu</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">Əksər başladıla biləcək tətbiqləri kəşf edə bilər</string>
     <string name="apps_details_manifest_hint_excessive">Bir çox xüsusi tətbiqi axtarır</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">Manifesta Baxışı</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -242,6 +242,7 @@
         <item quantity="other">%d запытаў правайдара</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">Знаходзіць большасць запускаемых праграм</string>
     <string name="apps_details_manifest_hint_excessive">Правярае наяўнасць многіх канкрэтных праграм</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">Праглядальнік маніфесту</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -224,6 +224,7 @@
         <item quantity="other">%d заявки за доставчик</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">Може да открие повечето пускаеми приложения</string>
     <string name="apps_details_manifest_hint_excessive">Проверява за много конкретни приложения</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">Преглед на манифеста</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -224,6 +224,7 @@
         <item quantity="other">%d টি প্রোভাইডার কোয়েরি</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">বেশিরভাগ চালু করা যায় এমন অ্যাপ আবিষ্কার করতে পারে</string>
     <string name="apps_details_manifest_hint_excessive">অনেক নির্দিষ্ট অ্যাপ খোঁজে</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">ম্যানিফেস্ট ভিউয়ার</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -224,6 +224,7 @@
         <item quantity="other">%d consultes de proveïdor</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">Pot descobrir la majoria d\'aplicacions llançables</string>
     <string name="apps_details_manifest_hint_excessive">Comprova moltes aplicacions específiques</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">Visualitzador del manifest</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -242,6 +242,7 @@
         <item quantity="other">%d dotazů na poskytovatele</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">Umí odhalit většinu spustitelných aplikací</string>
     <string name="apps_details_manifest_hint_excessive">Kontroluje mnoho konkrétních aplikací</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">Prohlížeč manifestu</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -224,6 +224,7 @@
         <item quantity="other">%d udbyderforespørgsler</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">Kan opdage de fleste startbare apps</string>
     <string name="apps_details_manifest_hint_excessive">Tjekker for mange specifikke apps</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">Manifest-visning</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -224,6 +224,7 @@
         <item quantity="other">%d Anbieterabfragen</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">Kann die meisten startbaren Apps finden</string>
     <string name="apps_details_manifest_hint_excessive">Prüft auf viele spezifische Apps</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">Manifest-Viewer</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -224,6 +224,7 @@
         <item quantity="other">%d ερωτήματα παρόχου</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">Μπορεί να ανακαλύψει τις περισσότερες εκκινήσιμες εφαρμογές</string>
     <string name="apps_details_manifest_hint_excessive">Ελέγχει για πολλές συγκεκριμένες εφαρμογές</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">Προβολή Manifest</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -224,6 +224,7 @@
         <item quantity="other">%d consultas de proveedor</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">Puede descubrir la mayoría de aplicaciones lanzables</string>
     <string name="apps_details_manifest_hint_excessive">Comprueba muchas apps específicas</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">Visor de manifiestos</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -224,6 +224,7 @@
         <item quantity="other">%d tarjoajakyselyt</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">Voi löytää useimmat käynnistettävät sovellukset</string>
     <string name="apps_details_manifest_hint_excessive">Tarkistaa monia tiettyjä sovelluksia</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">Manifestin katseluohjelma</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -224,6 +224,7 @@
         <item quantity="other">%d requêtes de fournisseurs</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">Peut découvrir la plupart des applis pouvant être lancées</string>
     <string name="apps_details_manifest_hint_excessive">Vérifie de nombreuses applis spécifiques</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">Visionneuse de manifeste</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -224,6 +224,7 @@
         <item quantity="other">%d प्रोवाइडर क्वेरीज़</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">अधिकांश लॉन्च योग्य ऐप्स खोज सकते हैं</string>
     <string name="apps_details_manifest_hint_excessive">कई विशिष्ट ऐप्स की जाँच करता है</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">मेनिफेस्ट व्यूअर</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -233,6 +233,7 @@
         <item quantity="other">%d upita pružatelja</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">Može otkriti većinu pokretljivih aplikacija</string>
     <string name="apps_details_manifest_hint_excessive">Provjerava mnoge određene aplikacije</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">Preglednik manifesta</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -224,6 +224,7 @@
         <item quantity="other">%d szolgáltató lekérdezés</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">Felfedezhet a legtöbb indítható alkalmazást</string>
     <string name="apps_details_manifest_hint_excessive">Sok specifikus alkalmazást keres</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">Manifest-néző</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -224,6 +224,7 @@
         <item quantity="other">%d query sui provider</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">Può scoprire la maggior parte delle app avviabili</string>
     <string name="apps_details_manifest_hint_excessive">Verifica la presenza di molte app specifiche</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">Visualizzatore manifest</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -242,6 +242,7 @@
         <item quantity="other">%d שאילותות ספק</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">יכול לגלות רוב האפליקציות הניתנות להפעלה</string>
     <string name="apps_details_manifest_hint_excessive">בודק אפליקציות ספציפיות רבות</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">צופה במניפסט</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -215,6 +215,7 @@
         <item quantity="other">%d 件のプロバイダクエリ</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">ほとんどの起動可能なアプリを検出できます</string>
     <string name="apps_details_manifest_hint_excessive">多くの特定のアプリを確認する</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">マニフェストビューア</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -215,6 +215,7 @@
         <item quantity="other">%d개의 프로바이더 쿼리</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">대부분의 실행 가능한 앱을 찾을 수 있어요</string>
     <string name="apps_details_manifest_hint_excessive">많은 특정 앱을 확인합니다</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">매니페스트 뷰어</string>

--- a/app/src/main/res/values-ku-rTR/strings.xml
+++ b/app/src/main/res/values-ku-rTR/strings.xml
@@ -224,6 +224,7 @@
         <item quantity="other">%d lêpisîrsînên pêşkêşker</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">Dikare piraniya bernameyên vexistinê nas bike</string>
     <string name="apps_details_manifest_hint_excessive">Ji bo gelek sepanên taybetî kontrol dike</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">Nêrînerê Manîfestoyê</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -224,6 +224,7 @@
         <item quantity="other">%d leverandørforespørsler</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">Kan oppdage de fleste startbare apper</string>
     <string name="apps_details_manifest_hint_excessive">Sjekker etter mange spesifikke apper</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">Manifestvisning</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -224,6 +224,7 @@
         <item quantity="other">%d provideropvragen</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">Kan de meeste startbare apps ontdekken</string>
     <string name="apps_details_manifest_hint_excessive">Controleert op veel specifieke apps</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">Manifest-viewer</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -242,6 +242,7 @@
         <item quantity="other">%d zapytań o dostawcę</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">Może odkryć większość uruchamialnych aplikacji</string>
     <string name="apps_details_manifest_hint_excessive">Sprawdza wiele konkretnych aplikacji</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">Przeglądarka manifestu</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -224,6 +224,7 @@
         <item quantity="other">%d consultas de provedor</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">Consegue descobrir a maioria dos apps inicializáveis</string>
     <string name="apps_details_manifest_hint_excessive">Verifica muitos apps específicos</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">Visualizador de Manifesto</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -224,6 +224,7 @@
         <item quantity="other">%d consultas de fornecedor</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">Consegue descobrir a maioria das aplicações lançáveis</string>
     <string name="apps_details_manifest_hint_excessive">Verifica muitas aplicações específicas</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">Visualizador de Manifesto</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -233,6 +233,7 @@
         <item quantity="other">%d de interogări furnizor</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">Poate descoperi cele mai multe aplicații lansabile</string>
     <string name="apps_details_manifest_hint_excessive">Verifică multe aplicații specifice</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">Vizualizator de manifest</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -242,6 +242,7 @@
         <item quantity="other">%d запросов провайдера</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">Может обнаружить большинство запускаемых приложений</string>
     <string name="apps_details_manifest_hint_excessive">Проверяет наличие многих конкретных приложений</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">Просмотр манифеста</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -242,6 +242,7 @@
         <item quantity="other">%d dopytov na poskytovateľov</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">Vie odhaliť väčšinu spustiteľných aplikácií</string>
     <string name="apps_details_manifest_hint_excessive">Kontroluje mnoho konkrétnych aplikácií</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">Prehľadáč manifestov</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -233,6 +233,7 @@
         <item quantity="other">%d упита добављача</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">Може открити већину покретљивих апликација</string>
     <string name="apps_details_manifest_hint_excessive">Проверава много одређених апликација</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">Прегледач манифеста</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -224,6 +224,7 @@
         <item quantity="other">%d leverantörsförfrågningar</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">Kan upptäcka de flesta startbara appar</string>
     <string name="apps_details_manifest_hint_excessive">Söker efter många specifika appar</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">Manifestvisare</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -215,6 +215,7 @@
         <item quantity="other">การค้นหา Provider %d รายการ</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">สามารถค้นพบแอปปลิเกชันที่เปิดได้ส่วนใหญ่</string>
     <string name="apps_details_manifest_hint_excessive">ตรวจสอบแอปเฉพาะจำนวนมาก</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">ตัวดู Manifest</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -224,6 +224,7 @@
         <item quantity="other">%d sağlayıcı sorgusu</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">Çoğu başlatılabilir uygulamayı keşfedebilir</string>
     <string name="apps_details_manifest_hint_excessive">Birçok belirli uygulama arar</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">Manifesto Görüntülleyici</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -242,6 +242,7 @@
         <item quantity="other">%d запитів постачальника</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">Може виявити більшість запускаємих додатків</string>
     <string name="apps_details_manifest_hint_excessive">Перевіряє наявність багатьох конкретних застосунків</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">Переглядач маніфесту</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -215,6 +215,7 @@
         <item quantity="other">%d truy vấn nhà cung cấp</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">Có thể khám phá hầu hết các ứng dụng</string>
     <string name="apps_details_manifest_hint_excessive">Kiểm tra nhiều ứng dụng cụ thể</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">Trình xem Manifest</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -215,6 +215,7 @@
         <item quantity="other">%d 个提供者查询</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">可发现大多数可启动的应用</string>
     <string name="apps_details_manifest_hint_excessive">检查多个特定应用</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">清单查看器</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -215,6 +215,7 @@
         <item quantity="other">%d 個提供者查詢</item>
     </plurals>
     <!-- Manifest hint flags -->
+    <string name="apps_details_manifest_hint_main_query">可以發現大多數可啟動的應用程式</string>
     <string name="apps_details_manifest_hint_excessive">檢查多個特定應用程式</string>
     <!-- Manifest viewer -->
     <string name="apps_manifest_viewer_label">清單檢視器</string>


### PR DESCRIPTION
## What changed

No user-facing behavior change beyond translation content: pulls the latest translated strings from Crowdin for `apps_details_manifest_hint_main_query` ("Can discover most launchable apps") across 39 locales.

## Technical Context

- Fastlane store listing metadata was already up to date on Crowdin — no changes in that phase.
- All 40 changed `strings.xml` files (39 locales, `pl` touching both `main` and `gplay` source sets) were validated per-locale for placeholder/escape correctness and vandalism; `assembleDebug` passed after the change.
- Three translations were flagged by validation as worth a closer look but left as-is (not errors): Croatian word-choice precision, Vietnamese omitting the "launchable" qualifier. A third flagged issue — a Thai transliteration typo (แอปปลิเกชัน instead of the standard แอปพลิเคชัน) — was a genuine defect and has already been corrected directly on Crowdin; this PR carries the corrected value.
