### PR TITLE
General: Say the user owns Pro rather than that they are Pro

### DIFF
--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeOwnership.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeOwnership.kt
@@ -68,7 +68,7 @@ internal fun UpgradeOwnershipContent(
             )
             if (subscription.isAutoRenewing && ownership.hasIap) {
                 Text(
-                    text = stringResource(R.string.upgrade_screen_owned_both_warning),
+                    text = stringResource(R.string.upgrade_screen_owned_both_renewing_warning),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.error,
                 )
@@ -94,8 +94,8 @@ internal fun UpgradeOwnershipContent(
                 title = stringResource(R.string.upgrade_screen_iap_offer_title),
                 price = uiState.iapPrice,
                 hint = stringResource(
-                    if (switchUnlocked) R.string.upgrade_screen_switch_purchase_note
-                    else R.string.upgrade_screen_switch_locked_note
+                    if (switchUnlocked) R.string.upgrade_screen_owned_iap_purchase_note
+                    else R.string.upgrade_screen_owned_iap_locked_note
                 ),
             ) {
                 Button(

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeOwnership.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeOwnership.kt
@@ -158,14 +158,20 @@ private fun UpgradeOwnedHero(
                 verticalArrangement = Arrangement.spacedBy(4.dp),
             ) {
                 Text(
-                    text = stringResource(R.string.upgrade_screen_owned_hero_title),
+                    // The tier is named by the shared brand composition, so the title follows
+                    // app_name and the translated title template instead of spelling "Pro" itself.
+                    text = stringResource(
+                        R.string.upgrade_screen_owned_hero_brand_title,
+                        brandTitleText(includeQualifier = true),
+                    ),
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.SemiBold,
                 )
                 Text(
                     // The permanent purchase is the meaningful one when both are owned.
-                    // PP's body strings name the app inline (no format arg) — they are among the
-                    // shared ids whose translations must stay untouched.
+                    // Neither body takes a format argument, and both keep the ids PP shipped before
+                    // the billing convergence (04b10e3) so their existing translations still apply
+                    // — renaming them would cost 39 locales.
                     text = stringResource(
                         if (ownership.hasIap) R.string.upgrade_screen_owned_hero_iap_body
                         else R.string.upgrade_screen_owned_hero_sub_body,

--- a/app/src/gplay/res/values-af-rZA/strings.xml
+++ b/app/src/gplay/res/values-af-rZA/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">Intekeninge vernuwe outomaties. Jy kan enige tyd kanselleer.</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">U is Pro — dankie!</string>
     <string name="upgrade_screen_owned_hero_iap_body">U eenmalige Pro-aankoop ontsluit alle Pro-funksies, voorgoed.</string>
     <string name="upgrade_screen_owned_hero_sub_body">U abonnement ontsluit alle Pro-funksies.</string>
     <string name="upgrade_screen_owned_sub_title">U abonnement</string>

--- a/app/src/gplay/res/values-af-rZA/strings.xml
+++ b/app/src/gplay/res/values-af-rZA/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">U abonnement</string>
     <string name="upgrade_screen_owned_sub_renewing_body">U abonnement is aktief en word outomaties vernuwe.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">U abonnement sal verval en word nie vernuwe nie. U behou Pro totdat dit afloop.</string>
-    <string name="upgrade_screen_owned_both_warning">U het die eenmalige Pro-opgradering en ook \'n aktiewe abonnement. U benodig nie albei — kanselleer die abonnement in Google Play om verdere koste te vermy.</string>
     <string name="upgrade_screen_manage_subscription_action">Bestuur abonnement</string>
     <string name="upgrade_screen_owned_iap_title">Lewenslange Pro</string>
     <string name="upgrade_screen_owned_iap_body">U het die eenmalige Pro-opgradering. Geen abonnement, geen vernuewings nie.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Omskakel na \'n eenmalige aankoop</string>
-    <string name="upgrade_screen_switch_purchase_note">U abonnement sal nie vernuwe nie, sodat u nou na die permanente eenmalige Pro-aankoop kan oorgaan.</string>
-    <string name="upgrade_screen_switch_locked_note">Om na die eenmalige aankoop oor te skakel, kanselleer eers u abonnement in Google Play. Hierdie aanbieding ontsluit sodra dit ingestel word om nie te vernuwe nie.</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play kontroleer slegs die rekening waarmee u tans aangemeld is. Die eenmalige aankoop is afsonderlik van u abonnement.</string>
     <string name="upgrade_screen_sub_still_renewing_message">U abonnement is steeds aktief en vernuwe. Kanselleer dit eers in Google Play.</string>
     <string name="upgrade_screen_sub_check_failed_message">Kon nie u abonnement met Google Play verifieer nie. Probeer asseblief weer.</string>

--- a/app/src/gplay/res/values-am/strings.xml
+++ b/app/src/gplay/res/values-am/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">ኰይዘቶች በርስ ይተያያኳሉ። በአንደም መቀሰል ይቻላሉ።</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Pro ነዎ — አመሰግናለሁ!</string>
     <string name="upgrade_screen_owned_hero_iap_body">የአንድ ጊዜ Pro ግዢ ሁሉንም Pro ባህሪ ለዘላለም ይከፍታል።</string>
     <string name="upgrade_screen_owned_hero_sub_body">ሰዋስክ ሁሉም ፕሮ ባህሪ ይከፍታል።</string>
     <string name="upgrade_screen_owned_sub_title">ሰዋስክ</string>

--- a/app/src/gplay/res/values-am/strings.xml
+++ b/app/src/gplay/res/values-am/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">ሰዋስክ</string>
     <string name="upgrade_screen_owned_sub_renewing_body">ሰዋስክ ንቁ ነው እና ራሱ በራሱ ይታደሳል።</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">ሰዋስክ ለመጨረስ ተዘጋጅቷል እና አይታደስም። እስከሚያልቅ ድረስ ፕሮ ይኖርዎታል።</string>
-    <string name="upgrade_screen_owned_both_warning">ለአንድ ጊዜ ፕሮ ማሻሻያ ይዞታል እንዲሁም ንቁ ሰዋስ አለዎት። ሁለቱን ስለማያስፈልግዎ — ተጨማሪ ክፍያ ለማስወገድ በGoogle Play ሰዋስን ይሰርዙ።</string>
     <string name="upgrade_screen_manage_subscription_action">ሰዋስን ያስተዳድሩ</string>
     <string name="upgrade_screen_owned_iap_title">ለዘላለም ፕሮ</string>
     <string name="upgrade_screen_owned_iap_body">ለአንድ ጊዜ ፕሮ ማሻሻያ ይዞታል። ሰዋስ የለም፣ ምንም ታደሳ አይደለም።</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">ወደ አንድ ጊዜ ግዢ ይቀይሩ</string>
-    <string name="upgrade_screen_switch_purchase_note">ሰዋስክ አይታደስም፣ ስለዚህ አሁን ወደ ዘላለም ለአንድ ጊዜ ፕሮ ግዢ መዋወር ይችላሉ።</string>
-    <string name="upgrade_screen_switch_locked_note">ወደ አንድ ጊዜ ያለው ገዥ ለመቀየር በመጀመሪያ Google Play ላይ የእርስዎን ምዝገባ ይሰርዙ። ይህ አማራጭ አቁም ሲተገበር ይክፈታል።</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play በሚገቡበት ሂሳብዎ ብቻ ይከታተላል። አንድ ጊዜ ያለው ገዥ ከእርስዎ ምዝገባ ተለይቶ ነው።</string>
     <string name="upgrade_screen_sub_still_renewing_message">የእርስዎ ምዝገባ አሁንም ንቁ እና ይታደሳል። በGoogle Play ውስጥ በመጀመሪያ ይሰርዙት።</string>
     <string name="upgrade_screen_sub_check_failed_message">የእርስዎን ምዝገባ በGoogle Play ሊያረጋገ አልቻለም። እንደገና ይሞክሩ።</string>

--- a/app/src/gplay/res/values-ar/strings.xml
+++ b/app/src/gplay/res/values-ar/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">اشتراكك</string>
     <string name="upgrade_screen_owned_sub_renewing_body">اشتراكك نشط ويتم تجديده تلقائياً.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">تم ضبط اشتراكك للانتهاء ولن يتم تجديده. ستحتفظ بـ Pro حتى ينتهي.</string>
-    <string name="upgrade_screen_owned_both_warning">أنت تمتلك ترقية Pro لمرة واحدة وأيضاً لديك اشتراك نشط. أنت لا تحتاج إلى كليهما — ألغِ الاشتراك في Google Play لتجنب رسوم إضافية.</string>
     <string name="upgrade_screen_manage_subscription_action">إدارة الاشتراك</string>
     <string name="upgrade_screen_owned_iap_title">Pro مدى الحياة</string>
     <string name="upgrade_screen_owned_iap_body">أنت تمتلك ترقية Pro لمرة واحدة. لا اشتراك، لا تجديدات.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">التبديل إلى الشراء لمرة واحدة</string>
-    <string name="upgrade_screen_switch_purchase_note">لن يتم تجديد اشتراكك، لذا يمكنك الآن الانتقال إلى شراء Pro لمرة واحدة دائم.</string>
-    <string name="upgrade_screen_switch_locked_note">للتبديل إلى الشراء لمرة واحدة، قم أولاً بإلغاء اشتراكك في Google Play. يصبح هذا العرض متاحاً عندما يتم إيقاف التجديد التلقائي.</string>
     <string name="upgrade_screen_limitation_disclosure">يتحقق Google Play فقط من الحساب الذي تم تسجيل الدخول إليه حالياً. الشراء لمرة واحدة منفصل عن اشتراكك.</string>
     <string name="upgrade_screen_sub_still_renewing_message">اشتراكك لا يزال نشطاً ويتم تجديده. قم بإلغائه في Google Play أولاً.</string>
     <string name="upgrade_screen_sub_check_failed_message">تعذر التحقق من اشتراكك مع Google Play. يرجى المحاولة مجدداً.</string>

--- a/app/src/gplay/res/values-ar/strings.xml
+++ b/app/src/gplay/res/values-ar/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">تتجدد الاشتراكات تلقائياً. يمكنك الإلغاء في أي وقت.</string>
     <string name="upgrade_title_suffix">احترافي</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">أنت Pro الآن - شكراً لك!</string>
     <string name="upgrade_screen_owned_hero_iap_body">شراء Pro لمرة واحدة يفتح كل ميزة Pro إلى الأبد.</string>
     <string name="upgrade_screen_owned_hero_sub_body">اشتراكك يفتح كل ميزة Pro.</string>
     <string name="upgrade_screen_owned_sub_title">اشتراكك</string>

--- a/app/src/gplay/res/values-az/strings.xml
+++ b/app/src/gplay/res/values-az/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">Abunəliklər avtomatik olaraq yenilinər. Hər zaman ldö bilərsiniz.</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Siz Pro istifadəçisisiniz — təşəkkür edirik!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Sizin tek seferlik Pro alımı hər Pro xüsusiyyətini əbədi açır.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Sizin abonelik hər Pro xüsusiyyətini açır.</string>
     <string name="upgrade_screen_owned_sub_title">Sizin abonelik</string>

--- a/app/src/gplay/res/values-az/strings.xml
+++ b/app/src/gplay/res/values-az/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">Sizin abonelik</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Sizin abonelik aktiv və avtomatik olaraq yenilənir.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Sizin abonelik bitməyə təyin edilib və yenilənməyəcək. Pro\'yu bitənə qədər saxlayacaqsınız.</string>
-    <string name="upgrade_screen_owned_both_warning">Sizin tek seferlik Pro yüksəltməsi və həm də aktiv abonelik var. Hər ikisinə ehtiyacınız yoxdur — əlavə ödəniş təkrarlamamaq üçün Google Play-də aboneliyi ləğv edin.</string>
     <string name="upgrade_screen_manage_subscription_action">Aboneliyi idarə edin</string>
     <string name="upgrade_screen_owned_iap_title">Ömürlük Pro</string>
     <string name="upgrade_screen_owned_iap_body">Sizin tek seferlik Pro yüksəltməsi var. Abonelik yoxdur, yenilənmə yoxdur.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Birdəfəlik satın almaya keçid</string>
-    <string name="upgrade_screen_switch_purchase_note">Sizin abunəlik yeniləməyəcəyindən, indi daimi birdefelik Pro satın almaya keçə bilərsiniz.</string>
-    <string name="upgrade_screen_switch_locked_note">Birdəfəlik satın almaya keçmək üçün əvvəlcə Google Play-də abunəliyinizi ləğv edin. Bu təklif abunəlik yeniləməsi söndürüldükdə açılacaq.</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play yalnız indi daxil olduğunuz hesabı yoxlayır. Birdəfəlik satın alma abunəlikdən ayrıdır.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Sizin abunəlik hələ də aktivdir və yenilənir. Əvvəlcə Google Play-də ləğv edin.</string>
     <string name="upgrade_screen_sub_check_failed_message">Sizin abunəlik Google Play ilə təsdiqlənə bilmədi. Lütfən yenidən cəhd edin.</string>

--- a/app/src/gplay/res/values-be/strings.xml
+++ b/app/src/gplay/res/values-be/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">Падпіскі аўтаматычна абнаўляюцца. Вы можаце адмяніць іх у любы час.</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Вы маеце Pro — дзякуй!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Ваша аднаразовая пакупка Pro адкрывае ўсе функцыі Pro назаўжды.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Ваша падпіска адкрывае ўсе функцыі Pro.</string>
     <string name="upgrade_screen_owned_sub_title">Ваша падпіска</string>

--- a/app/src/gplay/res/values-be/strings.xml
+++ b/app/src/gplay/res/values-be/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">Ваша падпіска</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Ваша падпіска актыўная і аднаўляецца аўтаматычна.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Ваша падпіска не будзе адноўлена і хутка скончыцца. Вы будзеце карыстацца Pro да яе заканчэння.</string>
-    <string name="upgrade_screen_owned_both_warning">Вы маеце аднаразовую пакупку Pro, а таксама актыўную падпіску. Вам не патрэбны абодва варыянты — адмяніце падпіску ў Google Play, каб пазбегнуць далейшых спагнанняў.</string>
     <string name="upgrade_screen_manage_subscription_action">Кіраваць падпіскай</string>
     <string name="upgrade_screen_owned_iap_title">Pro назаўжды</string>
     <string name="upgrade_screen_owned_iap_body">Вы маеце аднаразовую пакупку Pro. Без падпіскі, без аднаўленняў.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Перайсці на адзінаразовую пакупку</string>
-    <string name="upgrade_screen_switch_purchase_note">Ваша падпіска не будзе аднаўляцца, таму вы можаце цяпер перайсці на сталую адзінаразовую пакупку Pro.</string>
-    <string name="upgrade_screen_switch_locked_note">Каб перайсці на адзінаразовую пакупку, спачатку скасуйце вашу падпіску ў Google Play. Гэтая прапанова разблакуецца, калі падпіска будзе наладжана не аднаўляцца.</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play правярае толькі акаўнт, у які вы зараз увайшлі. Адзінаразовая пакупка не звязана з вашай падпіскай.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Ваша падпіска ўсё яшчэ актыўная і аднаўляецца. Спачатку скасуйце яе ў Google Play.</string>
     <string name="upgrade_screen_sub_check_failed_message">Не ўдалося праверыць вашу падпіску ў Google Play. Калі ласка, паспрабуйце яшчэ раз.</string>

--- a/app/src/gplay/res/values-bg/strings.xml
+++ b/app/src/gplay/res/values-bg/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">Абонаментите се поднавят автоматично. Можете да откажете по всяко време.</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Вие сте Pro — благодаря!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Вашата еднократна Pro покупка отключва всяка Pro функция, завинаги.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Вашият абонамент отключва всички Pro функции.</string>
     <string name="upgrade_screen_owned_sub_title">Вашият абонамент</string>

--- a/app/src/gplay/res/values-bg/strings.xml
+++ b/app/src/gplay/res/values-bg/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">Вашият абонамент</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Вашият абонамент е активен и се подновява автоматично.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Вашият абонамент е настроен да изтече и няма да се подновява. Ще задържите Pro, докато не завърши.</string>
-    <string name="upgrade_screen_owned_both_warning">Притежавате еднократната Pro надстройка и имате активен абонамент. Не се нуждаете от двете — отменете абонамента в Google Play, за да избегнете допълнителни разходи.</string>
     <string name="upgrade_screen_manage_subscription_action">Управление на абонамента</string>
     <string name="upgrade_screen_owned_iap_title">Доживотен Pro</string>
     <string name="upgrade_screen_owned_iap_body">Притежавате еднократната Pro надстройка. Без абонамент, без подновявания.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Преминете към еднократна покупка</string>
-    <string name="upgrade_screen_switch_purchase_note">Вашият абонамент няма да се подновява, така че можете да преминете към постоянната еднократна Pro покупка сега.</string>
-    <string name="upgrade_screen_switch_locked_note">За да преминете към еднократната покупка, първо отменете абонамента си в Google Play. Това предложение се отключва, след като е зададено да не се подновява.</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play проверява само акаунта, в който сте вписани в момента. Еднократната покупка е отделна от абонамента ви.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Абонаментът ви все още е активен и се подновява. Първо го отменете в Google Play.</string>
     <string name="upgrade_screen_sub_check_failed_message">Не можахме да потвърдим абонамента ви с Google Play. Моля, опитайте отново.</string>

--- a/app/src/gplay/res/values-bn-rBD/strings.xml
+++ b/app/src/gplay/res/values-bn-rBD/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">সাবস্ক্রিপশন স্বয়ংক্রিয়ভাবে নবায়ন হয়। যেকোনো সময় বাতিল করতে পারেন।</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">আপনি Pro ব্যবহারকারী — ধন্যবাদ!</string>
     <string name="upgrade_screen_owned_hero_iap_body">আপনার একবারের Pro ক্রয় প্রতিটি Pro বৈশিষ্ট্য চিরকালের জন্য আনলক করে।</string>
     <string name="upgrade_screen_owned_hero_sub_body">আপনার সাবস্ক্রিপশন প্রতিটি প্রো বৈশিষ্ট্য আনলক করে।</string>
     <string name="upgrade_screen_owned_sub_title">আপনার সাবস্ক্রিপশন</string>

--- a/app/src/gplay/res/values-bn-rBD/strings.xml
+++ b/app/src/gplay/res/values-bn-rBD/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">আপনার সাবস্ক্রিপশন</string>
     <string name="upgrade_screen_owned_sub_renewing_body">আপনার সাবস্ক্রিপশন সক্রিয় এবং স্বয়ংক্রিয়ভাবে পুনর্নবীকরণ হয়।</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">আপনার সাবস্ক্রিপশন মেয়াদ শেষ হওয়ার জন্য নির্ধারিত এবং পুনর্নবীকরণ হবে না। আপনি এটি শেষ না হওয়া পর্যন্ত প্রো রাখবেন।</string>
-    <string name="upgrade_screen_owned_both_warning">আপনি একবার প্রো আপগ্রেড মালিক এবং একটি সক্রিয় সাবস্ক্রিপশনও রয়েছে। আপনার উভয়ের প্রয়োজন নেই — আরও চার্জ এড়াতে গুগল প্লেতে সাবস্ক্রিপশন বাতিল করুন।</string>
     <string name="upgrade_screen_manage_subscription_action">সাবস্ক্রিপশন পরিচালনা করুন</string>
     <string name="upgrade_screen_owned_iap_title">আজীবন প্রো</string>
     <string name="upgrade_screen_owned_iap_body">আপনি একবার প্রো আপগ্রেড মালিক। কোন সাবস্ক্রিপশন নেই, কোন পুনর্নবীকরণ নেই।</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">একবার ক্রয়ে স্যুইচ করুন</string>
-    <string name="upgrade_screen_switch_purchase_note">আপনার সাবস্ক্রিপশন পুনর্নবীকরণ হবে না, তাই আপনি এখন স্থায়ী একবার প্রো ক্রয়ে যেতে পারেন।</string>
-    <string name="upgrade_screen_switch_locked_note">এককালীন ক্রয়ে সরানোর জন্য, প্রথমে Google Play-এ আপনার সাবস্ক্রিপশন বাতিল করুন। এই অফারটি আনলক হয় যখন এটি পুনর্নবীকরণ না করার জন্য সেট করা হয়।</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play শুধুমাত্র আপনি যে অ্যাকাউন্টে সাইন ইন করেছেন তা চেক করে। এককালীন ক্রয় আপনার সাবস্ক্রিপশন থেকে আলাদা।</string>
     <string name="upgrade_screen_sub_still_renewing_message">আপনার সাবস্ক্রিপশন এখনও সক্রিয় এবং পুনর্নবীকরণ হচ্ছে। প্রথমে Google Play-এ এটি বাতিল করুন।</string>
     <string name="upgrade_screen_sub_check_failed_message">Google Play-এর সাথে আপনার সাবস্ক্রিপশন যাচাই করা যায়নি। অনুগ্রহ করে আবার চেষ্টা করুন।</string>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">Les subscripcions es renoven automàticament. Podeu cancel·lar-les en qualsevol moment.</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Sou Pro, gràcies!</string>
     <string name="upgrade_screen_owned_hero_iap_body">La vostra compra única desbloqueja totes les funcions de Pro, per sempre.</string>
     <string name="upgrade_screen_owned_hero_sub_body">La vostra subscripció desbloqueja totes les funcions de Pro.</string>
     <string name="upgrade_screen_owned_sub_title">La vostra subscripció</string>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">La vostra subscripció</string>
     <string name="upgrade_screen_owned_sub_renewing_body">La vostra subscripció està activa i es renova automàticament.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">La vostra subscripció està configurada per caducar i no es renovarà. Mantindreu el Pro fins que finalitzi.</string>
-    <string name="upgrade_screen_owned_both_warning">Teniu l\'actualització única al Pro i també una subscripció activa. No necessites totes dues coses: cancel·leu la subscripció al Google Play per evitar càrrecs addicionals.</string>
     <string name="upgrade_screen_manage_subscription_action">Gestiona la subscripció</string>
     <string name="upgrade_screen_owned_iap_title">Pro de per vida</string>
     <string name="upgrade_screen_owned_iap_body">Teniu l\'actualització Pro única. Sense subscripcions, sense renovacions.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Canvieu a una compra única</string>
-    <string name="upgrade_screen_switch_purchase_note">La vostra subscripció no es renovarà, així que ara podeu canviar a la compra permanent única per al Pro.</string>
-    <string name="upgrade_screen_switch_locked_note">Per canviar a la compra única, primer cancel·leu la vostra subscripció al Google Play. Aquesta oferta es desbloqueja un cop està configurada per no renovar-se.</string>
     <string name="upgrade_screen_limitation_disclosure">El Google Play només comprova el compte en el qual esteu actualment connectats. La compra única és independent de la vostra subscripció.</string>
     <string name="upgrade_screen_sub_still_renewing_message">La vostra subscripció segueix activa i es renova. Cancel·leu-la primer al Google Play.</string>
     <string name="upgrade_screen_sub_check_failed_message">No s\'ha pogut verificar la vostra subscripció amb el Google Play. Torneu-ho a provar.</string>

--- a/app/src/gplay/res/values-cs/strings.xml
+++ b/app/src/gplay/res/values-cs/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">Předplatné se obnovuje automaticky. Můžete je kdykoliv zrušit.</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Jste Pro — děkujeme!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Váš jednorázový nákup Pro odemyká každou funkci Pro navždy.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Vaše předplatné odemyká každou funkci Pro.</string>
     <string name="upgrade_screen_owned_sub_title">Vaše předplatné</string>

--- a/app/src/gplay/res/values-cs/strings.xml
+++ b/app/src/gplay/res/values-cs/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">Vaše předplatné</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Vaše předplatné je aktivní a obnovuje se automaticky.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Vaše předplatné je nastaveno na vypršení a nebude se obnovovat. Budete mít Pro až do konce.</string>
-    <string name="upgrade_screen_owned_both_warning">Vlastníte jednorázový Pro upgrade a zároveň máte aktivní předplatné. Nepotřebujete obojí – zrušte předplatné v Google Play, abyste se vyhnuli dalším poplatkům.</string>
     <string name="upgrade_screen_manage_subscription_action">Spravovat předplatné</string>
     <string name="upgrade_screen_owned_iap_title">Celoživotní Pro</string>
     <string name="upgrade_screen_owned_iap_body">Vlastníte jednorázový Pro upgrade. Žádné předplatné, žádné obnovení.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Přejít na jednorázový nákup</string>
-    <string name="upgrade_screen_switch_purchase_note">Vaše předplatné se nebude obnovovat, takže se nyní můžete přesunout na trvalý jednorázový Pro nákup.</string>
-    <string name="upgrade_screen_switch_locked_note">Chcete-li se přesunout na jednorázový nákup, nejdříve zrušte své předplatné v Google Play. Tato nabídka se odemkne, jakmile bude nastaveno tak, aby se neobnovovalo.</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play kontroluje pouze účet, ke kterému jste právě přihlášeni. Jednorázový nákup je oddělený od vašeho předplatného.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Vaše předplatné je stále aktivní a obnovuje se. Nejdřív jej zrušte v Google Play.</string>
     <string name="upgrade_screen_sub_check_failed_message">Nelze ověřit vaše předplatné v Google Play. Zkuste to prosím znovu.</string>

--- a/app/src/gplay/res/values-da/strings.xml
+++ b/app/src/gplay/res/values-da/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">Abonnementer fornyes automatisk. Du kan annullere når som helst.</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Du er Pro – tak!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Dit engangs Pro-køb låser op for alle Pro-funktioner, for evigt.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Dit abonnement låser alle Pro-funktioner op.</string>
     <string name="upgrade_screen_owned_sub_title">Dit abonnement</string>

--- a/app/src/gplay/res/values-da/strings.xml
+++ b/app/src/gplay/res/values-da/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">Dit abonnement</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Dit abonnement er aktivt og fornyes automatisk.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Dit abonnement er indstillet til at udløbe og fornyes ikke. Du beholder Pro, indtil det slutter.</string>
-    <string name="upgrade_screen_owned_both_warning">Du ejer Pro-opgraderingen til engangsudgift og har også et aktivt abonnement. Du behøver ikke begge dele — annuller abonnementet i Google Play for at undgå yderligere gebyrer.</string>
     <string name="upgrade_screen_manage_subscription_action">Administrer abonnement</string>
     <string name="upgrade_screen_owned_iap_title">Livstids Pro</string>
     <string name="upgrade_screen_owned_iap_body">Du ejer Pro-opgraderingen til engangsudgift. Intet abonnement, ingen fornyelser.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Skift til engangsudgift</string>
-    <string name="upgrade_screen_switch_purchase_note">Dit abonnement fornyes ikke, så du kan skifte til det permanente engangs-Pro-køb nu.</string>
-    <string name="upgrade_screen_switch_locked_note">Hvis du vil skifte til engangsbetalingen, skal du først annullere dit abonnement i Google Play. Dette tilbud bliver tilgængeligt, når det er indstillet til ikke at forny.</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play kontrollerer kun den konto, du er logget ind på. Engangsbetalingen er adskilt fra dit abonnement.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Dit abonnement er stadig aktivt og fornyes. Annuller det først i Google Play.</string>
     <string name="upgrade_screen_sub_check_failed_message">Kunne ikke bekræfte dit abonnement med Google Play. Prøv igen.</string>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">Dein Abonnement</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Dein Abonnement ist aktiv und wird automatisch verlängert.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Dein Abonnement läuft aus und wird nicht verlängert. Du behältst Pro bis zum Ende.</string>
-    <string name="upgrade_screen_owned_both_warning">Du besitzt das einmalige Pro-Upgrade und hast auch ein aktives Abonnement. Du brauchst nicht beides – kündige das Abonnement in Google Play, um weitere Gebühren zu vermeiden.</string>
     <string name="upgrade_screen_manage_subscription_action">Abo verwalten</string>
     <string name="upgrade_screen_owned_iap_title">Pro für immer</string>
     <string name="upgrade_screen_owned_iap_body">Du besitzt das einmalige Pro-Upgrade. Kein Abonnement, keine Verlängerungen.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Zum einmaligen Kauf wechseln</string>
-    <string name="upgrade_screen_switch_purchase_note">Dein Abonnement wird nicht verlängert, daher kannst du jetzt zum permanenten einmaligen Pro-Kauf wechseln.</string>
-    <string name="upgrade_screen_switch_locked_note">Um zum einmaligen Kauf zu wechseln, kündige zunächst dein Abonnement in Google Play. Dieses Angebot wird freigegeben, sobald es nicht mehr verlängert wird.</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play überprüft nur das Konto, mit dem du gerade angemeldet bist. Der Einmalkauf ist unabhängig von deinem Abonnement.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Dein Abonnement ist noch aktiv und wird erneuert. Kündige es zuerst in Google Play.</string>
     <string name="upgrade_screen_sub_check_failed_message">Dein Abonnement konnte nicht bei Google Play überprüft werden. Bitte versuche es noch einmal.</string>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">Abonnements verlängern sich automatisch. Du kannst jederzeit kündigen.</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Du hast Pro – vielen Dank!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Dein einmaliger Pro-Kauf entsperrt alle Pro-Funktionen für immer.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Dein Abonnement entsperrt alle Pro-Funktionen.</string>
     <string name="upgrade_screen_owned_sub_title">Dein Abonnement</string>

--- a/app/src/gplay/res/values-el/strings.xml
+++ b/app/src/gplay/res/values-el/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">Η συνδρομή σας</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Η συνδρομή σας είναι ενεργή και ανανεώνεται αυτόματα.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Η συνδρομή σας έχει οριστεί να λήξει και δεν θα ανανεωθεί. Θα διατηρήσετε το Pro μέχρι να τελειώσει.</string>
-    <string name="upgrade_screen_owned_both_warning">Διαθέτετε την εφάπαξ αναβάθμιση Pro και έχετε επίσης ενεργή συνδρομή. Δεν χρειάζεστε και τα δύο — ακυρώστε τη συνδρομή στο Google Play για να αποφύγετε περαιτέρω χρεώσεις.</string>
     <string name="upgrade_screen_manage_subscription_action">Διαχείριση συνδρομής</string>
     <string name="upgrade_screen_owned_iap_title">Ισόβιο Pro</string>
     <string name="upgrade_screen_owned_iap_body">Διαθέτετε την εφάπαξ αναβάθμιση Pro. Χωρίς συνδρομή, χωρίς ανανεώσεις.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Μετάβαση σε μια εφάπαξ αγορά</string>
-    <string name="upgrade_screen_switch_purchase_note">Η συνδρομή σας δεν θα ανανεωθεί, έτσι μπορείτε να μεταβείτε στη μόνιμη εφάπαξ αγορά Pro τώρα.</string>
-    <string name="upgrade_screen_switch_locked_note">Για να μεταβείτε στην εφάπαξ αγορά, ακυρώστε πρώτα τη συνδρομή σας στο Google Play. Αυτή η προσφορά ξεκλειδώνεται όταν οριστεί να μην ανανεωθεί.</string>
     <string name="upgrade_screen_limitation_disclosure">Το Google Play ελέγχει μόνο το λογαριασμό στον οποίο είστε συνδεδεμένοι. Η εφάπαξ αγορά είναι ξεχωριστή από τη συνδρομή σας.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Η συνδρομή σας είναι ακόμα ενεργή και ανανεώνεται. Ακυρώστε την πρώτα στο Google Play.</string>
     <string name="upgrade_screen_sub_check_failed_message">Δεν ήταν δυνατή η επαλήθευση της συνδρομής σας με το Google Play. Δοκιμάστε ξανά.</string>

--- a/app/src/gplay/res/values-el/strings.xml
+++ b/app/src/gplay/res/values-el/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">Οι συνδρομές ανανεώνονται αυτόματα. Μπορείτε να ακυρώσετε ανά πάσα στιγμή.</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Είστε Pro — ευχαριστούμε!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Η ενιαία αγορά Pro ξεκλειδώνει κάθε λειτουργία Pro, για πάντα.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Η συνδρομή σας ξεκλειδώνει κάθε λειτουργία Pro.</string>
     <string name="upgrade_screen_owned_sub_title">Η συνδρομή σας</string>

--- a/app/src/gplay/res/values-es/strings.xml
+++ b/app/src/gplay/res/values-es/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">Tu suscripción</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Tu suscripción está activa y se renueva automáticamente.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Tu suscripción está configurada para expirar y no se renovará. Mantendrás Pro hasta que finalice.</string>
-    <string name="upgrade_screen_owned_both_warning">Posees la actualización única de Pro y también tienes una suscripción activa. No necesitas ambas: cancela la suscripción en Google Play para evitar cargos adicionales.</string>
     <string name="upgrade_screen_manage_subscription_action">Gestionar suscripción</string>
     <string name="upgrade_screen_owned_iap_title">Pro de por vida</string>
     <string name="upgrade_screen_owned_iap_body">Posees la actualización única de Pro. Sin suscripción, sin renovaciones.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Cambiar a una compra única</string>
-    <string name="upgrade_screen_switch_purchase_note">Tu suscripción no se renovará, por lo que ahora puedes cambiar a la compra Pro única y permanente.</string>
-    <string name="upgrade_screen_switch_locked_note">Para cambiar a la compra única, primero cancela tu suscripción en Google Play. Esta oferta se desbloquea una vez que esté configurada para no renovarse.</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play solo verifica la cuenta en la que actualmente has iniciado sesión. La compra única es independiente de tu suscripción.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Tu suscripción sigue activa y se está renovando. Cancélala en Google Play primero.</string>
     <string name="upgrade_screen_sub_check_failed_message">No se pudo verificar tu suscripción con Google Play. Por favor, intenta de nuevo.</string>

--- a/app/src/gplay/res/values-es/strings.xml
+++ b/app/src/gplay/res/values-es/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">Las suscripciones se renuevan automáticamente. Puedes cancelar en cualquier momento.</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">¡Eres Pro — gracias!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Tu compra única de Pro desbloquea todas las funciones Pro, para siempre.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Tu suscripción desbloquea todas las funciones Pro.</string>
     <string name="upgrade_screen_owned_sub_title">Tu suscripción</string>

--- a/app/src/gplay/res/values-fi/strings.xml
+++ b/app/src/gplay/res/values-fi/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">Tilauksesi</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Tilauksesi on aktiivinen ja uusiutuu automaattisesti.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Tilauksesi on asetettu vanhentumaan eikä se uusiudu. Säilytät Pro-ominaisuudet sen loppuun asti.</string>
-    <string name="upgrade_screen_owned_both_warning">Omistat kertamaksullisen Pro-päivityksen ja sinulla on myös aktiivinen tilaus. Et tarvitse molempia – peruuta tilaus Google Playssa, jotta vältyt lisäkustannuksilta.</string>
     <string name="upgrade_screen_manage_subscription_action">Hallitse tilausta</string>
     <string name="upgrade_screen_owned_iap_title">Elinikäinen Pro</string>
     <string name="upgrade_screen_owned_iap_body">Omistat kertamaksullisen Pro-päivityksen. Ei tilausta, ei uusintoja.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Siirry kertamaksuun</string>
-    <string name="upgrade_screen_switch_purchase_note">Tilauksesi ei uusiudu, joten voit siirtyä pysyvään kertamaksulliseen Pro-ostoon nyt.</string>
-    <string name="upgrade_screen_switch_locked_note">Vaihda kertamaksun ostoon peruuttamalla ensin tilauspalvelusi Google Playsta. Tämä tarjous vapautuu, kun se on asetettu pois uusiutumasta.</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play tarkistaa vain tilin, johon olet tällä hetkellä kirjautunut. Kertaosto on erillinen tilauspalvelustasi.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Tilauspalvelusi on vielä aktiivinen ja uusiutuu. Peruuta se ensin Google Playsta.</string>
     <string name="upgrade_screen_sub_check_failed_message">Tilauspalvelusi tarkistaminen Google Playsta epäonnistui. Yritä uudelleen.</string>

--- a/app/src/gplay/res/values-fi/strings.xml
+++ b/app/src/gplay/res/values-fi/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">Tilaukset uusiutuvat automaattisesti. Voit peruuttaa milloin tahansa.</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Olet Pro – kiitos!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Kertaluonteinen Pro-ostos avaa kaikki Pro-ominaisuudet ikuisesti.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Tilauksesi avaa kaikki Pro-ominaisuudet.</string>
     <string name="upgrade_screen_owned_sub_title">Tilauksesi</string>

--- a/app/src/gplay/res/values-fr/strings.xml
+++ b/app/src/gplay/res/values-fr/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">Les abonnements se renouvellent automatiquement. Vous pouvez annuler à tout moment.</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Vous êtes Pro — merci !</string>
     <string name="upgrade_screen_owned_hero_iap_body">Votre achat Pro unique déverrouille toutes les fonctionnalités Pro, pour toujours.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Votre abonnement déverrouille toutes les fonctionnalités Pro.</string>
     <string name="upgrade_screen_owned_sub_title">Votre abonnement</string>

--- a/app/src/gplay/res/values-fr/strings.xml
+++ b/app/src/gplay/res/values-fr/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">Votre abonnement</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Votre abonnement est actif et se renouvelle automatiquement.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Votre abonnement est configuré pour expirer et ne se renouvellera pas. Vous conserverez Pro jusqu’à sa fin.</string>
-    <string name="upgrade_screen_owned_both_warning">Vous possédez l’achat unique Pro et vous avez également un abonnement actif. Vous n’avez pas besoin des deux — annulez l’abonnement dans Google Play pour éviter des frais supplémentaires.</string>
     <string name="upgrade_screen_manage_subscription_action">Gérer l’abonnement</string>
     <string name="upgrade_screen_owned_iap_title">Pro à vie</string>
     <string name="upgrade_screen_owned_iap_body">Vous possédez l’achat unique Pro. Pas d’abonnement, pas de renouvellements.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Passer à un achat unique</string>
-    <string name="upgrade_screen_switch_purchase_note">Votre abonnement ne se renouvellera pas, vous pouvez donc passer à l’achat Pro permanent et unique dès maintenant.</string>
-    <string name="upgrade_screen_switch_locked_note">Pour passer à l’achat unique, annulez d’abord votre abonnement dans Google Play. Cette offre se déverrouille une fois l’abonnement défini pour ne pas se renouveler.</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play vérifie uniquement le compte auquel vous êtes actuellement connecté. L’achat unique est distinct de votre abonnement.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Votre abonnement est toujours actif et se renouvelle. Annulez-le d’abord dans Google Play.</string>
     <string name="upgrade_screen_sub_check_failed_message">Impossible de vérifier votre abonnement auprès de Google Play. Veuillez réessayer.</string>

--- a/app/src/gplay/res/values-hi-rIN/strings.xml
+++ b/app/src/gplay/res/values-hi-rIN/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">सदस्यता स्वचालित रूप से नवीनीकृत होती है। आप कभी भी रद्द कर सकते हैं।</string>
     <string name="upgrade_title_suffix">प्रो</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">आप Pro हैं — धन्यवाद!</string>
     <string name="upgrade_screen_owned_hero_iap_body">आपकी एक बार की Pro खरीद हमेशा के लिए हर Pro सुविधा को अनलॉक करती है।</string>
     <string name="upgrade_screen_owned_hero_sub_body">आपकी सदस्यता हर Pro सुविधा को अनलॉक करती है।</string>
     <string name="upgrade_screen_owned_sub_title">आपकी सदस्यता</string>

--- a/app/src/gplay/res/values-hi-rIN/strings.xml
+++ b/app/src/gplay/res/values-hi-rIN/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">आपकी सदस्यता</string>
     <string name="upgrade_screen_owned_sub_renewing_body">आपकी सदस्यता सक्रिय है और स्वचालित रूप से नवीनीकृत होती है।</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">आपकी सदस्यता समाप्त होने के लिए सेट है और नवीनीकृत नहीं होगी। आप इसके समाप्त होने तक Pro को रखेंगे।</string>
-    <string name="upgrade_screen_owned_both_warning">आप एक बार की Pro अपग्रेड के मालिक हैं और एक सक्रिय सदस्यता भी रखते हैं। आपको दोनों की आवश्यकता नहीं है — आगे के शुल्क से बचने के लिए Google Play में सदस्यता को रद्द करें।</string>
     <string name="upgrade_screen_manage_subscription_action">सदस्यता प्रबंधित करें</string>
     <string name="upgrade_screen_owned_iap_title">आजीवन Pro</string>
     <string name="upgrade_screen_owned_iap_body">आप एक बार की Pro अपग्रेड के मालिक हैं। कोई सदस्यता नहीं, कोई नवीनीकरण नहीं।</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">एक बार की खरीदारी पर स्विच करें</string>
-    <string name="upgrade_screen_switch_purchase_note">आपकी सदस्यता नवीनीकृत नहीं होगी, इसलिए आप अब स्थायी एक बार की Pro खरीदारी पर जा सकते हैं।</string>
-    <string name="upgrade_screen_switch_locked_note">एक बार की खरीदारी पर स्विच करने के लिए, पहले Google Play में अपनी सदस्यता को रद्द करें। यह ऑफर तब अनलॉक हो जाता है जब इसे नवीनीकृत न करने के लिए सेट किया जाता है।</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play केवल उस खाते की जांच करता है जिसमें आप वर्तमान में साइन इन हैं। एक बार की खरीदारी आपकी सदस्यता से अलग है।</string>
     <string name="upgrade_screen_sub_still_renewing_message">आपकी सदस्यता अभी भी सक्रिय है और नवीनीकृत हो रही है। पहले इसे Google Play में रद्द करें।</string>
     <string name="upgrade_screen_sub_check_failed_message">Google Play के साथ आपकी सदस्यता को सत्यापित नहीं किया जा सका। कृपया पुनः प्रयास करें।</string>

--- a/app/src/gplay/res/values-hr/strings.xml
+++ b/app/src/gplay/res/values-hr/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">Vaša pretplata</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Vaša pretplata je aktivna i obnavlja se automatski.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Vaša pretplata je postavljena da ističe i neće se obnoviti. Zadržat ćete Pro dok ne istekne.</string>
-    <string name="upgrade_screen_owned_both_warning">Posjedujete jednokratnu Pro nadogradnju i također imate aktivnu pretplatu. Ne trebate oboje — otkažite pretplatu u Google Playu kako biste izbjegli daljnje naknade.</string>
     <string name="upgrade_screen_manage_subscription_action">Upravljajte pretplatom</string>
     <string name="upgrade_screen_owned_iap_title">Doživotni Pro</string>
     <string name="upgrade_screen_owned_iap_body">Posjedujete jednokratnu Pro nadogradnju. Bez pretplate, bez obnove.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Prebacite se na jednokratnu kupnju</string>
-    <string name="upgrade_screen_switch_purchase_note">Vaša pretplata se neće obnoviti, pa sada možete prijeći na trajnu jednokratnu Pro kupnju.</string>
-    <string name="upgrade_screen_switch_locked_note">Za prebacivanje na jednokratnu kupnju, prvo trebate otkazati pretplatu na Google Playu. Ova ponuda se otključava nakon što je postavljena da se ne obnovi.</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play provjerava samo račun na koji ste trenutno prijavljeni. Jednokratna kupnja je odvojena od vaše pretplate.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Vaša pretplata je i dalje aktivna i obnavlja se. Trebate je prvo otkazati na Google Playu.</string>
     <string name="upgrade_screen_sub_check_failed_message">Nije moguće provjeriti vašu pretplatu s Google Playom. Pokušajte ponovno.</string>

--- a/app/src/gplay/res/values-hr/strings.xml
+++ b/app/src/gplay/res/values-hr/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">Pretplate se automatski obnavljaju. Možete otkazati u bilo koje vrijeme.</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Sada ste Pro — hvala!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Vaša jednokratna Pro kupnja otključava sve Pro značajke zauvijek.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Vaša pretplata otključava sve Pro značajke.</string>
     <string name="upgrade_screen_owned_sub_title">Vaša pretplata</string>

--- a/app/src/gplay/res/values-hu/strings.xml
+++ b/app/src/gplay/res/values-hu/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">Az előfizetések automatikusan megújulnak. Bármikor lemondhatod.</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Pro vagy – köszönjük!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Az egyszeri Pro vásárlásod minden Pro funkciót feloldja, örökre.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Az előfizetésed minden Pro funkciót feloldja.</string>
     <string name="upgrade_screen_owned_sub_title">Az előfizetésed</string>

--- a/app/src/gplay/res/values-hu/strings.xml
+++ b/app/src/gplay/res/values-hu/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">Az előfizetésed</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Az előfizetésed aktív és automatikusan megújul.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Az előfizetésed nem fog megújulni. Pro marad, amíg le nem jár.</string>
-    <string name="upgrade_screen_owned_both_warning">Megvásároltad az egyszeri Pro verzióját, és van egy aktív előfizetésed is. Nincs szükséged mindkettőre — szüntesd meg az előfizetésed a Google Play-ben a további díjak elkerüléséhez.</string>
     <string name="upgrade_screen_manage_subscription_action">Előfizetés kezelése</string>
     <string name="upgrade_screen_owned_iap_title">Élettartam Pro</string>
     <string name="upgrade_screen_owned_iap_body">Megvásároltad az egyszeri Pro verzióját. Nincs előfizetés, nincs megújítás.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Váltás egyszeri vásárlásra</string>
-    <string name="upgrade_screen_switch_purchase_note">Az előfizetésed nem újul meg, így most már áttérhetsz az egyszeri Pro vásárlásra.</string>
-    <string name="upgrade_screen_switch_locked_note">Az egyszeri vásárlásra való váltáshoz először szüntesd meg az előfizetésed a Google Play-ben. Ez az ajánlat akkor lesz elérhető, ha beállítod, hogy ne újuljon meg.</string>
     <string name="upgrade_screen_limitation_disclosure">A Google Play csak az aktuálisan bejelentkeztetett fiókot ellenőrzi. Az egyszeri vásárlás és az előfizetésed egymástól függetlenek.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Az előfizetésed továbbra is aktív és megújul. Előbb szüntesd meg azt a Google Play-ben.</string>
     <string name="upgrade_screen_sub_check_failed_message">Nem sikerült ellenőrizni az előfizetésed a Google Play-ben. Kérjük, próbáld újra.</string>

--- a/app/src/gplay/res/values-it/strings.xml
+++ b/app/src/gplay/res/values-it/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">Gli abbonamenti si rinnovano automaticamente. Puoi annullare in qualsiasi momento.</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Sei Pro — grazie!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Il tuo acquisto unico di Pro sblocca ogni funzione Pro, per sempre.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Il tuo abbonamento sblocca ogni funzione Pro.</string>
     <string name="upgrade_screen_owned_sub_title">Il tuo abbonamento</string>

--- a/app/src/gplay/res/values-it/strings.xml
+++ b/app/src/gplay/res/values-it/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">Il tuo abbonamento</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Il tuo abbonamento è attivo e si rinnova automaticamente.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Il tuo abbonamento è impostato per scadere e non si rinnoverà. Manterrai Pro fino al termine.</string>
-    <string name="upgrade_screen_owned_both_warning">Possiedi l’acquisto unico di Pro e hai anche un abbonamento attivo. Non hai bisogno di entrambi — annulla l’abbonamento in Google Play per evitare ulteriori addebiti.</string>
     <string name="upgrade_screen_manage_subscription_action">Gestisci abbonamento</string>
     <string name="upgrade_screen_owned_iap_title">Pro a vita</string>
     <string name="upgrade_screen_owned_iap_body">Possiedi l’acquisto unico di Pro. Nessun abbonamento, nessun rinnovo.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Passa a un acquisto unico</string>
-    <string name="upgrade_screen_switch_purchase_note">Il tuo abbonamento non si rinnoverà, quindi ora puoi passare all’acquisto unico permanente di Pro.</string>
-    <string name="upgrade_screen_switch_locked_note">Per passare all’acquisto unico, annulla prima il tuo abbonamento in Google Play. Questa offerta si sblocca una volta impostato per non rinnovarsi.</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play controlla solo l’account con cui sei attualmente connesso. L’acquisto unico è separato dal tuo abbonamento.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Il tuo abbonamento è ancora attivo e si sta rinnovando. Annullalo prima in Google Play.</string>
     <string name="upgrade_screen_sub_check_failed_message">Impossibile verificare il tuo abbonamento con Google Play. Riprova.</string>

--- a/app/src/gplay/res/values-iw/strings.xml
+++ b/app/src/gplay/res/values-iw/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">מנויים מתחדשים אוטומטית. ניתן לבטל בכל עת.</string>
     <string name="upgrade_title_suffix">פרו</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">אתה Pro — תודה!</string>
     <string name="upgrade_screen_owned_hero_iap_body">הרכישה החד-פעמית של Pro שלך פותחת את כל תכונות Pro, לנצח.</string>
     <string name="upgrade_screen_owned_hero_sub_body">המנוי שלך פותח את כל תכונות Pro.</string>
     <string name="upgrade_screen_owned_sub_title">המנוי שלך</string>

--- a/app/src/gplay/res/values-iw/strings.xml
+++ b/app/src/gplay/res/values-iw/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">המנוי שלך</string>
     <string name="upgrade_screen_owned_sub_renewing_body">המנוי שלך פעיל ומתחדש באופן אוטומטי.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">המנוי שלך מוגדר לפוג ולא יתחדש. תוכל להשתמש ב-Pro עד שיסתיים.</string>
-    <string name="upgrade_screen_owned_both_warning">יש לך שדרוג Pro חד-פעמי ויש לך גם מנוי פעיל. אתה לא צריך את שניהם — בטל את המנוי בגוגל פליי כדי להימנע מחיובים נוספים.</string>
     <string name="upgrade_screen_manage_subscription_action">ניהול המנוי</string>
     <string name="upgrade_screen_owned_iap_title">Pro לכל החיים</string>
     <string name="upgrade_screen_owned_iap_body">יש לך שדרוג Pro חד-פעמי. אין מנוי, אין התחדשויות.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">עבור לרכישה חד-פעמית</string>
-    <string name="upgrade_screen_switch_purchase_note">המנוי שלך לא יתחדש, כך שתוכל לעבור לרכישה קבועה של Pro עכשיו.</string>
-    <string name="upgrade_screen_switch_locked_note">כדי לעבור לרכישה חד-פעמית, ראשית בטל את המנוי שלך בגוגל פליי. ההצעה הזו נפתחת ברגע שהוגדרה לא להתחדש.</string>
     <string name="upgrade_screen_limitation_disclosure">גוגל פליי בודקת רק את החשבון שאתה כרגע מחובר אליו. הרכישה החד-פעמית נפרדת מהמנוי שלך.</string>
     <string name="upgrade_screen_sub_still_renewing_message">המנוי שלך עדיין פעיל ומתחדש. בטל אותו בגוגל פליי קודם.</string>
     <string name="upgrade_screen_sub_check_failed_message">לא הצלחנו לאמת את המנוי שלך עם גוגל פליי. אנא נסה שוב.</string>

--- a/app/src/gplay/res/values-ja/strings.xml
+++ b/app/src/gplay/res/values-ja/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">サブスクリプションは自動更新されます。いつでもキャンセルできます。</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Pro のご利用ありがとうございます！</string>
     <string name="upgrade_screen_owned_hero_iap_body">Pro のワンタイム購入により、すべての Pro 機能が永久にロック解除されます。</string>
     <string name="upgrade_screen_owned_hero_sub_body">ご契約により、すべての Pro 機能がロック解除されます。</string>
     <string name="upgrade_screen_owned_sub_title">ご契約</string>

--- a/app/src/gplay/res/values-ja/strings.xml
+++ b/app/src/gplay/res/values-ja/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">ご契約</string>
     <string name="upgrade_screen_owned_sub_renewing_body">ご契約は有効で、自動更新されます。</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">ご契約は更新しないように設定されており、終了予定です。Pro は終了までご利用いただけます。</string>
-    <string name="upgrade_screen_owned_both_warning">一度限りの Pro アップグレードとアクティブなサブスクリプションの両方をお持ちです。両方は必要ありません。さらなる料金を避けるため、Google Play でご契約をキャンセルしてください。</string>
     <string name="upgrade_screen_manage_subscription_action">ご契約を管理</string>
     <string name="upgrade_screen_owned_iap_title">生涯 Pro</string>
     <string name="upgrade_screen_owned_iap_body">一度限りの Pro アップグレードをお持ちです。サブスクリプションはなく、更新もありません。</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">ワンタイム購入に切り替える</string>
-    <string name="upgrade_screen_switch_purchase_note">ご契約は更新されないため、今すぐ永続的なワンタイム Pro 購入に切り替えることができます。</string>
-    <string name="upgrade_screen_switch_locked_note">ワンタイム購入に切り替えるには、まず Google Play でご契約をキャンセルしてください。このオファーは、更新しないように設定されるとロック解除されます。</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play は、現在サインインしているアカウントのみをチェックします。一度限りの購入はサブスクリプションとは別です。</string>
     <string name="upgrade_screen_sub_still_renewing_message">ご契約はまだ有効で更新されています。まず Google Play でキャンセルしてください。</string>
     <string name="upgrade_screen_sub_check_failed_message">Google Play でご契約を確認できませんでした。もう一度お試しください。</string>

--- a/app/src/gplay/res/values-ko/strings.xml
+++ b/app/src/gplay/res/values-ko/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">구독</string>
     <string name="upgrade_screen_owned_sub_renewing_body">구독이 활성화되어 있으며 자동으로 갱신됩니다.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">구독이 만료되도록 설정되어 있으며 갱신되지 않습니다. 만료될 때까지 Pro를 계속 사용할 수 있습니다.</string>
-    <string name="upgrade_screen_owned_both_warning">일회성 Pro 업그레이드를 소유했으면서 동시에 활성 구독도 있습니다. 둘 다 필요하지 않습니다 — 추가 요금을 피하려면 Google Play에서 구독을 취소하세요.</string>
     <string name="upgrade_screen_manage_subscription_action">구독 관리</string>
     <string name="upgrade_screen_owned_iap_title">평생 Pro</string>
     <string name="upgrade_screen_owned_iap_body">일회성 Pro 업그레이드를 소유했습니다. 구독 없음, 갱신 없음.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">일회성 구매로 전환</string>
-    <string name="upgrade_screen_switch_purchase_note">구독이 갱신되지 않으므로 이제 영구적인 일회성 Pro 구매로 이동할 수 있습니다.</string>
-    <string name="upgrade_screen_switch_locked_note">일회 구매로 전환하려면 먼저 Google Play에서 구독을 취소하세요. 자동 갱신하지 않도록 설정하면 이 오퍼가 활성화됩니다.</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play는 현재 로그인한 계정만 확인합니다. 일회 구매는 구독과 별개입니다.</string>
     <string name="upgrade_screen_sub_still_renewing_message">구독이 아직 활성 상태이며 갱신 중입니다. 먼저 Google Play에서 취소하세요.</string>
     <string name="upgrade_screen_sub_check_failed_message">Google Play에서 구독을 확인할 수 없습니다. 다시 시도하세요.</string>

--- a/app/src/gplay/res/values-ko/strings.xml
+++ b/app/src/gplay/res/values-ko/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">구독은 자동으로 갱신됩니다. 언제든지 취소할 수 있습니다.</string>
     <string name="upgrade_title_suffix">프로</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Pro 이용 중이시네요 — 감사합니다!</string>
     <string name="upgrade_screen_owned_hero_iap_body">일회성 Pro 구매로 모든 Pro 기능을 영원히 사용할 수 있습니다.</string>
     <string name="upgrade_screen_owned_hero_sub_body">구독하면 모든 Pro 기능을 사용할 수 있습니다.</string>
     <string name="upgrade_screen_owned_sub_title">구독</string>

--- a/app/src/gplay/res/values-ku-rTR/strings.xml
+++ b/app/src/gplay/res/values-ku-rTR/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">Aboneya te</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Aboneya te çalak e û bi otomatîk nû dibe.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Aboneya te sazkirî ye da ku qede bibe û nû nabibe. Tu Pro-yî heta qedandîna wê bihûnîne.</string>
-    <string name="upgrade_screen_owned_both_warning">Tu pêbazirandina Pro-ya yek-car heye û tu jî aboneyeke çalak heye. Tu hewce nikare her du — aboneya di Google Play de betal bike da ku xercên zêde nabe.</string>
     <string name="upgrade_screen_manage_subscription_action">Aboneya birêve bike</string>
     <string name="upgrade_screen_owned_iap_title">Pro-ya sedemzî</string>
     <string name="upgrade_screen_owned_iap_body">Tu pêbazirandina Pro-ya yek-car heye. Aboneya tune, nû kirin tune.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Veguherîn bo kirîna yek-car</string>
-    <string name="upgrade_screen_switch_purchase_note">Peymanê we nabe nûkirî, lewra we niha dikarin biçin beşdareya Pro ya demdemî ya yekcarî.</string>
-    <string name="upgrade_screen_switch_locked_note">Ji bo ku biçin beşdareya yekcarî, pêşî peymanê we di Google Play da betal bikin. Ev pêşkêş açilî dibe dema peymanê we nabe nûkirî.</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play tenê hesaba we ya niha kontrol dike. Beşdareya yekcarî ji peymanê we cuda ye.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Peymanê we hîn jî çalak e û nabe nûkirî. Pêşî ew di Google Play da betal bikin.</string>
     <string name="upgrade_screen_sub_check_failed_message">Peymanê we bi Google Play piştrast nekirî. Ji kerema xwe dîsa hewl bide.</string>

--- a/app/src/gplay/res/values-ku-rTR/strings.xml
+++ b/app/src/gplay/res/values-ku-rTR/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">بوونهەڵبەستەکان بە خۆدیکەوە نوێكردرەوەن. دەتوانیت ھەر کاتیک لاببکەیت.</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Tu Pro yî — spas!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Kirîna Pro-ya yek-car hemû taybetmendiyên Pro derxîne, sedemzî.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Aboneya te hemû taybetmendiyên Pro derxîne.</string>
     <string name="upgrade_screen_owned_sub_title">Aboneya te</string>

--- a/app/src/gplay/res/values-nb/strings.xml
+++ b/app/src/gplay/res/values-nb/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">Abonnementer fornyes automatisk. Du kan avbryte når som helst.</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Du er Pro – takk!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Ditt engangs Pro-kjøp låser opp hver Pro-funksjon, for alltid.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Abonnementet ditt låser opp alle Pro-funksjoner.</string>
     <string name="upgrade_screen_owned_sub_title">Abonnementet ditt</string>

--- a/app/src/gplay/res/values-nb/strings.xml
+++ b/app/src/gplay/res/values-nb/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">Abonnementet ditt</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Abonnementet ditt er aktivt og fornyes automatisk.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Abonnementet ditt er satt til å utløpe og vil ikke fornyes. Du beholder Pro til det utløper.</string>
-    <string name="upgrade_screen_owned_both_warning">Du eier engangs Pro-oppgraderingen og har også et aktivt abonnement. Du trenger ikke begge deler – avbryt abonnementet i Google Play for å unngå ytterligere kostnader.</string>
     <string name="upgrade_screen_manage_subscription_action">Administrer abonnement</string>
     <string name="upgrade_screen_owned_iap_title">Livstids Pro</string>
     <string name="upgrade_screen_owned_iap_body">Du eier engangs Pro-oppgraderingen. Ingen abonnement, ingen fornyelser.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Bytt til engangskjøp</string>
-    <string name="upgrade_screen_switch_purchase_note">Abonnementet ditt vil ikke fornyes, så du kan gå over til det permanente engangs Pro-kjøpet nå.</string>
-    <string name="upgrade_screen_switch_locked_note">For å bytte til engangskjøp, må du først avbryte abonnementet ditt i Google Play. Dette tilbudet låses opp når det er satt til ikke å fornyes.</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play sjekker bare kontoen du er logget inn på. Engangskjøpet er atskilt fra abonnementet ditt.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Abonnementet ditt er fortsatt aktivt og fornyes. Avbryt det i Google Play først.</string>
     <string name="upgrade_screen_sub_check_failed_message">Kunne ikke bekrefte abonnementet ditt med Google Play. Vennligst prøv igjen.</string>

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">Je abonnement</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Je abonnement is actief en vernieuwt zich automatisch.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Je abonnement verloopt binnenkort en wordt niet vernieuwd. Je behoudt Pro totdat het afloopt.</string>
-    <string name="upgrade_screen_owned_both_warning">Je bezit de eenmalige Pro-upgrade en hebt ook een actief abonnement. Je hebt niet beide nodig — annuleer het abonnement in Google Play om verdere kosten te voorkomen.</string>
     <string name="upgrade_screen_manage_subscription_action">Abonnement beheren</string>
     <string name="upgrade_screen_owned_iap_title">Pro voor altijd</string>
     <string name="upgrade_screen_owned_iap_body">Je bezit de eenmalige Pro-upgrade. Geen abonnement, geen verlengingen.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Schakel over naar eenmalige aankoop</string>
-    <string name="upgrade_screen_switch_purchase_note">Je abonnement wordt niet vernieuwd, dus je kunt nu overstappen naar de permanente eenmalige Pro-aankoop.</string>
-    <string name="upgrade_screen_switch_locked_note">Om over te schakelen naar de eenmalige aankoop, annuleer je abonnement eerst in Google Play. Deze aanbieding wordt beschikbaar zodra het is ingesteld om niet te verlengen.</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play controleert alleen het account waarbij je momenteel bent aangemeld. De eenmalige aankoop is gescheiden van je abonnement.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Je abonnement is nog steeds actief en vernieuwt. Annuleer het eerst in Google Play.</string>
     <string name="upgrade_screen_sub_check_failed_message">Je abonnement kon niet met Google Play worden geverifieerd. Probeer het opnieuw.</string>

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">Abonnementen verlengen automatisch. Je kunt op elk moment opzeggen.</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Je bent Pro — dank je wel!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Je eenmalige Pro-aankoop ontgrendelt elk Pro-onderdeel voor altijd.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Je abonnement ontgrendelt elk Pro-onderdeel.</string>
     <string name="upgrade_screen_owned_sub_title">Je abonnement</string>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">Subskrypcje odnawiają się automatycznie. Możesz anulować w dowolnym momencie.</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Jesteś Pro - dziękuję!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Twój jednorazowy zakup Pro odblokowuje każdą funkcję Pro na zawsze.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Twoja subskrypcja odblokowuje każdą funkcję Pro.</string>
     <string name="upgrade_screen_owned_sub_title">Twoja subskrypcja</string>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">Twoja subskrypcja</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Twoja subskrypcja jest aktywna i odnawia się automatycznie.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Twoja subskrypcja wygasa i nie będzie odnawiana. Pro będzie przechowywany do czasu jej zakończenia.</string>
-    <string name="upgrade_screen_owned_both_warning">Posiadasz jednorazową aktualizację Pro, a także aktywną subskrypcję. Nie potrzebujesz obu opcji — anuluj subskrypcję w Sklepie Google Play, aby uniknąć dodatkowych opłat.</string>
     <string name="upgrade_screen_manage_subscription_action">Zarządzaj subskrypcją</string>
     <string name="upgrade_screen_owned_iap_title">Dożywotni Pro</string>
     <string name="upgrade_screen_owned_iap_body">Jesteś właścicielem jednorazowej aktualizacji do wersji Pro. Bez subskrypcji i odnawiania.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Przełącz na jednorazowy zakup</string>
-    <string name="upgrade_screen_switch_purchase_note">Twoja subskrypcja nie zostanie odnowiona, więc możesz już teraz dokonać jednorazowego zakupu wersji Pro.</string>
-    <string name="upgrade_screen_switch_locked_note">Aby przejść na zakup jednorazowy, najpierw anuluj subskrypcję w Sklepie Google Play. Oferta zostanie odblokowana po ustawieniu opcji nie odnawiaj.</string>
     <string name="upgrade_screen_limitation_disclosure">Sklep Google Play sprawdza tylko konto, na którym jesteś aktualnie zalogowany. Jednorazowy zakup jest niezależny od subskrypcji.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Twoja subskrypcja jest nadal aktywna i odnawia się. Anuluj ją najpierw w Sklepie Google Play.</string>
     <string name="upgrade_screen_sub_check_failed_message">Nie udało się zweryfikować twojej subskrypcji w Sklepie Google Play. Spróbuj ponownie.</string>

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">As assinaturas são renovadas automaticamente. Você pode cancelar a qualquer momento.</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Você é Pro — obrigado!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Sua compra única do Pro desbloqueia todos os recursos Pro, para sempre.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Sua assinatura desbloqueia todos os recursos Pro.</string>
     <string name="upgrade_screen_owned_sub_title">Sua assinatura</string>

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">Sua assinatura</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Sua assinatura está ativa e renova automaticamente.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Sua assinatura está marcada para expirar e não será renovada. Você manterá o Pro até que expire.</string>
-    <string name="upgrade_screen_owned_both_warning">Você possui a atualização Pro única e também tem uma assinatura ativa. Você não precisa de ambas — cancele a assinatura no Google Play para evitar cobranças futuras.</string>
     <string name="upgrade_screen_manage_subscription_action">Gerenciar assinatura</string>
     <string name="upgrade_screen_owned_iap_title">Pro Vitalício</string>
     <string name="upgrade_screen_owned_iap_body">Você possui a atualização Pro única. Sem assinatura, sem renovações.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Mudar para uma compra única</string>
-    <string name="upgrade_screen_switch_purchase_note">Sua assinatura não será renovada, então você pode mudar para a compra Pro única permanente agora.</string>
-    <string name="upgrade_screen_switch_locked_note">Para mudar para a compra única, primeiro cancele sua assinatura no Google Play. Esta oferta será desbloqueada quando estiver definida para não renovar.</string>
     <string name="upgrade_screen_limitation_disclosure">O Google Play verifica apenas a conta com a qual você está conectado. A compra única é separada de sua assinatura.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Sua assinatura ainda está ativa e se renovando. Cancele-a no Google Play primeiro.</string>
     <string name="upgrade_screen_sub_check_failed_message">Não foi possível verificar sua assinatura no Google Play. Tente novamente.</string>

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">A sua subscrição</string>
     <string name="upgrade_screen_owned_sub_renewing_body">A sua subscrição está ativa e renova-se automaticamente.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">A sua subscrição está definida para expirar e não será renovada. Pode manter o Pro até ao fim.</string>
-    <string name="upgrade_screen_owned_both_warning">Possui a compra Pro única e também tem uma subscrição ativa. Não precisa de ambas — cancele a subscrição no Google Play para evitar cobranças futuras.</string>
     <string name="upgrade_screen_manage_subscription_action">Gerir subscrição</string>
     <string name="upgrade_screen_owned_iap_title">Pro Permanente</string>
     <string name="upgrade_screen_owned_iap_body">Possui a compra Pro única. Sem subscrição, sem renovações.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Mudar para uma compra única</string>
-    <string name="upgrade_screen_switch_purchase_note">A sua subscrição não será renovada, portanto pode agora mudar para a compra Pro única e permanente.</string>
-    <string name="upgrade_screen_switch_locked_note">Para mudar para a compra única, primeiro cancele a sua subscrição no Google Play. Esta oferta desbloqueia-se depois de ser definida para não renovar.</string>
     <string name="upgrade_screen_limitation_disclosure">O Google Play apenas verifica a conta em que está atualmente ligado. A compra única é separada da sua subscrição.</string>
     <string name="upgrade_screen_sub_still_renewing_message">A sua subscrição ainda está ativa e em renovação. Cancele-a primeiro no Google Play.</string>
     <string name="upgrade_screen_sub_check_failed_message">Não foi possível verificar a sua subscrição no Google Play. Tente novamente.</string>

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">As subscrições renovam automaticamente. Pode cancelar a qualquer momento.</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Tem o Pro — obrigado!</string>
     <string name="upgrade_screen_owned_hero_iap_body">A sua compra única do Pro desbloqueia todas as funcionalidades Pro, para sempre.</string>
     <string name="upgrade_screen_owned_hero_sub_body">A sua subscrição desbloqueia todas as funcionalidades Pro.</string>
     <string name="upgrade_screen_owned_sub_title">A sua subscrição</string>

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">Abonamentul tău</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Abonamentul tău este activ și se reînoiește automat.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Abonamentul tău este setat să expire și nu se va reînnoi. Vei continua să ai acces la Pro până la expirare.</string>
-    <string name="upgrade_screen_owned_both_warning">Deții achiziția Pro de o singură dată și de asemenea ai un abonament activ. Nu ai nevoie de ambele — anulează abonamentul din Google Play pentru a evita cheltuielile suplimentare.</string>
     <string name="upgrade_screen_manage_subscription_action">Gestionează abonamentul</string>
     <string name="upgrade_screen_owned_iap_title">Pro pe viață</string>
     <string name="upgrade_screen_owned_iap_body">Deții achiziția Pro de o singură dată. Fără abonament, fără reînnouiri.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Treci la o achiziție unică</string>
-    <string name="upgrade_screen_switch_purchase_note">Abonamentul tău nu se va reînnoi, deci poți trece acum la achiziția Pro unică și permanentă.</string>
-    <string name="upgrade_screen_switch_locked_note">Pentru a trece la achiziția unică, anulează mai întâi abonamentul tău în Google Play. Această ofertă se deblochează odată ce este setată să nu se reînnoiască.</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play verifică doar contul cu care ești conectat în acest moment. Achiziția unică este separată de abonamentul tău.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Abonamentul tău este încă activ și se reînnoiește. Anulează-l mai întâi în Google Play.</string>
     <string name="upgrade_screen_sub_check_failed_message">Nu am putut verifica abonamentul tău cu Google Play. Te rog să încerci din nou.</string>

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">Abonamentele se reînnoiesc automat. Poți anula oricând.</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Ești Pro — mulțumim!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Achiziția ta Pro de o singură dată deblochează fiecare caracteristică Pro, pentru totdeauna.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Abonamentul tău deblochează fiecare caracteristică Pro.</string>
     <string name="upgrade_screen_owned_sub_title">Abonamentul tău</string>

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">Ваша подписка</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Ваша подписка активна и автоматически продлевается.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Ваша подписка истечет и не будет продлеваться. Вы сохраняете Pro до конца.</string>
-    <string name="upgrade_screen_owned_both_warning">Вы имеете единоразовое обновление Pro и активную подписку. Вам не нужны обе — отмените подписку в Google Play, чтобы избежать дополнительных платежей.</string>
     <string name="upgrade_screen_manage_subscription_action">Управлять подпиской</string>
     <string name="upgrade_screen_owned_iap_title">Pro на всю жизнь</string>
     <string name="upgrade_screen_owned_iap_body">У вас есть единоразовое обновление Pro. Без подписки, без продлений.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Переключиться на единоразовую покупку</string>
-    <string name="upgrade_screen_switch_purchase_note">Ваша подписка не будет продлеваться, поэтому вы можете перейти на постоянное единоразовое обновление Pro.</string>
-    <string name="upgrade_screen_switch_locked_note">Чтобы переключиться на единоразовую покупку, сначала отмените подписку в Google Play. Это предложение станет доступным, когда вы отключите автоматическое продление.</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play проверяет только аккаунт, в который вы сейчас вошли. Единоразовая покупка отделена от вашей подписки.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Ваша подписка по-прежнему активна и продлевается. Сначала отмените ее в Google Play.</string>
     <string name="upgrade_screen_sub_check_failed_message">Не удалось проверить вашу подписку в Google Play. Пожалуйста, попробуйте еще раз.</string>

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">Подписки обновляются автоматически. Вы можете отменить в любое время.</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Вы Pro — спасибо!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Ваша единоразовая покупка Pro разблокирует все функции Pro навсегда.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Ваша подписка разблокирует все функции Pro.</string>
     <string name="upgrade_screen_owned_sub_title">Ваша подписка</string>

--- a/app/src/gplay/res/values-sk/strings.xml
+++ b/app/src/gplay/res/values-sk/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">Vaše predplatné</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Vaše predplatné je aktívne a automaticky sa obnovuje.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Vaše predplatné vypršia a nebude sa obnovovať. Budete mať Pro až do jeho konca.</string>
-    <string name="upgrade_screen_owned_both_warning">Vlastníte jednorazový upgrade Pro a máte aj aktívne predplatné. Nepotrebujete oboje – zrušte predplatné v Google Play, aby ste sa vyhli ďalším poplatkom.</string>
     <string name="upgrade_screen_manage_subscription_action">Spravovať predplatné</string>
     <string name="upgrade_screen_owned_iap_title">Doživotný Pro</string>
     <string name="upgrade_screen_owned_iap_body">Vlastníte jednorazový upgrade Pro. Žiadne predplatné, žiadne obnovy.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Prejsť na jednorazový nákup</string>
-    <string name="upgrade_screen_switch_purchase_note">Vaše predplatné sa neobnoví, takže teraz môžete prejsť na trvalý jednorazový nákup Pro.</string>
-    <string name="upgrade_screen_switch_locked_note">Ak chcete prejsť na jednorazový nákup, najskôr zrušte svoje predplatné v Google Play. Táto ponuka sa odomkne, keď nastavíte predplatné, aby sa neobnovalo.</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play kontroluje iba účet, s ktorým ste momentálne prihlásení. Jednorazový nákup je nezávislý od vášho predplatného.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Vaše predplatné je stále aktívne a obnovuje sa. Zrušte ho najskôr v Google Play.</string>
     <string name="upgrade_screen_sub_check_failed_message">Nepodarilo sa overiť vaše predplatné v Google Play. Skúste znova prosím.</string>

--- a/app/src/gplay/res/values-sk/strings.xml
+++ b/app/src/gplay/res/values-sk/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">Predplatné sa obnovia automaticky. Môžete ich kedykoľvek zrušiť.</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Ste Pro — ďakujeme!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Váš jednorazový nákup Pro odomyká všetky funkcie Pro. Navždy.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Vaše predplatné odomyká všetky funkcie Pro.</string>
     <string name="upgrade_screen_owned_sub_title">Vaše predplatné</string>

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">Ваша претплата</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Ваша претплата је активна и аутоматски се обнавља.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Ваша претплата је подешена да истекне и неће се обновити. Задржаћете Pro док се не заврши.</string>
-    <string name="upgrade_screen_owned_both_warning">Поседујете једнократно Pro ажурирање и такође имате активну претплату. Не требају вам обе — откажите претплату у Google Play како бисте избегли даље трошкове.</string>
     <string name="upgrade_screen_manage_subscription_action">Управљај претплатом</string>
     <string name="upgrade_screen_owned_iap_title">Доживотни Pro</string>
     <string name="upgrade_screen_owned_iap_body">Поседујете једнократно Pro ажурирање. Без претплате, без обнављања.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Пређите на једнократну куповину</string>
-    <string name="upgrade_screen_switch_purchase_note">Ваша претплата се неће обновити, па сада можете прећи на трајно једнократно Pro куповање.</string>
-    <string name="upgrade_screen_switch_locked_note">Да бисте прешли на једнократну куповину, прво откажите своју претплату у Google Play. Та понуда ће бити доступна када је претплата подешена да се не обнови.</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play проверава само налог са којим сте пријављени. Једнократна куповина је одвојена од ваше претплате.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Ваша претплата је још активна и обнавља се. Прво је откажите у Google Play.</string>
     <string name="upgrade_screen_sub_check_failed_message">Провера ваше претплате са Google Play није успела. Покушајте поново.</string>

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">Претплате се аутоматски обнављају. Можете отказати када хоћете.</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Ви сте Pro — хвала!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Ваша једнократна куповина Pro откључава све Pro функције заувек.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Ваша претплата откључава сваку Pro функцију.</string>
     <string name="upgrade_screen_owned_sub_title">Ваша претплата</string>

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">Din prenumeration</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Din prenumeration är aktiv och förnyas automatiskt.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Din prenumeration är inställd på att upphöra och kommer inte att förnyas. Du behåller Pro tills den slutar.</string>
-    <string name="upgrade_screen_owned_both_warning">Du äger engångsuppgraderingen till Pro och har också en aktiv prenumeration. Du behöver inte båda – avsluta prenumerationen i Google Play för att undvika ytterligare debiteringar.</string>
     <string name="upgrade_screen_manage_subscription_action">Hantera prenumeration</string>
     <string name="upgrade_screen_owned_iap_title">Pro på livstid</string>
     <string name="upgrade_screen_owned_iap_body">Du äger engångsuppgraderingen till Pro. Ingen prenumeration, inga förnyelser.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Växla till ett engångsköp</string>
-    <string name="upgrade_screen_switch_purchase_note">Din prenumeration kommer inte att förnyas, så du kan byta till det permanenta engångsköpet av Pro nu.</string>
-    <string name="upgrade_screen_switch_locked_note">För att byta till engångsköpet måste du först avbryta din prenumeration i Google Play. Det här erbjudandet aktiveras när det är inställt på att inte förnyas.</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play kontrollerar bara kontot du är inloggad på. Engångsköpet är separat från din prenumeration.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Din prenumeration är fortfarande aktiv och förnyas. Avbryt den i Google Play först.</string>
     <string name="upgrade_screen_sub_check_failed_message">Kunde inte verifiera din prenumeration med Google Play. Försök igen.</string>

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">Prenumerationer förnyas automatiskt. Du kan avsluta när som helst.</string>
     <string name="upgrade_title_suffix">Expert</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Du är Pro – tack!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Ditt engångköp av Pro låser upp alla Pro-funktioner för alltid.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Din prenumeration låser upp alla Pro-funktioner.</string>
     <string name="upgrade_screen_owned_sub_title">Din prenumeration</string>

--- a/app/src/gplay/res/values-th/strings.xml
+++ b/app/src/gplay/res/values-th/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">สมาชิกภาพจะต่ออายุโดยอัตโนมัติ คุณยกเลิกได้เมื่อใดก็ได้</string>
     <string name="upgrade_title_suffix">โปร</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">คุณเป็น Pro — ขอบคุณ!</string>
     <string name="upgrade_screen_owned_hero_iap_body">การซื้อ Pro ครั้งเดียวของคุณปลดล็อคฟีเจอร์ Pro ทั้งหมดเป็นการถาวร</string>
     <string name="upgrade_screen_owned_hero_sub_body">การสมัครสมาชิกของคุณปลดล็อคฟีเจอร์ Pro ทั้งหมด</string>
     <string name="upgrade_screen_owned_sub_title">การสมัครสมาชิกของคุณ</string>

--- a/app/src/gplay/res/values-th/strings.xml
+++ b/app/src/gplay/res/values-th/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">การสมัครสมาชิกของคุณ</string>
     <string name="upgrade_screen_owned_sub_renewing_body">การสมัครสมาชิกของคุณยังใช้งานอยู่ และต่ออายุโดยอัตโนมัติ</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">การสมัครสมาชิกของคุณจะหมดอายุและจะไม่ต่ออายุ คุณจะยังคงใช้ Pro จนกว่าจะสิ้นสุด</string>
-    <string name="upgrade_screen_owned_both_warning">คุณมี Pro upgrade แบบครั้งเดียว และมีการสมัครสมาชิกที่ยังใช้งานอยู่ คุณไม่ต้องใช้ทั้งสอง — ยกเลิกการสมัครสมาชิกใน Google Play เพื่อหลีกเลี่ยงค่าใช้จ่ายเพิ่มเติม</string>
     <string name="upgrade_screen_manage_subscription_action">จัดการการสมัครสมาชิก</string>
     <string name="upgrade_screen_owned_iap_title">Lifetime Pro</string>
     <string name="upgrade_screen_owned_iap_body">คุณมี Pro upgrade แบบครั้งเดียว ไม่มีการสมัครสมาชิก ไม่มีการต่ออายุ</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">เปลี่ยนไปซื้อแบบครั้งเดียว</string>
-    <string name="upgrade_screen_switch_purchase_note">การสมัครสมาชิกของคุณจะไม่ต่ออายุ ดังนั้นตอนนี้คุณสามารถเปลี่ยนไปซื้อ Pro แบบครั้งเดียวได้</string>
-    <string name="upgrade_screen_switch_locked_note">หากต้องการสลับไปใช้การซื้อแบบครั้งเดียว ให้ยกเลิกการสมัครสมาชิกของคุณใน Google Play ก่อน ข้อเสนอนี้จะปลดล็อกเมื่อคุณตั้งค่าให้ไม่ต่ออายุ</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play จะตรวจสอบเฉพาะบัญชีที่คุณลงชื่อเข้าสู่ระบบอยู่เท่านั้น การซื้อแบบครั้งเดียวจะแยกต่างหากจากการสมัครสมาชิกของคุณ</string>
     <string name="upgrade_screen_sub_still_renewing_message">การสมัครสมาชิกของคุณยังคงใช้งานและต่ออายุอยู่ ให้ยกเลิกใน Google Play ก่อน</string>
     <string name="upgrade_screen_sub_check_failed_message">ไม่สามารถยืนยันการสมัครสมาชิกของคุณกับ Google Play ได้ โปรดลองอีกครั้ง</string>

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">Abonelikler otomatik olarak yenilenir. İstediğiniz zaman iptal edebilirsiniz.</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Pro\'sunuz — teşekkür ederiz!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Bir defaya mahsus Pro satın alımınız tüm Pro özelliklerini sonsuza kadar açar.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Aboneliğiniz tüm Pro özelliklerini açar.</string>
     <string name="upgrade_screen_owned_sub_title">Aboneliğiniz</string>

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">Aboneliğiniz</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Aboneliğiniz etkin ve otomatik olarak yenileniyor.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Aboneliğiniz süresi dolmak üzere ve yenilenmeyecektir. Pro\'yu süresi bitene kadar kullanabileceksiniz.</string>
-    <string name="upgrade_screen_owned_both_warning">Hem bir defaya mahsus Pro yükseltmesine hem de etkin bir aboneliğe sahipsiniz. İkisine de ihtiyacınız yok — daha fazla ücretlerden kaçınmak için Google Play\'den aboneliği iptal edin.</string>
     <string name="upgrade_screen_manage_subscription_action">Aboneliği yönet</string>
     <string name="upgrade_screen_owned_iap_title">Ömür Boyu Pro</string>
     <string name="upgrade_screen_owned_iap_body">Bir defaya mahsus Pro yükseltmesine sahipsiniz. Abonelik yok, yenileme yok.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Tek seferlik satın almaya geç</string>
-    <string name="upgrade_screen_switch_purchase_note">Aboneliğiniz yenilenmiyor, bu nedenle artık kalıcı tek seferlik Pro satın almaya geçebilirsiniz.</string>
-    <string name="upgrade_screen_switch_locked_note">Tek seferlik satın almaya geçmek için önce Google Play\'de aboneliğinizi iptal edin. Bu teklif yenilenmeyecek şekilde ayarlandığında açılır.</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play yalnızca şu anda oturum açtığınız hesabı kontrol eder. Tek seferlik satın alma, aboneliğinizden ayrıdır.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Aboneliğiniz hala aktif ve yenileniyor. Önce Google Play\'de iptal edin.</string>
     <string name="upgrade_screen_sub_check_failed_message">Aboneliğiniz Google Play ile doğrulanamadı. Lütfen tekrar deneyin.</string>

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">Ваша підписка</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Ваша підписка активна і автоматично поновлюється.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Ваша підписка припиниться й не поновиться. Ви матимете Pro до її закінчення.</string>
-    <string name="upgrade_screen_owned_both_warning">Ви маєте одноразове оновлення Pro і також активну підписку. Вам не потрібні обидва — скасуйте підписку в Google Play, щоб уникнути подальших платежів.</string>
     <string name="upgrade_screen_manage_subscription_action">Керування підпискою</string>
     <string name="upgrade_screen_owned_iap_title">Безстрокове Pro</string>
     <string name="upgrade_screen_owned_iap_body">Ви маєте одноразове оновлення Pro. Без підписки, без поновлень.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Перейти на одноразову покупку</string>
-    <string name="upgrade_screen_switch_purchase_note">Ваша підписка не поновиться, тому зараз ви можете перейти на постійну одноразову покупку Pro.</string>
-    <string name="upgrade_screen_switch_locked_note">Щоб перейти на одноразову покупку, спочатку скасуйте підписку в Google Play. Пропозиція розблокується, коли буде припинено поновлення.</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play перевіряє лише обліковий запис, в якому ви зараз увійшли. Разова покупка відокремлена від вашої підписки.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Ваша підписка все ще активна і поновлюється. Спочатку скасуйте її в Google Play.</string>
     <string name="upgrade_screen_sub_check_failed_message">Не вдалося перевірити вашу підписку в Google Play. Будь ласка, спробуйте ще раз.</string>

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">Підписки поновлюються автоматично. Скасувати можна будь-коли.</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Ви маєте Pro — дякуємо!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Ваша одноразова покупка Pro розблокує всі функції Pro навічно.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Ваша підписка розблокує всі функції Pro.</string>
     <string name="upgrade_screen_owned_sub_title">Ваша підписка</string>

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">Đăng ký sẽ tự động gia hạn. Bạn có thể hủy bất kỳ lúc nào.</string>
     <string name="upgrade_title_suffix">Pro</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">Bạn là Pro — cảm ơn bạn!</string>
     <string name="upgrade_screen_owned_hero_iap_body">Mua hàng Pro một lần của bạn mở khóa mọi tính năng Pro, mãi mãi.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Gói đăng ký của bạn mở khóa mọi tính năng Pro.</string>
     <string name="upgrade_screen_owned_sub_title">Gói đăng ký của bạn</string>

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">Gói đăng ký của bạn</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Gói đăng ký của bạn đang hoạt động và tự động gia hạn.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Gói đăng ký của bạn được đặt để hết hạn và sẽ không gia hạn. Bạn sẽ giữ Pro cho đến khi nó kết thúc.</string>
-    <string name="upgrade_screen_owned_both_warning">Bạn sở hữu nâng cấp Pro một lần và cũng có gói đăng ký đang hoạt động. Bạn không cần cả hai — hủy gói đăng ký trong Google Play để tránh các khoản phí tiếp theo.</string>
     <string name="upgrade_screen_manage_subscription_action">Quản lý gói đăng ký</string>
     <string name="upgrade_screen_owned_iap_title">Pro Trọn đời</string>
     <string name="upgrade_screen_owned_iap_body">Bạn sở hữu nâng cấp Pro một lần. Không có gói đăng ký, không có gia hạn.</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Chuyển sang mua một lần</string>
-    <string name="upgrade_screen_switch_purchase_note">Gói đăng ký của bạn sẽ không tự động gia hạn, vì vậy bạn có thể chuyển sang lần mua Pro vĩnh viễn ngay bây giờ.</string>
-    <string name="upgrade_screen_switch_locked_note">Để chuyển sang lần mua một lần, trước tiên hãy hủy gói đăng ký của bạn trong Google Play. Ưu đãi này sẽ được mở khóa khi bạn đặt để không tự động gia hạn.</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play chỉ kiểm tra tài khoản bạn đang đăng nhập. Lần mua một lần này riêng biệt từ gói đăng ký của bạn.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Gói đăng ký của bạn vẫn còn hoạt động và đang tự động gia hạn. Hãy hủy nó trong Google Play trước.</string>
     <string name="upgrade_screen_sub_check_failed_message">Không thể xác minh gói đăng ký của bạn với Google Play. Vui lòng thử lại.</string>

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">您的订阅</string>
     <string name="upgrade_screen_owned_sub_renewing_body">您的订阅处于活跃状态，会自动续订。</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">您的订阅已设置为过期且不会续订。您将保留 Pro 直到订阅结束。</string>
-    <string name="upgrade_screen_owned_both_warning">您既拥有一次性 Pro 升级，也有一个活跃的订阅。您无需同时拥有两者，请在 Google Play 中取消订阅以避免继续扣费。</string>
     <string name="upgrade_screen_manage_subscription_action">管理订阅</string>
     <string name="upgrade_screen_owned_iap_title">终身 Pro</string>
     <string name="upgrade_screen_owned_iap_body">您拥有一次性 Pro 升级。无需订阅，无需续订。</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">切换为一次性购买</string>
-    <string name="upgrade_screen_switch_purchase_note">您的订阅将不会续期，因此您现在可以切换到永久的一次性 Pro 购买。</string>
-    <string name="upgrade_screen_switch_locked_note">要切换到一次性购买，请先在 Google Play 中取消您的订阅。设置为不续期后，该优惠才会解锁。</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play 只会检查您当前登录的账户。一次性购买与您的订阅是分开的。</string>
     <string name="upgrade_screen_sub_still_renewing_message">您的订阅仍然有效且将继续续期。请先在 Google Play 中取消。</string>
     <string name="upgrade_screen_sub_check_failed_message">无法与 Google Play 验证您的订阅。请重试。</string>

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">订阅自动续费，可随时取消。</string>
     <string name="upgrade_title_suffix">专业版</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">您是 Pro 用户，感谢您！</string>
     <string name="upgrade_screen_owned_hero_iap_body">您的一次性 Pro 购买永久解锁所有 Pro 功能。</string>
     <string name="upgrade_screen_owned_hero_sub_body">您的订阅解锁所有 Pro 功能。</string>
     <string name="upgrade_screen_owned_sub_title">您的订阅</string>

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -24,14 +24,11 @@
     <string name="upgrade_screen_owned_sub_title">您的訂閱</string>
     <string name="upgrade_screen_owned_sub_renewing_body">您的訂閱處於有效狀態，將自動更新。</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">您的訂閱設定為過期且不會更新。在訂閱結束前，您將保持 Pro 狀態。</string>
-    <string name="upgrade_screen_owned_both_warning">您同時擁有一次性 Pro 升級和有效訂閱。您不需要兩者——取消 Google Play 中的訂閱以避免進一步扣費。</string>
     <string name="upgrade_screen_manage_subscription_action">管理訂閱</string>
     <string name="upgrade_screen_owned_iap_title">終身 Pro</string>
     <string name="upgrade_screen_owned_iap_body">您擁有一次性 Pro 升級。無需訂閱，無需更新。</string>
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">切換為一次性購買</string>
-    <string name="upgrade_screen_switch_purchase_note">您的訂閱不會更新，因此您現在可以轉換為永久一次性 Pro 購買。</string>
-    <string name="upgrade_screen_switch_locked_note">若要切換到一次性購買，請先在 Google Play 中取消訂閱。將訂閱設為不自動續約後，此優惠即會解鎖。</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play 只會檢查您目前登入的帳戶。一次性購買與您的訂閱是分開的。</string>
     <string name="upgrade_screen_sub_still_renewing_message">您的訂閱仍處於活動狀態且正在續約。請先在 Google Play 中取消訂閱。</string>
     <string name="upgrade_screen_sub_check_failed_message">無法透過 Google Play 驗證您的訂閱。請重試。</string>

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -19,7 +19,6 @@
     <string name="upgrade_screen_options_description">訂閱自動續費。您可隨時取消。</string>
     <string name="upgrade_title_suffix">專業版</string>
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">您已升級至 Pro——感謝您！</string>
     <string name="upgrade_screen_owned_hero_iap_body">您的一次性 Pro 購買解鎖所有 Pro 功能，永久有效。</string>
     <string name="upgrade_screen_owned_hero_sub_body">您的訂閱解鎖所有 Pro 功能。</string>
     <string name="upgrade_screen_owned_sub_title">您的訂閱</string>

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -33,15 +33,15 @@
     <string name="upgrade_screen_owned_sub_title">Your subscription</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Your subscription is active and renews automatically.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Your subscription is set to expire and won\'t renew. You\'ll keep Pro until it ends.</string>
-    <string name="upgrade_screen_owned_both_warning">You own the one-time Pro upgrade and also have an active subscription. You don\'t need both — cancel the subscription in Google Play to avoid further charges.</string>
+    <string name="upgrade_screen_owned_both_renewing_warning">You own the one-time Pro upgrade and also have an active subscription. You don\'t need both — cancel the subscription in Google Play to avoid further charges.</string>
     <string name="upgrade_screen_manage_subscription_action">Manage subscription</string>
     <string name="upgrade_screen_owned_iap_title">Lifetime Pro</string>
     <string name="upgrade_screen_owned_iap_body">You own the one-time Pro upgrade. No subscription, no renewals.</string>
 
     <!-- Switch subscription -> one-time purchase -->
     <string name="upgrade_screen_switch_title">Switch to a one-time purchase</string>
-    <string name="upgrade_screen_switch_purchase_note">Your subscription won\'t renew, so you can move to the permanent one-time Pro purchase now.</string>
-    <string name="upgrade_screen_switch_locked_note">To switch to the one-time purchase, first cancel your subscription in Google Play. This offer unlocks once it\'s set not to renew.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Your subscription won\'t renew, so you can move to the permanent one-time Pro purchase now.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">To switch to the one-time purchase, first cancel your subscription in Google Play. This offer unlocks once it\'s set not to renew.</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play only checks the account you\'re currently signed in with. The one-time purchase is separate from your subscription.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Your subscription is still active and renewing. Cancel it in Google Play first.</string>
     <string name="upgrade_screen_sub_check_failed_message">Couldn\'t verify your subscription with Google Play. Please try again.</string>

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -22,7 +22,12 @@
 
 
     <!-- Ownership / status -->
-    <string name="upgrade_screen_owned_hero_title">You\'re Pro — thank you!</string>
+    <!-- Hero title on the status screen for users who already own Pro. %1$s is the complete
+         localized tier name, e.g. "Permission Pilot Pro" - never insert the app name or "Pro"
+         yourself. The sentence may be rendered idiomatically ("X is active", "Your X access is
+         active") as long as the placeholder survives. Replaces upgrade_screen_owned_hero_title,
+         which told the user they *were* the tier instead of that they own it. -->
+    <string name="upgrade_screen_owned_hero_brand_title">You have %1$s</string>
     <string name="upgrade_screen_owned_hero_iap_body">Your one-time Pro purchase unlocks every Pro feature, forever.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Your subscription unlocks every Pro feature.</string>
     <string name="upgrade_screen_owned_sub_title">Your subscription</string>

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/GplayUpgradeScreenTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/GplayUpgradeScreenTest.kt
@@ -437,7 +437,7 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_owned_hero_sub_body))
             .assertCountEquals(1)
         // The switch path is a visible LOCKED offer: present, disabled, with the unlock condition.
-        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_switch_locked_note)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_owned_iap_locked_note)).assertCountEquals(1)
         composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_IAP).assertIsNotEnabled()
         composeRule.runOnIdle { check(iapClicks == 0) { "locked offer must not be clickable" } }
         // No acquisition upsell copy anywhere on the ownership screen.
@@ -464,9 +464,9 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
 
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_MANAGE_SUB).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_owned_sub_not_renewing_body)).assertCountEquals(1)
-        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_switch_purchase_note)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_owned_iap_purchase_note)).assertCountEquals(1)
         // The offer is unlocked — the locked-state note must be gone.
-        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_switch_locked_note)).assertCountEquals(0)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_owned_iap_locked_note)).assertCountEquals(0)
         composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_IAP).performScrollTo().performClick()
         composeRule.runOnIdle { check(iapClicks == 1) { "expected 1 iap click, got $iapClicks" } }
     }
@@ -504,7 +504,7 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
             )
         }
 
-        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_owned_both_warning)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_owned_both_renewing_warning)).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_MANAGE_SUB).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_IAP).assertCountEquals(0)
     }

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/GplayUpgradeScreenTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/GplayUpgradeScreenTest.kt
@@ -41,11 +41,6 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
     private val appNameWithPostfix: String
         get() = context.expectedBrandTitle
 
-    private fun appNameWithPostfixedHeroBody(bodyRes: Int): String = context.getString(
-        bodyRes,
-        appNameWithPostfix,
-    )
-
     // What the acquisition top bar must render: the translated pitch pattern with the composed
     // brand formatted into it.
     private val acquisitionTitle: String
@@ -402,6 +397,26 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
             busy = busy,
         )
 
+    // What the owned hero must render: its own outer string with the composed brand formatted in.
+    // Both halves are resolved, never spelled out, so a locale that reorders either the sentence or
+    // the title template still describes the same render.
+    private val ownedHeroTitle: String
+        get() = context.getString(R.string.upgrade_screen_owned_hero_brand_title, appNameWithPostfix)
+
+    @Test
+    fun `the owned hero titles ownership of the composed brand`() {
+        composeRule.setUpgradeContent {
+            UpgradeScreen(uiState = ownedState(Ownership(hasIap = true)))
+        }
+
+        composeRule.onAllNodesWithText(ownedHeroTitle).assertCountEquals(1)
+        // The expectation itself must stay a composition, not a coincidence: if the outer string
+        // ever loses its placeholder the assertion above would still pass against a title that
+        // names no tier at all.
+        ownedHeroTitle.contains(context.getString(R.string.app_name)) shouldBe true
+        ownedHeroTitle.contains(context.brandQualifier) shouldBe true
+    }
+
     @Test
     fun `renewing subscription owner sees a locked one-time offer and management`() {
         var iapClicks = 0
@@ -418,7 +433,8 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithText(context.expectedBrandTitle).assertCountEquals(1)
         // The congrats hero names the variant.
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_OWNED_HERO).assertCountEquals(1)
-        composeRule.onAllNodesWithText(appNameWithPostfixedHeroBody(R.string.upgrade_screen_owned_hero_sub_body))
+        composeRule.onAllNodesWithText(ownedHeroTitle).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_owned_hero_sub_body))
             .assertCountEquals(1)
         // The switch path is a visible LOCKED offer: present, disabled, with the unlock condition.
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_switch_locked_note)).assertCountEquals(1)
@@ -467,9 +483,9 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_MANAGE_SUB).assertCountEquals(0)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_owned_iap_body)).assertCountEquals(1)
         // The hero names the permanent purchase as the unlock, never the subscription variant.
-        composeRule.onAllNodesWithText(appNameWithPostfixedHeroBody(R.string.upgrade_screen_owned_hero_iap_body))
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_owned_hero_iap_body))
             .assertCountEquals(1)
-        composeRule.onAllNodesWithText(appNameWithPostfixedHeroBody(R.string.upgrade_screen_owned_hero_sub_body))
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_owned_hero_sub_body))
             .assertCountEquals(0)
         // Owners get their mascot from the congrats hero only — the acquisition hero card and its
         // preamble must stay away entirely.


### PR DESCRIPTION
## What changed

The upgrade screen told users who had bought Pro "You're Pro, thank you!", which says the person *is* the product tier rather than that they own it. It now reads "You have Permission Pilot Pro", with the tier name built from the app name and the translated title template so translators keep control of word order.

A second commit renames three ownership strings onto the names the sibling apps use. No user-visible change, the wording is identical.

## Technical Context

- New string id instead of editing the English in place. Every existing translation of the old headline repeats the same defect, so an in-place source edit would keep shipping them until Crowdin re-translates. The old id is deleted from the base file and all 39 locale copies in the same commit, leaving no orphaned translations behind.
- The new headline id matches the one now used in octi and bluemusic, so the three apps stay aligned.
- The rename commit covers the switch-to-one-time-purchase notes and the both-owned warning, which rendered under app-specific names despite identical gating logic (`subscription.isAutoRenewing && ownership.hasIap`). Cross-app changes to this card previously had to be written twice.
- The two body strings under the headline are unchanged. A comment claimed they name the app inline; they do not, that wording was carried over from capod where it is accurate. It now records the real reason they keep their ids: their existing translations still apply.
- Translations: the headline's old translations were defective and should not be reused. The renamed strings are the opposite case, their English is untouched, so translation memory should restore all 117 entries as exact matches on the next sync.
