### PR TITLE
General: Show when a Google Play payment is still being processed

### DIFF
--- a/app/src/foss/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModel.kt
@@ -42,8 +42,10 @@ class UpgradeViewModel @Inject constructor(
 
     // Which presentation the screen shows. The manage route (settings "upgrade status" entry)
     // gets a status view first; the pitch only appears once a free user asks for the upgrade
-    // options. Upgrading wins over that choice — completing the sponsor flow from the pitch must
-    // land on the upgraded status, not back on the ask. null until the route is bound.
+    // options. Upgrading wins on EVERY route, not just manage: forced routes (Pro-locked settings)
+    // stay open after the sponsor flow completes, and the pitch with its live sponsor button reads
+    // as "sponsoring didn't work" to a fresh supporter — the toast alone is too transient for a
+    // money moment without a receipt behind it. null until the route is bound.
     internal val state: StateFlow<State?> = combine(
         routeFlow,
         upgradeRepo.upgradeInfo,
@@ -51,7 +53,7 @@ class UpgradeViewModel @Inject constructor(
     ) { route, info, showOptions ->
         val view = when {
             route == null -> null
-            route.manage && info.isPro -> FossUpgradeView.STATUS_UPGRADED
+            info.isPro -> FossUpgradeView.STATUS_UPGRADED
             route.manage && !showOptions -> FossUpgradeView.STATUS_FREE
             else -> FossUpgradeView.PITCH
         }

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/UpgradeRepoGplay.kt
@@ -2,7 +2,6 @@ package eu.darken.myperm.common.upgrade.core
 
 import android.app.Activity
 import com.android.billingclient.api.BillingClient.BillingResponseCode
-import com.android.billingclient.api.Purchase
 import eu.darken.myperm.common.coroutine.AppScope
 import eu.darken.myperm.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.myperm.common.debug.logging.Logging.Priority.INFO
@@ -17,6 +16,7 @@ import eu.darken.myperm.common.upgrade.core.billing.BillingData
 import eu.darken.myperm.common.upgrade.core.billing.BillingManager
 import eu.darken.myperm.common.upgrade.core.billing.GplayServiceUnavailableException
 import eu.darken.myperm.common.upgrade.core.billing.ItemAlreadyOwnedBillingException
+import eu.darken.myperm.common.upgrade.core.billing.PendingPurchaseBillingException
 import eu.darken.myperm.common.upgrade.core.billing.PurchasedSku
 import eu.darken.myperm.common.upgrade.core.billing.Sku
 import eu.darken.myperm.common.upgrade.core.billing.SkuDetails
@@ -283,9 +283,18 @@ class UpgradeRepoGplay @Inject constructor(
                     // Reconciled only if the restore actually returned the SKU Play claims is
                     // owned — a grace-only isPro doesn't count, the entitlement is still missing.
                     if (restored?.upgrades?.any { it.sku == sku } != true) {
-                        // Couldn't reconcile the entitlement (pending purchase, account mismatch,
-                        // Play quirk) — fall back to the already-owned dialog with restore tips.
-                        onError(e)
+                        if (restored?.pendingSkus?.isNotEmpty() == true) {
+                            // Play blocks re-purchasing a product whose payment it is still
+                            // processing. "Already owned" is technically what Play said, but the
+                            // dialog's restore tips are the wrong advice: nothing to restore, and
+                            // the entitlement lands by itself once the payment clears.
+                            log(TAG, INFO) { "Already-owned recovery found a pending payment" }
+                            onError(PendingPurchaseBillingException(e))
+                        } else {
+                            // Couldn't reconcile the entitlement (account mismatch, Play quirk) —
+                            // fall back to the already-owned dialog with restore tips.
+                            onError(e)
+                        }
                     }
                 }
 
@@ -328,12 +337,15 @@ class UpgradeRepoGplay @Inject constructor(
 
     suspend fun querySkus(vararg skus: Sku): Collection<SkuDetails> = billingManager.querySkus(*skus)
 
-    // Strict subscription lookup for the pre-purchase gate: fresh SUBS-only query with explicit
-    // failure. No grace substitution and no cross-product-type tolerance (unlike refresh() and
+    // Strict purchase-state lookup for the pre-purchase gates: a fresh COMPLETE round-trip with
+    // explicit failure. No grace substitution and no partial tolerance (unlike refresh() and
     // restorePurchaseNow()) — callers must treat any error as "couldn't verify" and fail closed.
-    suspend fun queryCurrentSubscriptions(): Collection<Purchase> {
-        log(TAG) { "queryCurrentSubscriptions()" }
-        return billingManager.querySubscriptions()
+    // Covers both product types and pending payments, because both can make a purchase wrong: a
+    // renewing subscription (double billing) and a payment Play is still processing (Play rejects
+    // the re-purchase).
+    suspend fun verifyPurchaseStateNow(): Info {
+        log(TAG) { "verifyPurchaseStateNow()" }
+        return Info(billingData = billingManager.refreshStrict(), isSettled = true)
     }
 
     override suspend fun refresh() {
@@ -495,8 +507,8 @@ class UpgradeRepoGplay @Inject constructor(
     // Shared Pro/grace mapping used by both the reactive upgradeInfo flow and restorePurchaseNow().
     // Only relinquishes Pro if we haven't had it for a while (grace period). READ-ONLY: this runs on
     // replayed shared-flow data too, so it must never stamp the grace cache — see recordProState().
-    // settled comes from the caller, never from billingData nullness: the grace branch returns an
-    // Info with billingData = null that may well be settled (built from a real empty snapshot).
+    // settled comes from the caller, never from billingData nullness: a null-data Info can be
+    // perfectly settled (a real empty snapshot), and the grace branch carries data through anyway.
     private suspend fun BillingData?.toUpgradeInfo(settled: Boolean): Info {
         // Branch on MAPPED upgrades, not raw purchases: a purchase list containing only products
         // this app doesn't know maps to zero upgrades and must fall through to the grace check —
@@ -512,7 +524,11 @@ class UpgradeRepoGplay @Inject constructor(
         return when {
             (now - lastProStateAt) < graceWindowMs() -> {
                 log(TAG, VERBOSE) { "We are not pro, but were recently, did GPlay try annoy us again?" }
-                Info(gracePeriod = true, billingData = null, isSettled = settled)
+                // billingData is carried through, not dropped: this branch is only reached when the
+                // mapped upgrades are empty, so entitlement stays empty either way — but a pending
+                // payment must stay visible, and a grace user waiting on one is exactly who needs
+                // the explanation.
+                Info(gracePeriod = true, billingData = this, isSettled = settled)
             }
 
             else -> mapped
@@ -556,6 +572,34 @@ class UpgradeRepoGplay @Inject constructor(
             }
             ?.flatten()
             ?: emptySet()
+
+        // Products with a payment Play is still processing. Deliberately NOT part of [isPro] or
+        // [upgrades]: a pending payment grants nothing. It exists so the UI can explain the wait
+        // and lock the purchase buttons — buying the alternative product now would double-charge.
+        val pendingSkus: Collection<Sku> = billingData?.pendingPurchases
+            ?.map { purchase ->
+                purchase.products.mapNotNull { productId ->
+                    val sku = OurSku.PRO_SKUS.singleOrNull { it.id == productId }
+                    if (sku == null) {
+                        log(TAG, WARN) { "Unknown pending product: $productId (${purchase.redacted()})" }
+                        return@mapNotNull null
+                    }
+                    sku
+                }
+            }
+            ?.flatten()
+            ?: emptySet()
+
+        // Any owned purchase Play still bills on a schedule. Deliberately computed from the RAW
+        // PURCHASED purchases instead of [upgrades]: the mapping drops products this app doesn't
+        // know, and the pre-purchase gate must keep blocking on a renewing subscription with an
+        // unknown or legacy product ID — being wrong there means billing the user twice for Pro.
+        // Both product types are scanned; a one-time purchase reports isAutoRenewing = false, so
+        // the broader input cannot produce a false positive.
+        // Computed on access, not in the initializer: an Info is built for every mapping pass, and
+        // only the purchase gate needs this.
+        val hasAutoRenewingSubscription: Boolean
+            get() = billingData?.purchases?.any { it.isAutoRenewing } == true
 
         override val isPro: Boolean = upgrades.isNotEmpty() || gracePeriod
 

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/billing/BillingData.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/billing/BillingData.kt
@@ -1,7 +1,28 @@
 package eu.darken.myperm.common.upgrade.core.billing
 
 import com.android.billingclient.api.Purchase
+import eu.darken.myperm.common.upgrade.core.billing.client.isPurchased
+import eu.darken.myperm.common.upgrade.core.billing.client.isRelevant
 
+/**
+ * Play's purchase state, split by what it may be used for. [purchases] is the entitlement carrier
+ * and PURCHASED-only by construction, so no consumer can grant Pro (or stamp the grace cache) from
+ * a payment Play is still processing; [pendingPurchases] keeps that payment visible to the UI.
+ */
 data class BillingData(
-    val purchases: Collection<Purchase>
-)
+    val purchases: Collection<Purchase>,
+    val pendingPurchases: Collection<Purchase> = emptyList(),
+) {
+
+    companion object {
+        // The one place raw Play data becomes a BillingData: splitting here (instead of at each
+        // consumer) is what keeps "pending never grants Pro" a property of the type. Anything
+        // that is neither PURCHASED nor PENDING is dropped — it is not an entitlement and not a
+        // payment in progress.
+        fun from(raw: Collection<Purchase>): BillingData {
+            val relevant = raw.filter { it.isRelevant }
+            val (purchased, pending) = relevant.partition { it.isPurchased }
+            return BillingData(purchases = purchased, pendingPurchases = pending)
+        }
+    }
+}

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/billing/BillingManager.kt
@@ -418,17 +418,12 @@ class BillingManager @Inject constructor(
         }
     }
 
-    // Everything a COMPLETED refresh owes the rest of the app, in one place: both the connect loop's
-    // initial refresh and manual refresh() calls run through it, so a Restore tap during an outage
-    // feeds the same bookkeeping the connect loop does. Only reached when refreshPurchases returned
-    // (it still throws when it found nothing AND a query failed — that path is the connect loop's /
-    // useConnection's).
-    private fun processReconciliation(refresh: BillingConnection.PurchaseRefresh) {
-        // A partial refresh no longer reaches useConnection's dead-binder detection (it returns
-        // instead of throwing), so the teardown that used to ride the throw path happens here.
-        // Cause chain, not the exception itself: the failure arrives user-friendly-mapped.
-        // Deliberately no holder CAS: the failing connection may already have been replaced, and
-        // the accepted cost of that rare race is one extra failed action while the loop reconnects.
+    // A partial refresh no longer reaches useConnection's dead-binder detection (it returns instead
+    // of throwing), so the teardown that used to ride the throw path happens here. Cause chain, not
+    // the exception itself: the failure arrives user-friendly-mapped. Deliberately no holder CAS:
+    // the failing connection may already have been replaced, and the accepted cost of that rare
+    // race is one extra failed action while the loop reconnects.
+    private fun invalidateOnDeadConnection(refresh: BillingConnection.PurchaseRefresh) {
         val clientError = refresh.partialError?.let {
             (it as? BillingClientException) ?: (it.cause as? BillingClientException)
         }
@@ -436,6 +431,15 @@ class BillingManager @Inject constructor(
             log(TAG, WARN) { "Refresh reported the connection dead (${clientError.result.responseCode}), invalidating." }
             invalidations.trySend(Unit)
         }
+    }
+
+    // Everything a COMPLETED refresh owes the rest of the app, in one place: both the connect loop's
+    // initial refresh and manual refresh() calls run through it, so a Restore tap during an outage
+    // feeds the same bookkeeping the connect loop does. Only reached when refreshPurchases returned
+    // (it still throws when it found nothing AND a query failed — that path is the connect loop's /
+    // useConnection's).
+    private fun processReconciliation(refresh: BillingConnection.PurchaseRefresh) {
+        invalidateOnDeadConnection(refresh)
 
         if (!refresh.isComplete && !refresh.hasConfirmedProPurchase) {
             // A reconciliation that couldn't confirm Pro. Stamped with the refresh's COMMIT time,
@@ -535,6 +539,11 @@ class BillingManager @Inject constructor(
     suspend fun refreshStrict(): BillingData {
         log(TAG) { "refreshStrict()" }
         val fresh = useConnection { refreshPurchases() }
+        // A gate that hit a dying connection must still trigger the reconnect (the throw below
+        // bypasses useConnection's detection, which already returned), or every later purchase
+        // check keeps reusing the corpse. No-op on a complete refresh. The episode clock stays out
+        // of this path: an aborted gate is not a reconciliation outcome.
+        invalidateOnDeadConnection(fresh)
         if (!fresh.isComplete) {
             // partialError is set for every incomplete refresh; the fallback only exists so a
             // future incompleteness without a captured cause still fails closed instead of passing.

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/billing/BillingManager.kt
@@ -14,6 +14,7 @@ import eu.darken.myperm.common.flow.setupCommonEventHandlers
 import eu.darken.myperm.common.upgrade.core.billing.client.BillingClientException
 import eu.darken.myperm.common.upgrade.core.billing.client.BillingConnection
 import eu.darken.myperm.common.upgrade.core.billing.client.BillingConnectionProvider
+import eu.darken.myperm.common.upgrade.core.billing.client.isPurchased
 import eu.darken.myperm.common.upgrade.core.billing.client.redacted
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -73,13 +74,13 @@ class BillingManager @Inject constructor(
     private val failedOnce = MutableStateFlow(false)
     val isFailureSettled: Flow<Boolean> = failedOnce
 
-    // Fires once per failed connect-loop iteration: connection setup failure, the mandatory initial
-    // refreshPurchases erroring or timing out, an established connection dropping, an action-level
-    // invalidation (SERVICE_DISCONNECTED/SERVICE_TIMEOUT from any useConnection call), or an
-    // unexpected provider completion. Every one is a fresh reconciliation that couldn't confirm Pro.
-    // The connect loop retries these internally and downstream flows just go quiet, so without this
-    // explicit signal the grace episode clock (UpgradeRepoGplay.proUnconfirmedSince) would only
-    // advance on an explicit ON_RESUME refresh().
+    // Fires once per reconciliation that couldn't confirm Pro: a failed connect-loop iteration
+    // (connection setup failure, the mandatory initial refreshPurchases erroring or timing out, an
+    // established connection dropping, an action-level invalidation, an unexpected provider
+    // completion) — and, via processReconciliation, a refresh that COMPLETED but only partially,
+    // without a confirmed Pro purchase. The connect loop retries its failures internally and
+    // downstream flows just go quiet, so without this explicit signal the grace episode clock
+    // (UpgradeRepoGplay.proUnconfirmedSince) would only advance on an explicit ON_RESUME refresh().
     //
     // Each value is the failure's OCCURRENCE time (epoch millis). It has to be, not a bare Unit: the
     // channel buffers, and this feed and freshBillingData are separate flows with no cross-stream
@@ -121,13 +122,18 @@ class BillingManager @Inject constructor(
                                 // isFailureSettled forever with no retry. withTimeoutOrNull, NOT
                                 // withTimeout: TimeoutCancellationException is a
                                 // CancellationException and would kill this loop.
-                                withTimeoutOrNull(INITIAL_REFRESH_TIMEOUT_MS) {
+                                val initialRefresh = withTimeoutOrNull(INITIAL_REFRESH_TIMEOUT_MS) {
                                     connection.refreshPurchases()
                                 } ?: throw BillingException("Initial purchase refresh timed out")
 
                                 failStreak = 0
                                 connectionHolder.value = connection
                                 log(TAG, INFO) { "Billing connection established" }
+                                // AFTER publishing: a partial refresh is still a usable connection
+                                // (a pending-only cold start must not starve billingData), but its
+                                // bookkeeping — episode clock, dead-binder teardown — has to run,
+                                // and an invalidation may only tear down an INSTALLED connection.
+                                processReconciliation(initialRefresh)
                             }
                             // The provider flow stays open for the connection's lifetime; a normal
                             // completion means the connection is gone without an error — treat it
@@ -214,7 +220,7 @@ class BillingManager @Inject constructor(
         .shareIn(scope, WhileSubscribed(3000L, 0L), replay = 1)
 
     val billingData: Flow<BillingData> = purchases
-        .map { BillingData(purchases = it) }
+        .map { BillingData.from(it) }
         .shareIn(scope, WhileSubscribed(3000L, 0L), replay = 1)
 
     val purchaseFailures: Flow<BillingResult> = connectionHolder
@@ -235,7 +241,10 @@ class BillingManager @Inject constructor(
                 // every emission here is a real Play round-trip the grace bookkeeping needs.
                 .resubscribeOnFailure("freshBillingData")
         }
-        .map { FreshData(data = BillingData(purchases = it.purchases), isFullSnapshot = it.isFullSnapshot, occurredAt = it.occurredAt) }
+        // Through from() like every other exit, although the connection only ever puts PURCHASED
+        // purchases on this stream: if that invariant ever broke, splitting keeps the grace
+        // bookkeeping from stamping a pending payment as a confirmation.
+        .map { FreshData(data = BillingData.from(it.purchases), isFullSnapshot = it.isFullSnapshot, occurredAt = it.occurredAt) }
         .setupCommonEventHandlers(TAG) { "freshBillingData" }
         // Same belt as `purchases`: an Eagerly shared flow that dies stays dead, and this one feeds
         // both the grace bookkeeping and the ack collector's re-drive signal.
@@ -292,6 +301,14 @@ class BillingManager @Inject constructor(
     // -data signals.
     private suspend fun runAckPass(purchases: Collection<Purchase>) {
         val needAck = purchases.filter {
+            // The canonical list carries pending payments too. Play rejects acknowledging one
+            // PERMANENTLY, so an unfiltered pass would fire a bug report for every pending purchase,
+            // every pass — and there is nothing to acknowledge until the payment completes anyway.
+            if (!it.isPurchased) {
+                log(TAG) { "Not acknowledgeable yet: ${it.redacted()}" }
+                return@filter false
+            }
+
             val needsAck = !it.isAcknowledged
 
             if (needsAck) log(TAG) { "Needs ACK: ${it.redacted()}" }
@@ -401,6 +418,35 @@ class BillingManager @Inject constructor(
         }
     }
 
+    // Everything a COMPLETED refresh owes the rest of the app, in one place: both the connect loop's
+    // initial refresh and manual refresh() calls run through it, so a Restore tap during an outage
+    // feeds the same bookkeeping the connect loop does. Only reached when refreshPurchases returned
+    // (it still throws when it found nothing AND a query failed — that path is the connect loop's /
+    // useConnection's).
+    private fun processReconciliation(refresh: BillingConnection.PurchaseRefresh) {
+        // A partial refresh no longer reaches useConnection's dead-binder detection (it returns
+        // instead of throwing), so the teardown that used to ride the throw path happens here.
+        // Cause chain, not the exception itself: the failure arrives user-friendly-mapped.
+        // Deliberately no holder CAS: the failing connection may already have been replaced, and
+        // the accepted cost of that rare race is one extra failed action while the loop reconnects.
+        val clientError = refresh.partialError?.let {
+            (it as? BillingClientException) ?: (it.cause as? BillingClientException)
+        }
+        if (clientError != null && clientError.result.responseCode in INVALIDATING_CODES) {
+            log(TAG, WARN) { "Refresh reported the connection dead (${clientError.result.responseCode}), invalidating." }
+            invalidations.trySend(Unit)
+        }
+
+        if (!refresh.isComplete && !refresh.hasConfirmedProPurchase) {
+            // A reconciliation that couldn't confirm Pro. Stamped with the refresh's COMMIT time,
+            // never now-at-send: a confirmation that committed between this refresh and the send
+            // (e.g. a pending payment completing) must stay NEWER than this failure, or the grace
+            // episode it closed would be reopened.
+            log(TAG, WARN) { "Partial refresh without a confirmed Pro purchase at ${refresh.occurredAt}" }
+            connectionFailuresChannel.trySend(refresh.occurredAt)
+        }
+    }
+
     private suspend fun <T> useConnection(action: suspend BillingConnection.() -> T): T {
         // Every caller here is active demand (opening the upgrade screen, restore/buy taps,
         // purchase acks) — cut a pending reconnect backoff short. A no-op while healthy.
@@ -479,18 +525,24 @@ class BillingManager @Inject constructor(
         // shared upgradeInfo replay cache. The freshBillingData emission happens inside the
         // reducer's commit, in commit order — not here.
         val fresh = useConnection { refreshPurchases() }
-        return BillingData(purchases = fresh.purchases)
+        processReconciliation(fresh)
+        return BillingData.from(fresh.purchases)
     }
 
-    // Strict SUBS-only query for the pre-purchase subscription gate: unlike refresh(), a failure
-    // here propagates (user-friendly-mapped) instead of being masked by the other product type.
-    suspend fun querySubscriptions(): Collection<Purchase> = try {
-        useConnection { querySubscriptions() }
-    } catch (e: CancellationException) {
-        throw e
-    } catch (e: Exception) {
-        log(TAG, WARN) { "querySubscriptions() failed: ${e.asLog()}" }
-        throw e.tryMapUserFriendly()
+    // Strict variant for the pre-purchase gates: unlike refresh(), anything short of a COMPLETE
+    // reconciliation throws (user-friendly-mapped) instead of returning what it happened to find —
+    // a gate must be able to tell "not owned" apart from "couldn't verify" and fail closed.
+    suspend fun refreshStrict(): BillingData {
+        log(TAG) { "refreshStrict()" }
+        val fresh = useConnection { refreshPurchases() }
+        if (!fresh.isComplete) {
+            // partialError is set for every incomplete refresh; the fallback only exists so a
+            // future incompleteness without a captured cause still fails closed instead of passing.
+            val error = fresh.partialError ?: BillingException("Purchase refresh was incomplete")
+            log(TAG, WARN) { "refreshStrict() incomplete: ${error.asLog()}" }
+            throw error.tryMapUserFriendly()
+        }
+        return BillingData.from(fresh.purchases)
     }
 
     companion object {

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/billing/PendingPurchaseBillingException.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/billing/PendingPurchaseBillingException.kt
@@ -1,0 +1,11 @@
+package eu.darken.myperm.common.upgrade.core.billing
+
+/**
+ * A purchase can't proceed because the account already has a payment Play is still processing.
+ *
+ * Typed so the UI can answer with the informational pending dialog instead of the already-owned
+ * error and its restore tips: restoring cannot help — Play refuses to re-sell a product with a
+ * pending payment, and the entitlement arrives on its own once the payment clears.
+ */
+class PendingPurchaseBillingException(cause: Throwable? = null) :
+    BillingException("A purchase with a pending payment already exists.", cause)

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/billing/client/BillingClientExtensions.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/billing/client/BillingClientExtensions.kt
@@ -9,6 +9,21 @@ internal val BillingResult.isSuccess: Boolean
     get() = responseCode == BillingClient.BillingResponseCode.OK
 
 /**
+ * Owned right now. The ONLY state that may grant an entitlement, stamp the Pro grace cache or be
+ * acknowledged — a PENDING purchase is a payment Play is still processing, and acknowledging one is
+ * rejected permanently.
+ */
+internal val Purchase.isPurchased: Boolean
+    get() = purchaseState == Purchase.PurchaseState.PURCHASED
+
+/**
+ * Worth carrying in our state at all: owned, or a payment in progress the user should see. Anything
+ * else (UNSPECIFIED_STATE) is dropped at ingestion — it is neither.
+ */
+internal val Purchase.isRelevant: Boolean
+    get() = isPurchased || purchaseState == Purchase.PurchaseState.PENDING
+
+/**
  * Log-safe rendering of a [Purchase].
  *
  * `Purchase.toString()` dumps the original response JSON, which carries the purchase token and the

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/core/billing/client/BillingConnection.kt
@@ -7,7 +7,6 @@ import com.android.billingclient.api.BillingClient.BillingResponseCode
 import com.android.billingclient.api.BillingFlowParams
 import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.Purchase
-import com.android.billingclient.api.Purchase.PurchaseState
 import com.android.billingclient.api.QueryProductDetailsParams
 import com.android.billingclient.api.QueryProductDetailsResult
 import com.android.billingclient.api.QueryPurchasesParams
@@ -41,11 +40,11 @@ class BillingConnection(
     private val skuTypeOf: (String) -> Sku.Type? = DEFAULT_SKU_TYPE_RESOLVER,
 ) {
 
-    // A purchase proven by an onPurchasesUpdated success event. Additive only: events prove
-    // ownership, never absence. `gen` orders it against queries (a query that STARTED before this
-    // event must not clear it); `type` is resolved at ingestion so a later per-type query that
-    // confirms absence can supersede it (null = product unknown to this app, only a complete
-    // refresh may clear it).
+    // A purchase (owned or with a pending payment) proven by an onPurchasesUpdated success event.
+    // Additive only: events prove existence, never absence. `gen` orders it against queries (a
+    // query that STARTED before this event must not clear it); `type` is resolved at ingestion so a
+    // later per-type query that confirms absence can supersede it (null = product unknown to this
+    // app, only a complete refresh may clear it).
     data class OverlayEntry(
         val purchase: Purchase,
         val gen: Long,
@@ -64,11 +63,11 @@ class BillingConnection(
     ) {
 
         internal fun withEvent(
-            purchased: Collection<Purchase>,
+            relevant: Collection<Purchase>,
             typeOf: (String) -> Sku.Type?,
         ): ReducerState {
             val gen = eventGen + 1
-            val entries = purchased.map { purchase ->
+            val entries = relevant.map { purchase ->
                 OverlayEntry(
                     purchase = purchase,
                     gen = gen,
@@ -169,10 +168,13 @@ class BillingConnection(
                 "onPurchasesUpdated(code=${result.responseCode}, message=${result.debugMessage}, " +
                     "purchases=${purchases?.redacted()})"
             }
-            // PENDING purchases must never surface as owned (or stamp the Pro grace cache).
-            val purchased = purchases.orEmpty().filter { it.purchaseState == PurchaseState.PURCHASED }
+            // The reducer carries PENDING purchases too (the UI must be able to show a payment in
+            // progress), but the fresh stream stays PURCHASED-only: it feeds the entitlement and
+            // grace bookkeeping, which must never see a payment Play hasn't completed.
+            val relevant = purchases.orEmpty().filter { it.isRelevant }
+            val purchased = relevant.filter { it.isPurchased }
             synchronized(reducerLock) {
-                state.value = state.value.withEvent(purchased, skuTypeOf)
+                state.value = state.value.withEvent(relevant, skuTypeOf)
                 if (purchased.isNotEmpty()) {
                     freshUpdatesChannel.trySend(FreshUpdate(purchased, isFullSnapshot = false))
                 }
@@ -193,12 +195,29 @@ class BillingConnection(
         failureChannel.close()
     }
 
-    // The purchases of a refresh plus whether it covered both product types: a partial result (one
-    // query failed) is still authoritative for what it FOUND, but must not be treated as proof of
-    // absence for the type that couldn't be checked.
+    // The full outcome of a refresh: what it committed, what it actually CONFIRMED, and how far it
+    // got. A partial result (one query failed) is still authoritative for what it found, but must
+    // not be treated as proof of absence for the type that couldn't be checked — so callers that
+    // need to fail closed, or to feed the grace episode clock, get the provenance instead of having
+    // to infer it from the merged view.
     data class PurchaseRefresh(
+        // The committed reducer state (queries merged with retained snapshots and surviving
+        // events) — the same view the reactive purchases flow emits.
         val purchases: Collection<Purchase>,
+        // ONLY what these queries returned: never retained state of a failed type, so a consumer
+        // can tell "Play said so just now" from "we still remember this".
+        val confirmed: Collection<Purchase> = emptyList(),
+        // A confirmed PURCHASED purchase of a product this app knows. Fail-safe default: "we
+        // couldn't confirm Pro" is the direction that keeps the grace bookkeeping honest.
+        val hasConfirmedProPurchase: Boolean = false,
         val isComplete: Boolean,
+        // Commit time under reducerLock — the same instant stamped on this refresh's FreshUpdate,
+        // so a confirmation and a later failure signal are ordered by when they HAPPENED.
+        val occurredAt: Long = System.currentTimeMillis(),
+        // Why the refresh is incomplete (the failed type's already user-friendly-mapped
+        // exception), null when complete. Carried rather than thrown: a partial refresh that found
+        // something is still useful, only the caller can decide whether partial is good enough.
+        val partialError: Throwable? = null,
     )
 
     // Serializes concurrent refreshes (manual, background, auto-restore): an older query that got
@@ -214,8 +233,8 @@ class BillingConnection(
         coroutineScope {
             log(TAG) { "refreshPurchases()" }
             val genAtQueryStart = state.value.eventGen
-            val iapJob = async { queryPurchasedProducts(BillingClient.ProductType.INAPP) }
-            val subJob = async { queryPurchasedProducts(BillingClient.ProductType.SUBS) }
+            val iapJob = async { queryRelevantProducts(BillingClient.ProductType.INAPP) }
+            val subJob = async { queryRelevantProducts(BillingClient.ProductType.SUBS) }
             val iap = iapJob.await()
             val sub = subJob.await()
             log(TAG) { "Refreshed IAPs=${iap.getOrNull()?.redacted()}, SUBs=${sub.getOrNull()?.redacted()}" }
@@ -224,6 +243,12 @@ class BillingConnection(
             // authoritative even when its sibling failed — verified absence (e.g. a refunded IAP)
             // must not be discarded just because the SUB query errored.
             val isComplete = iap.isSuccess && sub.isSuccess
+            // Only what the queries CONFIRMED as owned — retained stale data of a failed type, and
+            // pending payments, stay out (both would keep re-stamping the grace window).
+            val confirmed = (iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty())
+                .filter { it.isPurchased }
+                .sortedByDescending { it.purchaseTime }
+            var committedAt = 0L
             val committed = synchronized(reducerLock) {
                 val next = state.value.withQueryResults(
                     iap = iap.getOrNull(),
@@ -231,17 +256,18 @@ class BillingConnection(
                     genAtQueryStart = genAtQueryStart,
                 )
                 state.value = next
+                committedAt = System.currentTimeMillis()
                 if (iap.isSuccess || sub.isSuccess) {
-                    // Only what the queries CONFIRMED — retained stale data of a failed type stays
-                    // out of the fresh stream (it would keep re-stamping the grace window).
-                    val confirmed = (iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty())
-                        .sortedByDescending { it.purchaseTime }
-                    // A surviving overlay entry (purchase event newer than the query start, or of
-                    // a failed type) means this result does NOT prove total absence: it must not
-                    // count as a full snapshot, or an empty query racing a fresh purchase event
-                    // would start a false unconfirmed-grace episode.
-                    val provesAbsence = isComplete && next.overlay.isEmpty()
-                    freshUpdatesChannel.trySend(FreshUpdate(confirmed, isFullSnapshot = provesAbsence))
+                    // A surviving OWNED overlay entry (purchase event newer than the query start,
+                    // or of a failed type) means this result does NOT prove total absence: it must
+                    // not count as a full snapshot, or an empty query racing a fresh purchase event
+                    // would start a false unconfirmed-grace episode. A surviving PENDING entry
+                    // proves nothing about ownership, so it must not suppress the bookkeeping
+                    // either — a payment in progress would otherwise freeze the episode clock.
+                    val provesAbsence = isComplete && next.overlay.none { it.purchase.isPurchased }
+                    freshUpdatesChannel.trySend(
+                        FreshUpdate(confirmed, isFullSnapshot = provesAbsence, occurredAt = committedAt)
+                    )
                 }
                 next
             }
@@ -249,31 +275,42 @@ class BillingConnection(
             // Support-log anchor, at INFO because purchase complaints arrive as debug recordings.
             // Logs what these queries CONFIRMED, kept distinct from the committed view: merged()
             // retains a failed type's previous purchases, so reporting it as "what Play returned"
-            // would be the same false-certainty trap the copy elsewhere had to fix. Product IDs
-            // only -- never the Purchase, which carries order and token data.
+            // would be the same false-certainty trap the copy elsewhere had to fix. Pending ids are
+            // listed separately — "bought it, still not Pro" reports are exactly this state.
+            // Product IDs only -- never the Purchase, which carries order and token data.
             log(TAG, INFO) {
-                val confirmedIds = (iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty()).flatMap { it.products }
-                "refreshPurchases(): confirmed=$confirmedIds, isComplete=$isComplete, " +
+                val returned = iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty()
+                val confirmedIds = returned.filter { it.isPurchased }.flatMap { it.products }
+                val pendingIds = returned.filterNot { it.isPurchased }.flatMap { it.products }
+                "refreshPurchases(): confirmed=$confirmedIds, pending=$pendingIds, isComplete=$isComplete, " +
                     "iapOk=${iap.isSuccess}, subOk=${sub.isSuccess}, merged=${committed.merged().size}"
             }
 
             // Throws when nothing was found and a query failed, so the caller can tell "not
             // owned" apart from "couldn't verify".
-            combinePurchaseResults(iap, sub)
+            combinePurchaseResults(iap, sub, skuTypeOf)
 
             PurchaseRefresh(
                 purchases = committed.merged(),
+                confirmed = confirmed,
+                hasConfirmedProPurchase = confirmed.any { purchase ->
+                    purchase.products.any { skuTypeOf(it) != null }
+                },
                 isComplete = isComplete,
+                occurredAt = committedAt,
+                partialError = iap.exceptionOrNull() ?: sub.exceptionOrNull(),
             )
         }
     }
 
     // Never throws except on cancellation, so a single failing product-type query doesn't cancel
     // the sibling query (or the coroutineScope). The exception is already user-friendly-mapped.
-    private suspend fun queryPurchasedProducts(
+    // Returns owned AND pending purchases; the split by state happens where it matters (fresh
+    // stream, entitlement mapping), so a pending payment stays visible instead of vanishing here.
+    private suspend fun queryRelevantProducts(
         @BillingClient.ProductType type: String,
     ): Result<Collection<Purchase>> = try {
-        Result.success(queryPurchases(type).filter { it.purchaseState == PurchaseState.PURCHASED })
+        Result.success(queryPurchases(type).filter { it.isRelevant })
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {
@@ -307,37 +344,6 @@ class BillingConnection(
         return purchaseData
     }
 
-    // Strict SUBS-only query for the pre-purchase subscription gate: unlike refreshPurchases(),
-    // a failure propagates (no cross-type tolerance) — callers must be able to fail closed on
-    // "couldn't verify". Commits through the reducer like any query, so the reactive purchases
-    // flow picks up the fresh renewal state, and emits a partial fresh update: it proves what the
-    // SUBS query found, never the absence of anything it didn't cover.
-    suspend fun querySubscriptions(): Collection<Purchase> = refreshMutex.withLock {
-        log(TAG) { "querySubscriptions()" }
-        val genAtQueryStart = state.value.eventGen
-        val subs = queryPurchases(BillingClient.ProductType.SUBS)
-            .filter { it.purchaseState == PurchaseState.PURCHASED }
-        val committed = synchronized(reducerLock) {
-            val next = state.value.withQueryResults(
-                iap = null,
-                sub = subs,
-                genAtQueryStart = genAtQueryStart,
-            )
-            state.value = next
-            freshUpdatesChannel.trySend(FreshUpdate(subs, isFullSnapshot = false))
-            next
-        }
-        // The COMMITTED view, not the raw response: a purchase event that arrived after the query
-        // started survives the commit as a newer overlay and must reach the gate too — otherwise a
-        // just-purchased renewing sub could slip past the fail-closed double-billing check.
-        // Non-IAP overlays only; untyped (unknown product) entries stay in on the safe side.
-        val byToken = LinkedHashMap<String, Purchase>()
-        subs.forEach { byToken[it.purchaseToken] = it }
-        committed.overlay
-            .filter { it.type != Sku.Type.IAP }
-            .forEach { byToken[it.purchase.purchaseToken] = it.purchase }
-        byToken.values.sortedByDescending { it.purchaseTime }
-    }
     suspend fun acknowledgePurchase(purchase: Purchase): BillingResult {
         val ack = AcknowledgePurchaseParams.newBuilder().apply {
             setPurchaseToken(purchase.purchaseToken)
@@ -529,16 +535,22 @@ class BillingConnection(
             OurSku.PRO_SKUS.singleOrNull { it.id == productId }?.type
         }
 
-        // Combines the two product-type query results: a purchase found by either type is
-        // authoritative; an error is only propagated when nothing was found, so callers can tell
-        // "not owned" apart from "couldn't verify one product type". Treating any found purchase
-        // as authoritative is safe because every product this app sells is a Pro SKU (see
-        // OurSku.PRO_SKUS). Pure and unit-tested.
+        // Combines the two product-type query results: an error is only propagated when the refresh
+        // learned nothing usable, so callers can tell "not owned" apart from "couldn't verify one
+        // product type". A PURCHASED result of ANY product suppresses the error — every product
+        // this app sells is a Pro SKU (see OurSku.PRO_SKUS), so it is by construction relevant. A
+        // PENDING result only counts when it maps to a KNOWN Pro SKU: it grants nothing, and an
+        // unknown pending product says nothing about the type whose query failed, so treating it
+        // as a find would swallow a real "couldn't verify". Pure and unit-tested.
         internal fun combinePurchaseResults(
             iap: Result<Collection<Purchase>>,
             sub: Result<Collection<Purchase>>,
+            typeOf: (String) -> Sku.Type? = DEFAULT_SKU_TYPE_RESOLVER,
         ): Collection<Purchase> {
-            val found = iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty()
+            val returned = iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty()
+            val found = returned.filter { purchase ->
+                purchase.isPurchased || purchase.products.any { typeOf(it) != null }
+            }
             return when {
                 found.isNotEmpty() -> found.sortedByDescending { it.purchaseTime }
                 else -> {

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeEvents.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeEvents.kt
@@ -13,5 +13,14 @@ sealed class UpgradeEvents {
      */
     data object RestoreInconclusive : UpgradeEvents()
     data object SubscriptionStillRenewing : UpgradeEvents()
-    data object SubscriptionCheckFailed : UpgradeEvents()
+
+    /**
+     * Play answered, no completed purchase exists, but a payment is still being processed. Purely
+     * informational: nothing to fix, nothing to restore — Pro unlocks by itself once Play clears
+     * the payment, and a new purchase would be rejected (or double-charge) in the meantime.
+     */
+    data object PurchasePending : UpgradeEvents()
+
+    /** The pre-purchase check with Play didn't finish, so the purchase was not started. */
+    data object PurchaseCheckFailed : UpgradeEvents()
 }

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeOwnership.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeOwnership.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.Autorenew
+import androidx.compose.material.icons.twotone.HourglassTop
 import androidx.compose.material.icons.twotone.Verified
 import androidx.compose.material3.Button
 import androidx.compose.material3.CardDefaults
@@ -101,8 +102,10 @@ internal fun UpgradeOwnershipContent(
                 Button(
                     onClick = onIap,
                     // Not gated on iapEnabled: prices may have failed to load while the purchase
-                    // itself would work (the billing flow re-queries details on launch).
-                    enabled = switchUnlocked && uiState.busy == null,
+                    // itself would work (the billing flow re-queries details on launch). A pending
+                    // payment does lock it — Play would reject the purchase, and the pending card
+                    // above carries the explanation.
+                    enabled = switchUnlocked && uiState.busy == null && !uiState.hasPendingPurchase,
                     modifier = Modifier
                         .fillMaxWidth()
                         .testTag(UpgradeScreenTags.GPLAY_IAP),
@@ -242,6 +245,38 @@ internal fun UpgradeGraceCard(
                 Text(stringResource(R.string.upgrade_screen_restore_purchase_action))
             }
         }
+    }
+}
+
+// Shown to EVERY audience while Google Play is still processing a payment: an acquisition user who
+// just bought, an owner buying the other product, and a grace user whose Pro is running out — all
+// three have purchase actions locked and need the same explanation. Calm reassurance styling like
+// the grace card: nothing is wrong, the payment just isn't done.
+@Composable
+internal fun PendingPurchaseCard(
+    modifier: Modifier = Modifier,
+) {
+    UpgradeSectionCard(
+        title = stringResource(R.string.upgrade_screen_pending_card_title),
+        icon = Icons.TwoTone.HourglassTop,
+        modifier = modifier.testTag(UpgradeScreenTags.GPLAY_PENDING),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        ),
+    ) {
+        Text(
+            text = stringResource(R.string.upgrade_screen_pending_card_body),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun PendingPurchaseCardPreview() {
+    PreviewWrapper {
+        PendingPurchaseCard()
     }
 }
 

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeScreen.kt
@@ -64,6 +64,7 @@ fun UpgradeScreenHost(
     var showRestoreInconclusive by rememberSaveable { mutableStateOf(false) }
     var showStillRenewing by rememberSaveable { mutableStateOf(false) }
     var showCheckFailed by rememberSaveable { mutableStateOf(false) }
+    var showPurchasePending by rememberSaveable { mutableStateOf(false) }
 
     LaunchedEffect(vm) {
         vm.events.collect { event ->
@@ -77,7 +78,8 @@ fun UpgradeScreenHost(
                 UpgradeEvents.RestoreFailed -> showRestoreFailed = true
                 UpgradeEvents.RestoreInconclusive -> showRestoreInconclusive = true
                 UpgradeEvents.SubscriptionStillRenewing -> showStillRenewing = true
-                UpgradeEvents.SubscriptionCheckFailed -> showCheckFailed = true
+                UpgradeEvents.PurchaseCheckFailed -> showCheckFailed = true
+                UpgradeEvents.PurchasePending -> showPurchasePending = true
             }
         }
     }
@@ -128,13 +130,17 @@ fun UpgradeScreenHost(
     if (showCheckFailed) {
         AlertDialog(
             onDismissRequest = { showCheckFailed = false },
-            text = { Text(text = stringResource(R.string.upgrade_screen_sub_check_failed_message)) },
+            text = { Text(text = stringResource(R.string.upgrade_screen_purchase_check_failed_message)) },
             confirmButton = {
                 TextButton(onClick = { showCheckFailed = false }) {
                     Text(text = stringResource(R.string.general_close_action))
                 }
             },
         )
+    }
+
+    if (showPurchasePending) {
+        PurchasePendingDialog(onDismiss = { showPurchasePending = false })
     }
 
     val uiState by vm.state.collectAsStateWithLifecycle()
@@ -179,6 +185,34 @@ internal fun RestoreFailedDialog(
             }
         },
     )
+}
+
+/**
+ * Shown when Play is still processing a payment. Purely informational: there is nothing to fix, no
+ * purchase to restore and no support case — the entitlement arrives on its own once the payment
+ * clears, so the dialog offers only a dismiss.
+ */
+@Composable
+internal fun PurchasePendingDialog(
+    onDismiss: () -> Unit = {},
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        text = { Text(text = stringResource(R.string.upgrade_screen_pending_dialog_message)) },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(R.string.general_close_action))
+            }
+        },
+    )
+}
+
+@Preview2
+@Composable
+private fun PurchasePendingDialogPreview() {
+    PreviewWrapper {
+        PurchasePendingDialog()
+    }
 }
 
 /**
@@ -274,6 +308,12 @@ internal fun UpgradeScreen(
                     )
                 }
             }
+
+            // Above the ownership/acquisition split, because a pending payment cuts across it: the
+            // buyer waiting for their first Pro purchase, the owner switching products and the
+            // grace user (whose offers box is hidden entirely) all need it, and it is the reason
+            // their purchase buttons are locked.
+            if (loaded?.hasPendingPurchase == true) PendingPurchaseCard()
 
             if (ownedState != null) {
                 UpgradeOwnershipContent(
@@ -475,6 +515,24 @@ private fun UpgradeScreenReturningBuyerPreview() {
                 iapEnabled = true,
                 iapPrice = "$24.99",
                 wasPreviouslyPro = true,
+            ),
+        )
+    }
+}
+
+// The acquisition variant of the pending state: card above the offers, both buy buttons locked.
+@Preview2
+@Composable
+private fun UpgradeScreenPendingPreview() {
+    PreviewWrapper {
+        UpgradeScreen(
+            uiState = GplayUpgradeUiState.Loaded(
+                subscriptionAction = SubscriptionAction.STANDARD,
+                subscriptionEnabled = false,
+                subscriptionPrice = "$12.99",
+                iapEnabled = false,
+                iapPrice = "$24.99",
+                hasPendingPurchase = true,
             ),
         )
     }

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeUiState.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeUiState.kt
@@ -23,6 +23,9 @@ internal sealed interface GplayUpgradeUiState {
         val ownership: Ownership = Ownership(),
         val grace: GraceHint? = null,
         val wasPreviouslyPro: Boolean = false,
+        // A payment Google Play is still processing. SKU-agnostic on purpose: the card explains the
+        // wait and both purchase actions lock, regardless of which product is pending.
+        val hasPendingPurchase: Boolean = false,
         val busy: BusyOp? = null,
     ) : GplayUpgradeUiState
 }
@@ -73,12 +76,18 @@ internal fun UpgradeRepoGplay.Info.toOwnership() = Ownership(
         ?.let { subs -> SubscriptionOwnership(isAutoRenewing = subs.any { it.purchase.isAutoRenewing }) },
 )
 
+// Any Pro payment Play is still processing. No per-product flag: the one-time purchase and the
+// subscription are alternatives, so a pending payment for either one must lock both — completing
+// both would charge the user twice for the same thing.
+internal fun UpgradeRepoGplay.Info.toPendingFlag(): Boolean = pendingSkus.isNotEmpty()
+
 internal fun toLoadedState(
     iap: SkuDetails?,
     sub: SkuDetails?,
     ownership: Ownership,
     grace: GraceHint? = null,
     wasPreviouslyPro: Boolean = false,
+    hasPendingPurchase: Boolean = false,
     busy: BusyOp? = null,
 ): GplayUpgradeUiState.Loaded {
     val iapOffer = iap?.details?.oneTimePurchaseOfferDetails
@@ -97,15 +106,18 @@ internal fun toLoadedState(
         },
         // Any running entitlement operation (restore, manual or the invisible already-owned
         // recovery, and purchases) pauses the buy actions too — starting a purchase while an
-        // entitlement is being reconciled just races Play into ITEM_ALREADY_OWNED.
+        // entitlement is being reconciled just races Play into ITEM_ALREADY_OWNED. A pending
+        // payment locks BOTH offers for the same reason the card explains: Play refuses the
+        // re-purchase, and the alternative product would double-charge for the same features.
         subscriptionEnabled = (subOffer != null || subOfferTrial != null) &&
-            ownership.subscription == null && busy == null,
+            ownership.subscription == null && busy == null && !hasPendingPurchase,
         subscriptionPrice = subOffer?.pricingPhases?.pricingPhaseList?.lastOrNull()?.formattedPrice,
-        iapEnabled = iapOffer != null && !ownership.hasIap && busy == null,
+        iapEnabled = iapOffer != null && !ownership.hasIap && busy == null && !hasPendingPurchase,
         iapPrice = iapOffer?.formattedPrice,
         ownership = ownership,
         grace = grace,
         wasPreviouslyPro = wasPreviouslyPro,
+        hasPendingPurchase = hasPendingPurchase,
         busy = busy,
     )
 }

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModel.kt
@@ -19,6 +19,7 @@ import eu.darken.myperm.common.upgrade.core.OurSku
 import eu.darken.myperm.common.upgrade.core.UpgradeRepoGplay
 import eu.darken.myperm.common.upgrade.core.billing.GplayServiceUnavailableException
 import eu.darken.myperm.common.upgrade.core.billing.OfferUnavailableBillingException
+import eu.darken.myperm.common.upgrade.core.billing.PendingPurchaseBillingException
 import eu.darken.myperm.common.upgrade.core.billing.Sku
 import eu.darken.myperm.common.upgrade.core.billing.SkuDetails
 import kotlinx.coroutines.CancellationException
@@ -161,8 +162,10 @@ class UpgradeViewModel @Inject constructor(
             null
         }
         // Owners and grace users don't depend on offer prices: their status and management
-        // actions render immediately and price problems are not their problem.
-        val priceIndependent = ownership.ownsAnything || grace != null
+        // actions render immediately and price problems are not their problem. A user waiting on a
+        // pending payment is in the same position — the card is their answer, and both offers are
+        // locked anyway, so a price failure must not replace it with an error screen.
+        val priceIndependent = ownership.ownsAnything || grace != null || current.pendingSkus.isNotEmpty()
 
         val done = queries as? SkuQueries.Done
         if (done == null) {
@@ -258,6 +261,7 @@ class UpgradeViewModel @Inject constructor(
             ownership = ownership,
             grace = grace,
             wasPreviouslyPro = wasEverPro && !current.isPro,
+            hasPendingPurchase = current.toPendingFlag(),
             // This ViewModel's own action wins; otherwise a launch started elsewhere (previous VM
             // instance, e.g. across a rotation — the launch lives on AppScope) or the repo's
             // invisible already-owned auto-restore still pauses the entitlement actions here.
@@ -303,44 +307,78 @@ class UpgradeViewModel @Inject constructor(
         return true
     }
 
+    // Outcome of the pre-purchase check with Play. Both purchase paths share it: they buy
+    // alternatives of the same entitlement from the same account, so a check only one of them runs
+    // is exactly how a double charge slips through. [Blocked] means the user was already told why.
+    private sealed interface PurchaseGate {
+        data class Clear(val info: UpgradeRepoGplay.Info) : PurchaseGate
+        data object Blocked : PurchaseGate
+    }
+
+    // Fails closed: no fresh, complete answer from Play (error, timeout) means no purchase. Bounded,
+    // because the repo waits for a healthy connection indefinitely and a tap must not park the
+    // single-flight guard through an outage.
+    private suspend fun runPurchaseGate(): PurchaseGate {
+        val info = try {
+            withTimeoutOrNull(VERIFY_TIMEOUT_MS) { upgradeRepo.verifyPurchaseStateNow() }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Purchase verification errored: ${e.asLog()}" }
+            errorEvents.tryEmit(e)
+            return PurchaseGate.Blocked
+        }
+        if (info == null) {
+            log(TAG, WARN) { "Purchase verification timed out" }
+            events.tryEmit(UpgradeEvents.PurchaseCheckFailed)
+            return PurchaseGate.Blocked
+        }
+        if (info.pendingSkus.isNotEmpty()) {
+            // Play rejects a purchase while it is still processing a payment for this account, and
+            // the alternative product would charge twice for the same features.
+            log(TAG, INFO) { "Purchase blocked: a payment is still pending" }
+            events.tryEmit(UpgradeEvents.PurchasePending)
+            return PurchaseGate.Blocked
+        }
+        return PurchaseGate.Clear(info)
+    }
+
+    // A launch that failed on a pending payment is not an error the user can act on: it gets the
+    // informational dialog instead of the already-owned copy and its restore tips.
+    private fun onLaunchError(error: Throwable) {
+        if (error is PendingPurchaseBillingException) {
+            events.tryEmit(UpgradeEvents.PurchasePending)
+        } else {
+            errorEvents.tryEmit(error)
+        }
+    }
+
     fun onGoIap(activity: Activity) {
         log(TAG) { "onGoIap($activity)" }
         launch {
             // Single-flight: repeated taps must not stack verifications or billing launches.
             if (!acquireOp(BusyOp.IAP)) return@launch
             try {
-                // Hard gate against double-billing: verify against a FRESH SUBS-only query — the
-                // replayed upgradeInfo can be stale or built from partial results. Fails closed:
-                // no verified "not set to renew" (or no sub at all), no one-time purchase.
-                val subscriptions = try {
-                    withTimeoutOrNull(VERIFY_TIMEOUT_MS) { upgradeRepo.queryCurrentSubscriptions() }
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    log(TAG, WARN) { "Subscription verification errored: ${e.asLog()}" }
-                    errorEvents.tryEmit(e)
+                val gate = runPurchaseGate()
+                if (gate !is PurchaseGate.Clear) return@launch
+                // Hard gate against double-billing, against the FRESH result — the replayed
+                // upgradeInfo can be stale or built from partial results. Asked of the RAW
+                // purchases (see Info.hasAutoRenewingSubscription), never of the mapped upgrades:
+                // a renewing subscription with an unknown or legacy product ID must block the
+                // one-time purchase too, or the user pays for Pro twice.
+                if (gate.info.hasAutoRenewingSubscription) {
+                    log(TAG, INFO) { "IAP purchase blocked: subscription is still set to renew" }
+                    events.tryEmit(UpgradeEvents.SubscriptionStillRenewing)
                     return@launch
                 }
-                when {
-                    subscriptions == null -> {
-                        log(TAG, WARN) { "Subscription verification timed out" }
-                        events.tryEmit(UpgradeEvents.SubscriptionCheckFailed)
-                    }
-
-                    subscriptions.any { it.isAutoRenewing } -> {
-                        log(TAG, INFO) { "IAP purchase blocked: subscription is still set to renew" }
-                        events.tryEmit(UpgradeEvents.SubscriptionStillRenewing)
-                    }
-
-                    // Suspends until the Play sheet launch resolved, so the single-flight guard
-                    // covers the whole tap-to-sheet window, not just the verification.
-                    else -> upgradeRepo.launchBillingFlowNow(
-                        activity,
-                        OurSku.Iap.PRO_UPGRADE,
-                        null,
-                        onError = errorEvents::tryEmit,
-                    )
-                }
+                // Suspends until the Play sheet launch resolved, so the single-flight guard covers
+                // the whole tap-to-sheet window, not just the verification.
+                upgradeRepo.launchBillingFlowNow(
+                    activity,
+                    OurSku.Iap.PRO_UPGRADE,
+                    null,
+                    onError = ::onLaunchError,
+                )
             } finally {
                 activeOp.value = null
             }
@@ -361,6 +399,9 @@ class UpgradeViewModel @Inject constructor(
         launch {
             if (!acquireOp(BusyOp.SUBSCRIPTION)) return@launch
             try {
+                // Same fresh check as the one-time path: a pending payment (for either product)
+                // must block this launch too — Play would reject it, or bill it on top.
+                if (runPurchaseGate() !is PurchaseGate.Clear) return@launch
                 // launchBillingFlowNow suspends until the launch resolved, so the guard covers the
                 // whole tap-to-sheet window. The flow itself still runs on AppScope, so closing the
                 // screen mid-launch doesn't abort the purchase.
@@ -368,7 +409,7 @@ class UpgradeViewModel @Inject constructor(
                     activity,
                     OurSku.Sub.PRO_UPGRADE,
                     offer,
-                    onError = errorEvents::tryEmit,
+                    onError = ::onLaunchError,
                 )
             } finally {
                 activeOp.value = null
@@ -430,6 +471,14 @@ class UpgradeViewModel @Inject constructor(
                     // Explicit feedback: on the ownership screen a successful restore changes
                     // nothing visible (the user already is Pro), so silence reads as "broken".
                     events.tryEmit(UpgradeEvents.RestoreSucceeded)
+                }
+
+                restored.info.pendingSkus.isNotEmpty() -> {
+                    // Play answered and found the purchase — it just hasn't been paid for yet.
+                    // RestoreFailed would send this user chasing account and support advice for
+                    // something that resolves itself.
+                    log(TAG, INFO) { "Restore found a purchase with a pending payment" }
+                    events.tryEmit(UpgradeEvents.PurchasePending)
                 }
 
                 else -> {

--- a/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/myperm/common/upgrade/ui/UpgradeViewModel.kt
@@ -401,7 +401,30 @@ class UpgradeViewModel @Inject constructor(
             try {
                 // Same fresh check as the one-time path: a pending payment (for either product)
                 // must block this launch too — Play would reject it, or bill it on top.
-                if (runPurchaseGate() !is PurchaseGate.Clear) return@launch
+                val gate = runPurchaseGate()
+                if (gate !is PurchaseGate.Clear) return@launch
+                // The reactive UI can be stale (the purchase was made on another device), and Play
+                // happily sells the subscription alongside an owned one-time purchase — the user
+                // would pay for Pro twice. The strict refresh already committed into the shared
+                // billing data, so the screen re-renders to the ownership state, and the
+                // restore-success toast explains why nothing launched. Deliberately the MAPPED
+                // upgrades, not isPro: grace users (mapped upgrades empty) may legitimately
+                // re-purchase.
+                if (gate.info.upgrades.isNotEmpty()) {
+                    log(TAG, INFO) { "Subscription purchase blocked: fresh check found an owned upgrade" }
+                    events.tryEmit(UpgradeEvents.RestoreSucceeded)
+                    return@launch
+                }
+                // Same breadth as the one-time path's renewal guard: an auto-renewing subscription
+                // with an unknown or legacy product ID (which maps to zero upgrades, so the block
+                // above passed) must still block a new subscription — two renewing subscriptions
+                // for the same features is the same double-billing. Reuses the existing
+                // manage-subscription dialog.
+                if (gate.info.hasAutoRenewingSubscription) {
+                    log(TAG, INFO) { "Subscription purchase blocked: another subscription is still set to renew" }
+                    events.tryEmit(UpgradeEvents.SubscriptionStillRenewing)
+                    return@launch
+                }
                 // launchBillingFlowNow suspends until the launch resolved, so the guard covers the
                 // whole tap-to-sheet window. The flow itself still runs on AppScope, so closing the
                 // screen mid-launch doesn't abort the purchase.

--- a/app/src/gplay/res/values-af-rZA/strings.xml
+++ b/app/src/gplay/res/values-af-rZA/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">Omskakel na \'n eenmalige aankoop</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play kontroleer slegs die rekening waarmee u tans aangemeld is. Die eenmalige aankoop is afsonderlik van u abonnement.</string>
     <string name="upgrade_screen_sub_still_renewing_message">U abonnement is steeds aktief en vernuwe. Kanselleer dit eers in Google Play.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Kon nie u abonnement met Google Play verifieer nie. Probeer asseblief weer.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">Bevestig u aankoop</string>
     <string name="upgrade_screen_grace_body">Wag vir Google Play om u Pro-aankoop weer te bevestig. Dit los gewoonlik vanself op.</string>

--- a/app/src/gplay/res/values-am/strings.xml
+++ b/app/src/gplay/res/values-am/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">ወደ አንድ ጊዜ ግዢ ይቀይሩ</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play በሚገቡበት ሂሳብዎ ብቻ ይከታተላል። አንድ ጊዜ ያለው ገዥ ከእርስዎ ምዝገባ ተለይቶ ነው።</string>
     <string name="upgrade_screen_sub_still_renewing_message">የእርስዎ ምዝገባ አሁንም ንቁ እና ይታደሳል። በGoogle Play ውስጥ በመጀመሪያ ይሰርዙት።</string>
-    <string name="upgrade_screen_sub_check_failed_message">የእርስዎን ምዝገባ በGoogle Play ሊያረጋገ አልቻለም። እንደገና ይሞክሩ።</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">የእርስዎን ገዥ በማረጋገጥ ላይ ነው</string>
     <string name="upgrade_screen_grace_body">Google Play የእርስዎን Pro ገዥ ለማረጋገጥ ጠብቋ ነው። ይህ ብዙውን ጊዜ በራሱ ይፈታል።</string>

--- a/app/src/gplay/res/values-ar/strings.xml
+++ b/app/src/gplay/res/values-ar/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">التبديل إلى الشراء لمرة واحدة</string>
     <string name="upgrade_screen_limitation_disclosure">يتحقق Google Play فقط من الحساب الذي تم تسجيل الدخول إليه حالياً. الشراء لمرة واحدة منفصل عن اشتراكك.</string>
     <string name="upgrade_screen_sub_still_renewing_message">اشتراكك لا يزال نشطاً ويتم تجديده. قم بإلغائه في Google Play أولاً.</string>
-    <string name="upgrade_screen_sub_check_failed_message">تعذر التحقق من اشتراكك مع Google Play. يرجى المحاولة مجدداً.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">جاري تأكيد عملية الشراء</string>
     <string name="upgrade_screen_grace_body">جاري انتظار Google Play لإعادة تأكيد شراء Pro الخاص بك. عادة ما يتم حل هذا تلقائياً.</string>

--- a/app/src/gplay/res/values-az/strings.xml
+++ b/app/src/gplay/res/values-az/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">Birdəfəlik satın almaya keçid</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play yalnız indi daxil olduğunuz hesabı yoxlayır. Birdəfəlik satın alma abunəlikdən ayrıdır.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Sizin abunəlik hələ də aktivdir və yenilənir. Əvvəlcə Google Play-də ləğv edin.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Sizin abunəlik Google Play ilə təsdiqlənə bilmədi. Lütfən yenidən cəhd edin.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">Alışınız təsdiqlənir</string>
     <string name="upgrade_screen_grace_body">Google Play sizin Pro alışınızı yenidən təsdiqləməsi gözlənilir. Bu adətən öz-özünə həll olur.</string>

--- a/app/src/gplay/res/values-be/strings.xml
+++ b/app/src/gplay/res/values-be/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">Перайсці на адзінаразовую пакупку</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play правярае толькі акаўнт, у які вы зараз увайшлі. Адзінаразовая пакупка не звязана з вашай падпіскай.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Ваша падпіска ўсё яшчэ актыўная і аднаўляецца. Спачатку скасуйце яе ў Google Play.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Не ўдалося праверыць вашу падпіску ў Google Play. Калі ласка, паспрабуйце яшчэ раз.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">Пацвярджэнне вашай пакупкі</string>
     <string name="upgrade_screen_grace_body">Мы чакаем паўторнага пацвярджэння вашай пакупкі Pro ад Google Play. Звычайна гэта вырашаецца самастойна.</string>

--- a/app/src/gplay/res/values-bg/strings.xml
+++ b/app/src/gplay/res/values-bg/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">Преминете към еднократна покупка</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play проверява само акаунта, в който сте вписани в момента. Еднократната покупка е отделна от абонамента ви.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Абонаментът ви все още е активен и се подновява. Първо го отменете в Google Play.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Не можахме да потвърдим абонамента ви с Google Play. Моля, опитайте отново.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">Потвърждаване на покупката ви</string>
     <string name="upgrade_screen_grace_body">Изчакване на Google Play да потвърди отново Pro покупката ви. Обикновено това се разрешава автоматично.</string>

--- a/app/src/gplay/res/values-bn-rBD/strings.xml
+++ b/app/src/gplay/res/values-bn-rBD/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">একবার ক্রয়ে স্যুইচ করুন</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play শুধুমাত্র আপনি যে অ্যাকাউন্টে সাইন ইন করেছেন তা চেক করে। এককালীন ক্রয় আপনার সাবস্ক্রিপশন থেকে আলাদা।</string>
     <string name="upgrade_screen_sub_still_renewing_message">আপনার সাবস্ক্রিপশন এখনও সক্রিয় এবং পুনর্নবীকরণ হচ্ছে। প্রথমে Google Play-এ এটি বাতিল করুন।</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play-এর সাথে আপনার সাবস্ক্রিপশন যাচাই করা যায়নি। অনুগ্রহ করে আবার চেষ্টা করুন।</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">আপনার ক্রয় নিশ্চিত করছি</string>
     <string name="upgrade_screen_grace_body">Google Play আপনার Pro ক্রয় পুনরায় নিশ্চিত করার অপেক্ষা করছি। এটি সাধারণত নিজে থেকেই সমাধান হয়।</string>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">Canvieu a una compra única</string>
     <string name="upgrade_screen_limitation_disclosure">El Google Play només comprova el compte en el qual esteu actualment connectats. La compra única és independent de la vostra subscripció.</string>
     <string name="upgrade_screen_sub_still_renewing_message">La vostra subscripció segueix activa i es renova. Cancel·leu-la primer al Google Play.</string>
-    <string name="upgrade_screen_sub_check_failed_message">No s\'ha pogut verificar la vostra subscripció amb el Google Play. Torneu-ho a provar.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">S\'està confirmant la vostra compra</string>
     <string name="upgrade_screen_grace_body">S\'està esperant que el Google Play confirmi novament la vostra compra del Pro. Això normalment es resol per si sol.</string>

--- a/app/src/gplay/res/values-cs/strings.xml
+++ b/app/src/gplay/res/values-cs/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">Přejít na jednorázový nákup</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play kontroluje pouze účet, ke kterému jste právě přihlášeni. Jednorázový nákup je oddělený od vašeho předplatného.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Vaše předplatné je stále aktivní a obnovuje se. Nejdřív jej zrušte v Google Play.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nelze ověřit vaše předplatné v Google Play. Zkuste to prosím znovu.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">Potvrzování nákupu</string>
     <string name="upgrade_screen_grace_body">Čekání na opětovné potvrzení nákupu Pro z Google Play. Obvykle se to vyřeší samo.</string>

--- a/app/src/gplay/res/values-da/strings.xml
+++ b/app/src/gplay/res/values-da/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">Skift til engangsudgift</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play kontrollerer kun den konto, du er logget ind på. Engangsbetalingen er adskilt fra dit abonnement.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Dit abonnement er stadig aktivt og fornyes. Annuller det først i Google Play.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Kunne ikke bekræfte dit abonnement med Google Play. Prøv igen.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">Bekræfter dit køb</string>
     <string name="upgrade_screen_grace_body">Venter på, at Google Play skal bekræfte dit Pro-køb igen. Dette løses normalt af sig selv.</string>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">Zum einmaligen Kauf wechseln</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play überprüft nur das Konto, mit dem du gerade angemeldet bist. Der Einmalkauf ist unabhängig von deinem Abonnement.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Dein Abonnement ist noch aktiv und wird erneuert. Kündige es zuerst in Google Play.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Dein Abonnement konnte nicht bei Google Play überprüft werden. Bitte versuche es noch einmal.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">Dein Kauf wird bestätigt</string>
     <string name="upgrade_screen_grace_body">Warten auf erneute Bestätigung deines Pro-Kaufs durch Google Play. Dies löst sich normalerweise von selbst.</string>

--- a/app/src/gplay/res/values-el/strings.xml
+++ b/app/src/gplay/res/values-el/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">Μετάβαση σε μια εφάπαξ αγορά</string>
     <string name="upgrade_screen_limitation_disclosure">Το Google Play ελέγχει μόνο το λογαριασμό στον οποίο είστε συνδεδεμένοι. Η εφάπαξ αγορά είναι ξεχωριστή από τη συνδρομή σας.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Η συνδρομή σας είναι ακόμα ενεργή και ανανεώνεται. Ακυρώστε την πρώτα στο Google Play.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Δεν ήταν δυνατή η επαλήθευση της συνδρομής σας με το Google Play. Δοκιμάστε ξανά.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">Επιβεβαίωση της αγοράς σας</string>
     <string name="upgrade_screen_grace_body">Αναμονή για το Google Play να επιβεβαιώσει ξανά την αγορά Pro σας. Συνήθως επιλύεται αυτόματα.</string>

--- a/app/src/gplay/res/values-es/strings.xml
+++ b/app/src/gplay/res/values-es/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">Cambiar a una compra única</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play solo verifica la cuenta en la que actualmente has iniciado sesión. La compra única es independiente de tu suscripción.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Tu suscripción sigue activa y se está renovando. Cancélala en Google Play primero.</string>
-    <string name="upgrade_screen_sub_check_failed_message">No se pudo verificar tu suscripción con Google Play. Por favor, intenta de nuevo.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">Confirmando tu compra</string>
     <string name="upgrade_screen_grace_body">Esperando que Google Play reconfirme tu compra Pro. Esto generalmente se resuelve por sí solo.</string>

--- a/app/src/gplay/res/values-fi/strings.xml
+++ b/app/src/gplay/res/values-fi/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">Siirry kertamaksuun</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play tarkistaa vain tilin, johon olet tällä hetkellä kirjautunut. Kertaosto on erillinen tilauspalvelustasi.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Tilauspalvelusi on vielä aktiivinen ja uusiutuu. Peruuta se ensin Google Playsta.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Tilauspalvelusi tarkistaminen Google Playsta epäonnistui. Yritä uudelleen.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">Vahvistetaan ostoasi</string>
     <string name="upgrade_screen_grace_body">Odotetaan Google Playta vahvistamaan uudelleen Pro-ostoasi. Tämä yleensä ratkeaa itsestään.</string>

--- a/app/src/gplay/res/values-fr/strings.xml
+++ b/app/src/gplay/res/values-fr/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">Passer à un achat unique</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play vérifie uniquement le compte auquel vous êtes actuellement connecté. L’achat unique est distinct de votre abonnement.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Votre abonnement est toujours actif et se renouvelle. Annulez-le d’abord dans Google Play.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Impossible de vérifier votre abonnement auprès de Google Play. Veuillez réessayer.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">Confirmation de votre achat</string>
     <string name="upgrade_screen_grace_body">En attente que Google Play confirme à nouveau votre achat Pro. Cela se résout généralement automatiquement.</string>

--- a/app/src/gplay/res/values-hi-rIN/strings.xml
+++ b/app/src/gplay/res/values-hi-rIN/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">एक बार की खरीदारी पर स्विच करें</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play केवल उस खाते की जांच करता है जिसमें आप वर्तमान में साइन इन हैं। एक बार की खरीदारी आपकी सदस्यता से अलग है।</string>
     <string name="upgrade_screen_sub_still_renewing_message">आपकी सदस्यता अभी भी सक्रिय है और नवीनीकृत हो रही है। पहले इसे Google Play में रद्द करें।</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play के साथ आपकी सदस्यता को सत्यापित नहीं किया जा सका। कृपया पुनः प्रयास करें।</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">आपकी खरीदारी की पुष्टि की जा रही है</string>
     <string name="upgrade_screen_grace_body">Google Play को आपकी Pro खरीदारी को फिर से पुष्टि करने की प्रतीक्षा है। यह आमतौर पर अपने आप ठीक हो जाता है।</string>

--- a/app/src/gplay/res/values-hr/strings.xml
+++ b/app/src/gplay/res/values-hr/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">Prebacite se na jednokratnu kupnju</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play provjerava samo račun na koji ste trenutno prijavljeni. Jednokratna kupnja je odvojena od vaše pretplate.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Vaša pretplata je i dalje aktivna i obnavlja se. Trebate je prvo otkazati na Google Playu.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nije moguće provjeriti vašu pretplatu s Google Playom. Pokušajte ponovno.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">Potvrda vaše kupnje</string>
     <string name="upgrade_screen_grace_body">Čeka se da Google Play ponovno potvrdi vašu Pro kupnju. Obično se to razriješi samo od sebe.</string>

--- a/app/src/gplay/res/values-hu/strings.xml
+++ b/app/src/gplay/res/values-hu/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">Váltás egyszeri vásárlásra</string>
     <string name="upgrade_screen_limitation_disclosure">A Google Play csak az aktuálisan bejelentkeztetett fiókot ellenőrzi. Az egyszeri vásárlás és az előfizetésed egymástól függetlenek.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Az előfizetésed továbbra is aktív és megújul. Előbb szüntesd meg azt a Google Play-ben.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nem sikerült ellenőrizni az előfizetésed a Google Play-ben. Kérjük, próbáld újra.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">Vásárlás megerősítése</string>
     <string name="upgrade_screen_grace_body">Arra várakozunk, hogy a Google Play újra megerősítse a Pro vásárlásod. Ez általában magától megoldódik.</string>

--- a/app/src/gplay/res/values-it/strings.xml
+++ b/app/src/gplay/res/values-it/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">Passa a un acquisto unico</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play controlla solo l’account con cui sei attualmente connesso. L’acquisto unico è separato dal tuo abbonamento.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Il tuo abbonamento è ancora attivo e si sta rinnovando. Annullalo prima in Google Play.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Impossibile verificare il tuo abbonamento con Google Play. Riprova.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">Conferma in corso</string>
     <string name="upgrade_screen_grace_body">In attesa che Google Play confermi di nuovo il tuo acquisto Pro. Di solito si risolve da solo.</string>

--- a/app/src/gplay/res/values-iw/strings.xml
+++ b/app/src/gplay/res/values-iw/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">עבור לרכישה חד-פעמית</string>
     <string name="upgrade_screen_limitation_disclosure">גוגל פליי בודקת רק את החשבון שאתה כרגע מחובר אליו. הרכישה החד-פעמית נפרדת מהמנוי שלך.</string>
     <string name="upgrade_screen_sub_still_renewing_message">המנוי שלך עדיין פעיל ומתחדש. בטל אותו בגוגל פליי קודם.</string>
-    <string name="upgrade_screen_sub_check_failed_message">לא הצלחנו לאמת את המנוי שלך עם גוגל פליי. אנא נסה שוב.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">מאשרים את הרכישה שלך</string>
     <string name="upgrade_screen_grace_body">ממתינים לאישור חוזר מגוגל פליי לרכישת ה-Pro שלך. זה בדרך כלל נפתר מעצמו.</string>

--- a/app/src/gplay/res/values-ja/strings.xml
+++ b/app/src/gplay/res/values-ja/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">ワンタイム購入に切り替える</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play は、現在サインインしているアカウントのみをチェックします。一度限りの購入はサブスクリプションとは別です。</string>
     <string name="upgrade_screen_sub_still_renewing_message">ご契約はまだ有効で更新されています。まず Google Play でキャンセルしてください。</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play でご契約を確認できませんでした。もう一度お試しください。</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">購入を確認中</string>
     <string name="upgrade_screen_grace_body">Google Play が Pro 購入を再確認するのを待っています。これは通常自動的に解決します。</string>

--- a/app/src/gplay/res/values-ko/strings.xml
+++ b/app/src/gplay/res/values-ko/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">일회성 구매로 전환</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play는 현재 로그인한 계정만 확인합니다. 일회 구매는 구독과 별개입니다.</string>
     <string name="upgrade_screen_sub_still_renewing_message">구독이 아직 활성 상태이며 갱신 중입니다. 먼저 Google Play에서 취소하세요.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Google Play에서 구독을 확인할 수 없습니다. 다시 시도하세요.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">구매 확인 중</string>
     <string name="upgrade_screen_grace_body">Google Play에서 Pro 구매를 다시 확인할 때까지 기다리는 중입니다. 일반적으로 자동으로 해결됩니다.</string>

--- a/app/src/gplay/res/values-ku-rTR/strings.xml
+++ b/app/src/gplay/res/values-ku-rTR/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">Veguherîn bo kirîna yek-car</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play tenê hesaba we ya niha kontrol dike. Beşdareya yekcarî ji peymanê we cuda ye.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Peymanê we hîn jî çalak e û nabe nûkirî. Pêşî ew di Google Play da betal bikin.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Peymanê we bi Google Play piştrast nekirî. Ji kerema xwe dîsa hewl bide.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">Beşdareya we tê piştraskirin</string>
     <string name="upgrade_screen_grace_body">Em li bendî ne ku Google Play beşdareya Pro ya we dîsa piştrast bike. Ev bi awayekî xweser çareserî dibe.</string>

--- a/app/src/gplay/res/values-nb/strings.xml
+++ b/app/src/gplay/res/values-nb/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">Bytt til engangskjøp</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play sjekker bare kontoen du er logget inn på. Engangskjøpet er atskilt fra abonnementet ditt.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Abonnementet ditt er fortsatt aktivt og fornyes. Avbryt det i Google Play først.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Kunne ikke bekrefte abonnementet ditt med Google Play. Vennligst prøv igjen.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">Bekrefter kjøpet ditt</string>
     <string name="upgrade_screen_grace_body">Venter på at Google Play skal bekrefte Pro-kjøpet ditt på nytt. Dette løser seg vanligvis av seg selv.</string>

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">Schakel over naar eenmalige aankoop</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play controleert alleen het account waarbij je momenteel bent aangemeld. De eenmalige aankoop is gescheiden van je abonnement.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Je abonnement is nog steeds actief en vernieuwt. Annuleer het eerst in Google Play.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Je abonnement kon niet met Google Play worden geverifieerd. Probeer het opnieuw.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">Je aankoop bevestigen</string>
     <string name="upgrade_screen_grace_body">Wachten tot Google Play je Pro-aankoop opnieuw bevestigt. Dit lost meestal vanzelf op.</string>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">Przełącz na jednorazowy zakup</string>
     <string name="upgrade_screen_limitation_disclosure">Sklep Google Play sprawdza tylko konto, na którym jesteś aktualnie zalogowany. Jednorazowy zakup jest niezależny od subskrypcji.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Twoja subskrypcja jest nadal aktywna i odnawia się. Anuluj ją najpierw w Sklepie Google Play.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nie udało się zweryfikować twojej subskrypcji w Sklepie Google Play. Spróbuj ponownie.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">Potwierdzanie twojego zakupu</string>
     <string name="upgrade_screen_grace_body">Oczekiwanie na ponowne potwierdzenie zakupu wersji Pro przez Sklepie Google Play. Zazwyczaj problem rozwiązuje się samoistnie.</string>

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">Mudar para uma compra única</string>
     <string name="upgrade_screen_limitation_disclosure">O Google Play verifica apenas a conta com a qual você está conectado. A compra única é separada de sua assinatura.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Sua assinatura ainda está ativa e se renovando. Cancele-a no Google Play primeiro.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Não foi possível verificar sua assinatura no Google Play. Tente novamente.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">Confirmando sua compra</string>
     <string name="upgrade_screen_grace_body">Aguardando o Google Play reconfirmar sua compra Pro. Isso geralmente se resolve sozinho.</string>

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">Mudar para uma compra única</string>
     <string name="upgrade_screen_limitation_disclosure">O Google Play apenas verifica a conta em que está atualmente ligado. A compra única é separada da sua subscrição.</string>
     <string name="upgrade_screen_sub_still_renewing_message">A sua subscrição ainda está ativa e em renovação. Cancele-a primeiro no Google Play.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Não foi possível verificar a sua subscrição no Google Play. Tente novamente.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">A confirmar a compra</string>
     <string name="upgrade_screen_grace_body">A aguardar que o Google Play confirme novamente a sua compra Pro. Normalmente resolve-se automaticamente.</string>

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">Treci la o achiziție unică</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play verifică doar contul cu care ești conectat în acest moment. Achiziția unică este separată de abonamentul tău.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Abonamentul tău este încă activ și se reînnoiește. Anulează-l mai întâi în Google Play.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nu am putut verifica abonamentul tău cu Google Play. Te rog să încerci din nou.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">Se confirmă achiziția ta</string>
     <string name="upgrade_screen_grace_body">Se așteaptă ca Google Play să reconfirme achiziția Pro. De obicei se rezolvă de la sine.</string>

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">Переключиться на единоразовую покупку</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play проверяет только аккаунт, в который вы сейчас вошли. Единоразовая покупка отделена от вашей подписки.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Ваша подписка по-прежнему активна и продлевается. Сначала отмените ее в Google Play.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Не удалось проверить вашу подписку в Google Play. Пожалуйста, попробуйте еще раз.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">Подтверждение покупки</string>
     <string name="upgrade_screen_grace_body">Ожидание подтверждения вашей покупки Pro в Google Play. Обычно это разрешается автоматически.</string>

--- a/app/src/gplay/res/values-sk/strings.xml
+++ b/app/src/gplay/res/values-sk/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">Prejsť na jednorazový nákup</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play kontroluje iba účet, s ktorým ste momentálne prihlásení. Jednorazový nákup je nezávislý od vášho predplatného.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Vaše predplatné je stále aktívne a obnovuje sa. Zrušte ho najskôr v Google Play.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nepodarilo sa overiť vaše predplatné v Google Play. Skúste znova prosím.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">Potvrdzovanie vášho nákupu</string>
     <string name="upgrade_screen_grace_body">Čakáme, kým Google Play znovu potvrdí váš nákup Pro. Zvyčajne sa to vyrieši automaticky.</string>

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">Пређите на једнократну куповину</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play проверава само налог са којим сте пријављени. Једнократна куповина је одвојена од ваше претплате.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Ваша претплата је још активна и обнавља се. Прво је откажите у Google Play.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Провера ваше претплате са Google Play није успела. Покушајте поново.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">Потврђивање ваше куповине</string>
     <string name="upgrade_screen_grace_body">Чека се да Google Play поново потврди вашу Pro куповину. Ово се обично решава аутоматски.</string>

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">Växla till ett engångsköp</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play kontrollerar bara kontot du är inloggad på. Engångsköpet är separat från din prenumeration.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Din prenumeration är fortfarande aktiv och förnyas. Avbryt den i Google Play först.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Kunde inte verifiera din prenumeration med Google Play. Försök igen.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">Bekräftar ditt köp</string>
     <string name="upgrade_screen_grace_body">Väntar på att Google Play ska ombekräfta ditt Pro-köp. Det löser sig vanligtvis själv.</string>

--- a/app/src/gplay/res/values-th/strings.xml
+++ b/app/src/gplay/res/values-th/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">เปลี่ยนไปซื้อแบบครั้งเดียว</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play จะตรวจสอบเฉพาะบัญชีที่คุณลงชื่อเข้าสู่ระบบอยู่เท่านั้น การซื้อแบบครั้งเดียวจะแยกต่างหากจากการสมัครสมาชิกของคุณ</string>
     <string name="upgrade_screen_sub_still_renewing_message">การสมัครสมาชิกของคุณยังคงใช้งานและต่ออายุอยู่ ให้ยกเลิกใน Google Play ก่อน</string>
-    <string name="upgrade_screen_sub_check_failed_message">ไม่สามารถยืนยันการสมัครสมาชิกของคุณกับ Google Play ได้ โปรดลองอีกครั้ง</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">กำลังยืนยันการซื้อของคุณ</string>
     <string name="upgrade_screen_grace_body">กำลังรอให้ Google Play ยืนยันการซื้อ Pro ของคุณอีกครั้ง ปกติจะแก้ไขได้เอง</string>

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">Tek seferlik satın almaya geç</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play yalnızca şu anda oturum açtığınız hesabı kontrol eder. Tek seferlik satın alma, aboneliğinizden ayrıdır.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Aboneliğiniz hala aktif ve yenileniyor. Önce Google Play\'de iptal edin.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Aboneliğiniz Google Play ile doğrulanamadı. Lütfen tekrar deneyin.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">Satın alımınız doğrulanıyor</string>
     <string name="upgrade_screen_grace_body">Google Play\'in Pro satın alımınızı yeniden doğrulaması bekleniyor. Bu genellikle kendi başına çözülür.</string>

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">Перейти на одноразову покупку</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play перевіряє лише обліковий запис, в якому ви зараз увійшли. Разова покупка відокремлена від вашої підписки.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Ваша підписка все ще активна і поновлюється. Спочатку скасуйте її в Google Play.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Не вдалося перевірити вашу підписку в Google Play. Будь ласка, спробуйте ще раз.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">Підтвердження вашої покупки</string>
     <string name="upgrade_screen_grace_body">Очікування повторного підтвердження вашої Pro покупки в Google Play. Зазвичай це розв\'язується само собою.</string>

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">Chuyển sang mua một lần</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play chỉ kiểm tra tài khoản bạn đang đăng nhập. Lần mua một lần này riêng biệt từ gói đăng ký của bạn.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Gói đăng ký của bạn vẫn còn hoạt động và đang tự động gia hạn. Hãy hủy nó trong Google Play trước.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Không thể xác minh gói đăng ký của bạn với Google Play. Vui lòng thử lại.</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">Đang xác nhận lần mua của bạn</string>
     <string name="upgrade_screen_grace_body">Đang chờ Google Play xác nhận lại lần mua Pro của bạn. Điều này thường tự động giải quyết.</string>

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">切换为一次性购买</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play 只会检查您当前登录的账户。一次性购买与您的订阅是分开的。</string>
     <string name="upgrade_screen_sub_still_renewing_message">您的订阅仍然有效且将继续续期。请先在 Google Play 中取消。</string>
-    <string name="upgrade_screen_sub_check_failed_message">无法与 Google Play 验证您的订阅。请重试。</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">正在确认您的购买</string>
     <string name="upgrade_screen_grace_body">正在等待 Google Play 重新确认您的 Pro 购买。这通常会自动解决。</string>

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -31,7 +31,6 @@
     <string name="upgrade_screen_switch_title">切換為一次性購買</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play 只會檢查您目前登入的帳戶。一次性購買與您的訂閱是分開的。</string>
     <string name="upgrade_screen_sub_still_renewing_message">您的訂閱仍處於活動狀態且正在續約。請先在 Google Play 中取消訂閱。</string>
-    <string name="upgrade_screen_sub_check_failed_message">無法透過 Google Play 驗證您的訂閱。請重試。</string>
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">正在確認您的購買</string>
     <string name="upgrade_screen_grace_body">等待 Google Play 重新確認您的 Pro 購買。這通常會自動解決。</string>

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -44,7 +44,12 @@
     <string name="upgrade_screen_owned_iap_locked_note">To switch to the one-time purchase, first cancel your subscription in Google Play. This offer unlocks once it\'s set not to renew.</string>
     <string name="upgrade_screen_limitation_disclosure">Google Play only checks the account you\'re currently signed in with. The one-time purchase is separate from your subscription.</string>
     <string name="upgrade_screen_sub_still_renewing_message">Your subscription is still active and renewing. Cancel it in Google Play first.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Couldn\'t verify your subscription with Google Play. Please try again.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Couldn\'t verify your purchases with Google Play. Please try again.</string>
+
+    <!-- Pending payment (Play is still processing) -->
+    <string name="upgrade_screen_pending_card_title">Payment pending</string>
+    <string name="upgrade_screen_pending_card_body">Google Play is still processing your payment. Pro unlocks automatically once it goes through. Some payment methods can take a while. There\'s nothing else you need to do.</string>
+    <string name="upgrade_screen_pending_dialog_message">Google Play found a purchase with a pending payment and is still processing it. Pro unlocks automatically once the payment goes through.</string>
 
     <!-- Grace (waiting for Play to re-confirm) -->
     <string name="upgrade_screen_grace_title">Confirming your purchase</string>

--- a/app/src/main/java/eu/darken/myperm/common/upgrade/ui/UpgradeContent.kt
+++ b/app/src/main/java/eu/darken/myperm/common/upgrade/ui/UpgradeContent.kt
@@ -85,6 +85,7 @@ internal object UpgradeScreenTags {
     const val GPLAY_OWNED_IAP = "upgrade_gplay_owned_iap"
     const val GPLAY_OWNED_SUB = "upgrade_gplay_owned_sub"
     const val GPLAY_MANAGE_SUB = "upgrade_gplay_manage_sub"
+    const val GPLAY_PENDING = "upgrade_gplay_pending"
     const val GPLAY_GRACE = "upgrade_gplay_grace"
     const val GPLAY_GRACE_SPINNER = "upgrade_gplay_grace_spinner"
     const val GPLAY_GRACE_RESTORE = "upgrade_gplay_grace_restore"

--- a/app/src/testFoss/java/eu/darken/myperm/common/upgrade/ui/FossUpgradeViewModelTest.kt
+++ b/app/src/testFoss/java/eu/darken/myperm/common/upgrade/ui/FossUpgradeViewModelTest.kt
@@ -126,14 +126,22 @@ class FossUpgradeViewModelTest : BaseTest() {
     @Test
     fun `only the upgraded status carries a supporter-since date`() = runTest2(context = testDispatcher) {
         // The pitch and the free status have no supporter date to show; carrying a stale one would
-        // let it leak into a view that must not claim an upgrade.
-        val vm = buildVm(repo = mockRepo(MutableStateFlow(upgradedInfo())))
+        // let it leak into a view that must not claim an upgrade. A supporter reaches the upgraded
+        // status on every route now, so the free user on the same route is what proves the null case.
+        val upgradedVm = buildVm(repo = mockRepo(MutableStateFlow(upgradedInfo())))
+        val upgradedState = async { upgradedVm.state.first { it != null }!! }
+        upgradedVm.bindRoute(Nav.Main.Upgrade(forced = true))
 
-        val state = async { vm.state.first { it != null }!! }
-        vm.bindRoute(Nav.Main.Upgrade(forced = true))
+        val freeVm = buildVm()
+        val freeState = async { freeVm.state.first { it != null }!! }
+        freeVm.bindRoute(Nav.Main.Upgrade(forced = true))
         advanceUntilIdle()
 
-        state.await() shouldBe UpgradeViewModel.State(
+        upgradedState.await() shouldBe UpgradeViewModel.State(
+            view = FossUpgradeView.STATUS_UPGRADED,
+            supporterSince = Instant.EPOCH,
+        )
+        freeState.await() shouldBe UpgradeViewModel.State(
             view = FossUpgradeView.PITCH,
             supporterSince = null,
         )
@@ -205,6 +213,35 @@ class FossUpgradeViewModelTest : BaseTest() {
         advanceUntilIdle()
 
         upgradedView.await().view shouldBe FossUpgradeView.STATUS_UPGRADED
+    }
+
+    @Test
+    fun `forced route lands on the upgraded status when the sponsor flow completes`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // Forced routes (Pro-locked settings entry) deliberately don't auto-close, so the screen is
+        // still up when the unlock lands — it must flip to the supporter status instead of keeping
+        // the sales pitch, which reads as "sponsoring didn't work".
+        val info = MutableStateFlow(UpgradeRepoFoss.Info())
+        val vm = buildVm(repo = mockRepo(info))
+
+        val navEvents = mutableListOf<NavEvent>()
+        val collector = launch(start = CoroutineStart.UNDISPATCHED) { vm.navEvents.collect { navEvents.add(it) } }
+
+        val pitchView = async { vm.state.first { it != null }!! }
+        vm.bindRoute(Nav.Main.Upgrade(forced = true))
+        advanceUntilIdle()
+        pitchView.await().view shouldBe FossUpgradeView.PITCH
+
+        val upgradedView = async { vm.state.first { it?.view == FossUpgradeView.STATUS_UPGRADED }!! }
+        info.value = upgradedInfo()
+        advanceUntilIdle()
+
+        upgradedView.await().view shouldBe FossUpgradeView.STATUS_UPGRADED
+        // The don't-auto-close semantics of forced routes are unchanged — status, not navigation,
+        // is what acknowledges the upgrade here.
+        navEvents.shouldBeEmpty()
+        collector.cancel()
     }
 
     @Test

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/UpgradeRepoGplayTest.kt
@@ -10,6 +10,7 @@ import eu.darken.myperm.common.upgrade.core.billing.BillingData
 import eu.darken.myperm.common.upgrade.core.billing.BillingManager
 import eu.darken.myperm.common.upgrade.core.billing.GplayServiceUnavailableException
 import eu.darken.myperm.common.upgrade.core.billing.ItemAlreadyOwnedBillingException
+import eu.darken.myperm.common.upgrade.core.billing.PendingPurchaseBillingException
 import eu.darken.myperm.common.upgrade.core.billing.PurchasedSku
 import eu.darken.myperm.common.upgrade.core.billing.UserCanceledBillingException
 import eu.darken.myperm.main.core.CurriculumVitae
@@ -125,6 +126,13 @@ class UpgradeRepoGplayTest : BaseTest() {
         every { purchaseTime } returns Instant.parse("2024-01-01T00:00:00Z").toEpochMilli()
     }
 
+    // A payment Play is still processing. Lands in BillingData.pendingPurchases, never in
+    // purchases — the split happens at the billing layer, this is what the repo receives.
+    private fun pendingPurchase(productId: String = OurSku.Iap.PRO_UPGRADE.id) = mockk<Purchase>().apply {
+        every { products } returns listOf(productId)
+        every { purchaseTime } returns 1_000L
+    }
+
     @Test fun `test upgrade info pro status mapping`() {
         UpgradeRepoGplay.Info(
             gracePeriod = false,
@@ -154,6 +162,108 @@ class UpgradeRepoGplayTest : BaseTest() {
         info.upgradedAt shouldBe Instant.parse("2023-12-10T00:00:00Z")
         info.type
     }
+
+    // region pending payments
+
+    @Test fun `a pending payment is mapped but grants nothing`() {
+        val info = UpgradeRepoGplay.Info(
+            gracePeriod = false,
+            billingData = BillingData(purchases = emptySet(), pendingPurchases = setOf(pendingPurchase())),
+        )
+
+        info.pendingSkus shouldBe listOf(OurSku.Iap.PRO_UPGRADE)
+        // The whole point of the split: visible, never an entitlement.
+        info.upgrades shouldBe emptyList()
+        info.isPro shouldBe false
+        info.upgradedAt shouldBe null
+    }
+
+    @Test fun `a pending payment for an unknown product is dropped`() {
+        UpgradeRepoGplay.Info(
+            gracePeriod = false,
+            billingData = BillingData(
+                purchases = emptySet(),
+                pendingPurchases = setOf(pendingPurchase("some.unknown.product")),
+            ),
+        ).pendingSkus shouldBe emptyList()
+    }
+
+    @Test fun `the grace-substituted info keeps the pending payment visible`() = runTest2 {
+        // The audience that needs the explanation most: Pro is running on grace while Play is still
+        // processing the payment that will renew it. Dropping the data here (as the grace branch
+        // used to) left them with a silent screen.
+        coEvery { billingManager.refresh() } returns BillingData(emptySet(), setOf(pendingPurchase()))
+
+        val outcome = repo(lastProAt = System.currentTimeMillis() - 1_000).restorePurchaseNow()
+
+        outcome.info.isPro shouldBe true
+        outcome.info.pendingSkus shouldBe listOf(OurSku.Iap.PRO_UPGRADE)
+    }
+
+    @Test fun `a restore that only finds a pending payment reports it without pro`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(emptySet(), setOf(pendingPurchase()))
+
+        val outcome = repo(lastProAt = 0L).restorePurchaseNow()
+
+        outcome.shouldBeInstanceOf<UpgradeRepoGplay.RestoreOutcome.Checked>()
+        outcome.info.isPro shouldBe false
+        outcome.info.pendingSkus shouldBe listOf(OurSku.Iap.PRO_UPGRADE)
+    }
+
+    @Test fun `a manual restore over a partial refresh still advances the unconfirmed episode`() = runTest2 {
+        // The restore itself succeeds (a pending payment IS an answer), so nothing on this path
+        // throws — the episode clock is fed by the manager's reconciliation signal instead, which
+        // carries the refresh's commit time.
+        val failures = MutableSharedFlow<Long>(extraBufferCapacity = 1)
+        val confirmedAt = System.currentTimeMillis() - 1_000
+        coEvery { billingManager.refresh() } returns BillingData(emptySet(), setOf(pendingPurchase()))
+        val repo = repo(lastProAt = confirmedAt, connectionFailures = failures)
+
+        repo.restorePurchaseNow().info.isPro shouldBe true
+        failures.emit(confirmedAt + 500)
+        advanceUntilIdle()
+
+        coVerify { proUnconfirmedMock.update(any()) }
+    }
+
+    @Test fun `verifyPurchaseStateNow fails closed instead of substituting grace`() = runTest2 {
+        val boom = GplayServiceUnavailableException(RuntimeException("one product type failed"))
+        coEvery { billingManager.refreshStrict() } throws boom
+
+        // Even a recent owner gets the error: a gate that can't verify must not let a purchase
+        // through on the strength of a grace window.
+        shouldThrow<GplayServiceUnavailableException> {
+            repo(lastProAt = System.currentTimeMillis() - 1_000).verifyPurchaseStateNow()
+        }
+    }
+
+    @Test fun `verifyPurchaseStateNow reports the fresh split state`() = runTest2 {
+        coEvery { billingManager.refreshStrict() } returns BillingData(
+            purchases = setOf(proPurchase()),
+            pendingPurchases = setOf(pendingPurchase(OurSku.Sub.PRO_UPGRADE.id)),
+        )
+
+        val info = repo(lastProAt = 0L).verifyPurchaseStateNow()
+
+        info.upgrades.map { it.sku } shouldBe OurSku.PRO_SKUS.toList()
+        info.pendingSkus shouldBe listOf(OurSku.Sub.PRO_UPGRADE)
+        info.isSettled shouldBe true
+    }
+
+    @Test fun `already-owned recovery reports a pending payment instead of restore tips`() = runTest2 {
+        // Play refuses to re-sell a product whose payment it is still processing. The already-owned
+        // dialog would tell the user to restore, which cannot help.
+        coEvery { billingManager.startIapFlow(any(), any(), null) } throws
+            ItemAlreadyOwnedBillingException(RuntimeException("launch result"))
+        coEvery { billingManager.refresh() } returns BillingData(emptySet(), setOf(pendingPurchase()))
+
+        val errors = mutableListOf<Throwable>()
+        repo(lastProAt = 0L).startLaunch { errors.add(it) }
+
+        errors.single().shouldBeInstanceOf<PendingPurchaseBillingException>()
+    }
+
+    // endregion
 
     @Test fun `grace period is 7 days`() {
         // Guards against the unit error where 7 * 24 * 60 * 1000 (2.8h) was used instead of 7 days,

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/billing/BillingManagerTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/billing/BillingManagerTest.kt
@@ -71,6 +71,15 @@ class BillingManagerTest : BaseTest() {
         every { isAcknowledged } returns true
     }
 
+    // A payment Play is still processing: carried by the state, but never owned and never ackable.
+    private fun pendingPurchase(token: String = "pending-token") = mockk<Purchase>().apply {
+        every { purchaseState } returns PurchaseState.PENDING
+        every { purchaseTime } returns 2_000L
+        every { purchaseToken } returns token
+        every { isAcknowledged } returns false
+        every { products } returns listOf(OurSku.Iap.PRO_UPGRADE.id)
+    }
+
     // An unacknowledged purchase with its own token: the ack bookkeeping (log level, permanent
     // failure reports) is keyed per token, so tests need distinguishable ones.
     private fun unackedPurchase(
@@ -89,16 +98,53 @@ class BillingManagerTest : BaseTest() {
     private fun connection(
         refreshResults: List<Collection<Purchase>> = listOf(emptyList()),
         refreshComplete: Boolean = true,
+        // Full refresh outcomes for the tests that care about provenance (confirmed set, commit
+        // time, partial error); overrides the plain refreshResults shorthand.
+        refreshes: List<BillingConnection.PurchaseRefresh>? = null,
         purchasesFlow: Flow<Collection<Purchase>> = flowOf(emptyList()),
         freshUpdatesFlow: Flow<BillingConnection.FreshUpdate> = emptyFlow(),
         failures: Flow<BillingResult> = emptyFlow(),
     ) = mockk<BillingConnection>().apply {
-        coEvery { refreshPurchases() } returnsMany
-            refreshResults.map { BillingConnection.PurchaseRefresh(it, isComplete = refreshComplete) }
+        coEvery { refreshPurchases() } returnsMany (
+            refreshes ?: refreshResults.map {
+                BillingConnection.PurchaseRefresh(
+                    purchases = it,
+                    confirmed = it,
+                    hasConfirmedProPurchase = it.isNotEmpty(),
+                    isComplete = refreshComplete,
+                )
+            }
+            )
         every { purchases } returns purchasesFlow
         every { freshUpdates } returns freshUpdatesFlow
         every { purchaseFailures } returns failures
     }
+
+    // An incomplete reconciliation: it committed what it found, but one product type couldn't be
+    // checked. The default cause is NON-invalidating — the dead-binder codes are opted into.
+    private fun partialRefresh(
+        purchases: Collection<Purchase> = emptyList(),
+        confirmed: Collection<Purchase> = emptyList(),
+        hasConfirmedPro: Boolean = false,
+        occurredAt: Long = 4242L,
+        error: Throwable = GplayServiceUnavailableException(
+            BillingClientException(result(BillingResponseCode.ERROR))
+        ),
+    ) = BillingConnection.PurchaseRefresh(
+        purchases = purchases,
+        confirmed = confirmed,
+        hasConfirmedProPurchase = hasConfirmedPro,
+        isComplete = false,
+        occurredAt = occurredAt,
+        partialError = error,
+    )
+
+    private fun completeRefresh(purchases: Collection<Purchase> = emptyList()) = BillingConnection.PurchaseRefresh(
+        purchases = purchases,
+        confirmed = purchases,
+        hasConfirmedProPurchase = purchases.isNotEmpty(),
+        isComplete = true,
+    )
 
     // The real provider flow emits one connection and stays open for its lifetime -- flowOf() would
     // complete immediately, which the connect loop rightly treats as a connection failure.
@@ -540,6 +586,10 @@ class BillingManagerTest : BaseTest() {
 
     // Drains the manager's connectionFailures (occurrence timestamps) into a list. Launched on
     // backgroundScope so it lives for the whole test.
+    //
+    // Drive it with runCurrent() (or a suspension of the test body), NEVER with advanceUntilIdle():
+    // that one stops as soon as no FOREGROUND event is left and never runs backgroundScope work, so
+    // a signal sent from the test body would sit unconsumed and the list would read empty.
     private fun TestScope.collectFailures(manager: BillingManager): List<Long> = mutableListOf<Long>().also { out ->
         backgroundScope.launch { manager.connectionFailures.collect { out.add(it) } }
     }
@@ -665,20 +715,199 @@ class BillingManagerTest : BaseTest() {
         failures.isNotEmpty() shouldBe true
     }
 
-    @Test fun `a non-invalidating action error does not emit`() = runTest2 {
-        // A strict querySubscriptions failure whose code is NOT invalidating leaves the connection
-        // installed, so no connect-loop iteration fails and nothing feeds the episode clock.
-        val conn = connection().apply {
-            coEvery { querySubscriptions() } throws BillingClientException(result(BillingResponseCode.ERROR))
-        }
+    @Test fun `a strict gate failure does not feed the episode clock`() = runTest2 {
+        // The gate surfaces its own failure to the user (fail-closed) and leaves the connection
+        // installed. The episode clock is fed by the connect loop and by refresh() — a gate that
+        // the user aborted mid-purchase is not a reconciliation outcome.
+        val conn = connection(refreshes = listOf(completeRefresh(), partialRefresh()))
         val manager = manager(conn)
         val failures = collectFailures(manager)
         runCurrent() // connection established
 
-        shouldThrow<Exception> { manager.querySubscriptions() }
-        advanceUntilIdle()
+        shouldThrow<Exception> { manager.refreshStrict() }
+        runCurrent()
 
         failures shouldBe emptyList()
+    }
+
+    @Test fun `a partial reconciliation without a confirmed pro purchase signals its commit time`() = runTest2 {
+        // The pending-only cold start: Play answered for one type with a payment in progress, the
+        // other failed. Nothing confirms Pro, so the grace episode clock must advance — stamped
+        // with the refresh's COMMIT time, so a confirmation landing in between stays newer.
+        val pending = pendingPurchase()
+        val conn = connection(
+            refreshes = listOf(partialRefresh(purchases = listOf(pending), occurredAt = 4242L)),
+            purchasesFlow = flowOf(listOf(pending)),
+        )
+        val manager = manager(conn)
+        val failures = collectFailures(manager)
+
+        runCurrent()
+
+        // Still published: a partial refresh is a usable connection, and starving billingData would
+        // leave the screen at Loading forever.
+        manager.billingData.first() shouldBe BillingData(
+            purchases = emptyList(),
+            pendingPurchases = listOf(pending),
+        )
+        failures shouldBe listOf(4242L)
+    }
+
+    @Test fun `a partial manual refresh signals too`() = runTest2 {
+        // Manual Restore runs the same reconciliation as the connect loop — before this it was the
+        // only path whose partial outcome silently vanished.
+        val conn = connection(refreshes = listOf(completeRefresh(), partialRefresh(occurredAt = 7_777L)))
+        val manager = manager(conn)
+        val failures = collectFailures(manager)
+        runCurrent()
+
+        manager.refresh()
+        runCurrent() // the collector lives on backgroundScope, which advanceUntilIdle would skip
+
+        failures shouldBe listOf(7_777L)
+    }
+
+    @Test fun `a partial refresh that confirmed pro does not signal`() = runTest2 {
+        val owned = purchase()
+        val conn = connection(
+            refreshes = listOf(
+                completeRefresh(),
+                partialRefresh(purchases = listOf(owned), confirmed = listOf(owned), hasConfirmedPro = true),
+            ),
+        )
+        val manager = manager(conn)
+        val failures = collectFailures(manager)
+        runCurrent()
+
+        manager.refresh()
+        runCurrent()
+
+        // Pro WAS confirmed by this round-trip; the failed sibling type proves nothing against it.
+        failures shouldBe emptyList()
+    }
+
+    @Test fun `an invalidating partial refresh tears the connection down`() = runTest2 {
+        // The dead-binder teardown used to ride refreshPurchases' throw path through useConnection.
+        // A partial refresh returns instead of throwing, so without the explicit invalidation the
+        // dead connection would stay installed for every later caller.
+        val owned = purchase()
+        val dead = connection(
+            refreshes = listOf(
+                partialRefresh(
+                    purchases = listOf(owned),
+                    confirmed = listOf(owned),
+                    hasConfirmedPro = true,
+                    error = GplayServiceUnavailableException(
+                        BillingClientException(result(BillingResponseCode.SERVICE_DISCONNECTED))
+                    ),
+                ),
+            ),
+        )
+        val good = connection(refreshResults = listOf(emptyList(), listOf(owned)))
+        var attempts = 0
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flow {
+                attempts++
+                emit(if (attempts == 1) dead else good)
+                awaitCancellation()
+            }
+        }
+        val manager = manager(provider)
+        runCurrent() // connection 1 established; its partial refresh signals the invalidation
+
+        // The next action is fresh demand: it skips the reconnect backoff and lands on connection 2.
+        // await() is what drives the connect loop here — it runs on backgroundScope, which
+        // advanceUntilIdle() alone would never touch.
+        val refreshed = async { manager.refresh() }
+        advanceUntilIdle()
+
+        refreshed.await() shouldBe BillingData(listOf(owned))
+        attempts shouldBe 2
+    }
+
+    // endregion
+
+    // region pending purchases
+
+    @Test fun `billing data splits owned purchases from pending payments`() = runTest2 {
+        val owned = purchase()
+        val pending = pendingPurchase()
+        val manager = manager(connection(purchasesFlow = flowOf(listOf(owned, pending))))
+
+        // The split is what keeps a payment in progress out of every entitlement decision while
+        // still letting the UI show it.
+        manager.billingData.first() shouldBe BillingData(
+            purchases = listOf(owned),
+            pendingPurchases = listOf(pending),
+        )
+    }
+
+    @Test fun `a pending purchase is never acknowledged`() = runTest2 {
+        val pending = pendingPurchase()
+        val purchases = purchasesFlow()
+        val conn = connection(purchasesFlow = purchases)
+        val acks = conn.scriptAck { _, _ -> result(BillingResponseCode.OK) }
+        manager(conn)
+        runCurrent()
+
+        purchases.tryEmit(listOf(pending))
+        advanceTimeBy(400_000)
+        runCurrent()
+
+        // Play rejects acking a pending purchase permanently: an unfiltered pass would fire a bug
+        // report on every pass, forever, for a purchase that has nothing to acknowledge yet.
+        acks shouldBe emptyList()
+        verify(exactly = 0) { Bugs.report(any()) }
+    }
+
+    @Test fun `a follow-up refresh after a partial publish recovers the full state`() = runTest2 {
+        val pending = pendingPurchase()
+        val owned = purchase()
+        val purchases = purchasesFlow()
+        val conn = connection(
+            refreshes = listOf(
+                partialRefresh(purchases = listOf(pending)),
+                completeRefresh(listOf(owned)),
+            ),
+            purchasesFlow = purchases,
+        )
+        val manager = manager(conn)
+        runCurrent()
+
+        purchases.tryEmit(listOf(pending))
+        manager.billingData.first().pendingPurchases shouldBe listOf(pending)
+
+        // The payment completed: the next reconciliation returns the owned purchase, no reconnect
+        // needed (the partial one left a working connection installed).
+        manager.refresh() shouldBe BillingData(listOf(owned))
+    }
+
+    @Test fun `refreshStrict fails closed on an incomplete refresh`() = runTest2 {
+        val conn = connection(
+            refreshes = listOf(
+                completeRefresh(),
+                partialRefresh(purchases = listOf(purchase()), confirmed = listOf(purchase())),
+            ),
+        )
+        val manager = manager(conn)
+        runCurrent()
+
+        // A gate must not treat "one product type couldn't be checked" as "nothing else is owned":
+        // that is exactly how a double purchase gets through.
+        shouldThrow<GplayServiceUnavailableException> { manager.refreshStrict() }
+    }
+
+    @Test fun `refreshStrict returns the split data on a complete refresh`() = runTest2 {
+        val owned = purchase()
+        val pending = pendingPurchase()
+        val conn = connection(refreshes = listOf(completeRefresh(), completeRefresh(listOf(owned, pending))))
+        val manager = manager(conn)
+        runCurrent()
+
+        manager.refreshStrict() shouldBe BillingData(
+            purchases = listOf(owned),
+            pendingPurchases = listOf(pending),
+        )
     }
 
     // endregion

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/billing/BillingManagerTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/billing/BillingManagerTest.kt
@@ -14,6 +14,7 @@ import eu.darken.myperm.common.upgrade.core.billing.client.BillingClientExceptio
 import eu.darken.myperm.common.upgrade.core.billing.client.BillingConnection
 import eu.darken.myperm.common.upgrade.core.billing.client.BillingConnectionProvider
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
@@ -728,6 +729,54 @@ class BillingManagerTest : BaseTest() {
         runCurrent()
 
         failures shouldBe emptyList()
+    }
+
+    @Test fun `a strict gate failure on a dead connection still tears the connection down`() = runTest2 {
+        // The gate's throw happens after useConnection already returned, so its dead-binder
+        // detection can't fire — without the explicit invalidation connection 1 stays installed and
+        // every later purchase check runs against the corpse. Feeding the episode clock still stays
+        // off this path.
+        val owned = purchase()
+        val dead = connection(
+            refreshes = listOf(
+                completeRefresh(),
+                partialRefresh(
+                    occurredAt = 4242L,
+                    error = GplayServiceUnavailableException(
+                        BillingClientException(result(BillingResponseCode.SERVICE_DISCONNECTED))
+                    ),
+                ),
+            ),
+        )
+        val good = connection(refreshResults = listOf(emptyList(), listOf(owned)))
+        var attempts = 0
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flow {
+                attempts++
+                emit(if (attempts == 1) dead else good)
+                awaitCancellation()
+            }
+        }
+        val manager = manager(provider)
+        val failures = collectFailures(manager)
+        runCurrent() // connection 1 established
+
+        shouldThrow<Exception> { manager.refreshStrict() }
+        // Teardown takes several dispatches and runs on backgroundScope — runCurrent, never
+        // advanceUntilIdle, which would leave the connect loop untouched.
+        runCurrent()
+
+        // The next action is fresh demand: it skips the reconnect backoff and lands on connection 2.
+        val refreshed = async { manager.refresh() }
+        advanceUntilIdle()
+        refreshed.await() shouldBe BillingData(listOf(owned))
+        attempts shouldBe 2
+
+        runCurrent()
+        // The torn-down connection is a failed loop iteration (wall-clock stamped), but the gate's
+        // own partial refresh must never reach the feed with its commit time.
+        failures.isNotEmpty() shouldBe true
+        failures shouldNotContain 4242L
     }
 
     @Test fun `a partial reconciliation without a confirmed pro purchase signals its commit time`() = runTest2 {

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/billing/client/BillingConnectionTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/core/billing/client/BillingConnectionTest.kt
@@ -25,7 +25,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
-import io.mockk.verify
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -69,13 +68,20 @@ class BillingConnectionTest : BaseTest() {
         token: String = "token-$time",
         products: List<String> = listOf(OurSku.Iap.PRO_UPGRADE.id),
         acknowledged: Boolean = false,
+        state: Int = PurchaseState.PURCHASED,
     ) = mockk<Purchase>().apply {
         every { purchaseTime } returns time
         every { purchaseToken } returns token
         every { this@apply.products } returns products
-        every { purchaseState } returns PurchaseState.PURCHASED
+        every { purchaseState } returns state
         every { isAcknowledged } returns acknowledged
     }
+
+    private fun pendingPurchase(
+        time: Long,
+        token: String = "pending-$time",
+        products: List<String> = listOf(OurSku.Iap.PRO_UPGRADE.id),
+    ) = purchase(time = time, token = token, products = products, state = PurchaseState.PENDING)
 
     private fun result(code: Int): BillingResult = BillingResult.newBuilder().setResponseCode(code).build()
 
@@ -121,6 +127,42 @@ class BillingConnectionTest : BaseTest() {
                 sub = Result.failure(RuntimeException("SUBS query failed")),
             )
         }
+    }
+
+    @Test fun `a known pending purchase suppresses the couldn't-verify error`() {
+        // The user's payment is being processed: that IS a usable answer about this account, so a
+        // failing sibling query must not turn the screen into "can't reach Play".
+        val pending = pendingPurchase(1_000)
+
+        BillingConnection.combinePurchaseResults(
+            iap = Result.success(listOf(pending)),
+            sub = Result.failure(RuntimeException("SUBS query failed")),
+            typeOf = typeOf,
+        ) shouldBe listOf(pending)
+    }
+
+    @Test fun `an unknown pending purchase does not suppress the couldn't-verify error`() {
+        // A pending payment for a product this app doesn't sell says nothing about the type whose
+        // query failed — counting it as a find would swallow a real "couldn't verify".
+        shouldThrow<RuntimeException> {
+            BillingConnection.combinePurchaseResults(
+                iap = Result.success(listOf(pendingPurchase(1_000, products = listOf("some.unknown.product")))),
+                sub = Result.failure(RuntimeException("SUBS query failed")),
+                typeOf = typeOf,
+            )
+        }
+    }
+
+    @Test fun `an unknown PURCHASED product still suppresses the error`() {
+        // Ownership of anything is authoritative: every product this app sells is a Pro SKU, so an
+        // unrecognized owned product means our own SKU list is stale, not that Play failed.
+        val owned = purchase(1_000, products = listOf("some.unknown.product"))
+
+        BillingConnection.combinePurchaseResults(
+            iap = Result.success(listOf(owned)),
+            sub = Result.failure(RuntimeException("SUBS query failed")),
+            typeOf = typeOf,
+        ) shouldBe listOf(owned)
     }
 
     // endregion
@@ -423,13 +465,8 @@ class BillingConnectionTest : BaseTest() {
         connection.purchaseFailures.first().responseCode shouldBe BillingResponseCode.USER_CANCELED
     }
 
-    @Test fun `a pending purchase never surfaces as owned or as fresh data`() = runTest2 {
-        val pending = mockk<Purchase>().apply {
-            every { purchaseState } returns PurchaseState.PENDING
-            every { purchaseTime } returns 1_000L
-            every { purchaseToken } returns "pending"
-            every { this@apply.products } returns listOf(OurSku.Iap.PRO_UPGRADE.id)
-        }
+    @Test fun `a pending purchase event enters the state but never the fresh stream`() = runTest2 {
+        val pending = pendingPurchase(1_000, token = "pending")
         val connection = BillingConnection(
             client = clientReturning(
                 result(BillingResponseCode.OK) to emptyList(),
@@ -437,14 +474,169 @@ class BillingConnectionTest : BaseTest() {
             ),
         )
 
-        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(pending))
-        connection.refreshPurchases()
+        val freshUpdates = mutableListOf<BillingConnection.FreshUpdate>()
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            connection.freshUpdates.collect { freshUpdates.add(it) }
+        }
+        connection.refreshPurchases() // settles the state; predates the event
 
-        connection.purchases.first() shouldBe emptyList()
-        // Only the refresh's own emission — the PENDING event never produced one.
+        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(pending))
+        runCurrent()
+
+        // Visible as state (the UI must be able to show a payment in progress)...
+        connection.purchases.first().map { it.purchaseToken } shouldBe listOf("pending")
+        // ...but the fresh stream feeds the entitlement and grace bookkeeping, so only the
+        // refresh's own emission is on it — a pending payment confirms nothing.
+        freshUpdates.size shouldBe 1
+        freshUpdates.single().purchases shouldBe emptyList()
+    }
+
+    @Test fun `a pending query result enters the state but never the fresh stream`() = runTest2 {
+        val pending = pendingPurchase(1_000, token = "pending")
+        val connection = BillingConnection(
+            client = clientReturning(
+                result(BillingResponseCode.OK) to listOf(pending),
+                result(BillingResponseCode.OK) to emptyList(),
+            ),
+        )
+
+        val refresh = connection.refreshPurchases()
+
+        refresh.purchases.map { it.purchaseToken } shouldBe listOf("pending")
+        refresh.confirmed shouldBe emptyList()
+        refresh.hasConfirmedProPurchase shouldBe false
+        connection.purchases.first().map { it.purchaseToken } shouldBe listOf("pending")
         val update = connection.freshUpdates.first()
         update.purchases shouldBe emptyList()
         update.isFullSnapshot shouldBe true
+    }
+
+    @Test fun `a completing payment supersedes its own pending entry`() = runTest2 {
+        // Play delivers the same purchaseToken again once the payment cleared: the dedup must let
+        // the PURCHASED instance win instead of leaving the user with two records.
+        val pending = pendingPurchase(1_000, token = "same")
+        val purchased = purchase(1_000, token = "same")
+        val connection = BillingConnection(
+            client = clientReturning(
+                result(BillingResponseCode.OK) to emptyList(),
+                result(BillingResponseCode.OK) to emptyList(),
+            ),
+        )
+
+        connection.refreshPurchases() // settles the state; predates both events
+        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(pending))
+        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(purchased))
+
+        val merged = connection.purchases.first()
+        merged.size shouldBe 1
+        merged.single().purchaseState shouldBe PurchaseState.PURCHASED
+        // The completion is fresh Play data: it must reach the grace bookkeeping, unlike the
+        // pending event before it.
+        val updates = connection.freshUpdates.take(2).toList()
+        updates[0].purchases shouldBe emptyList()
+        updates[1].purchases shouldBe listOf(purchased)
+    }
+
+    @Test fun `an unspecified-state purchase is dropped everywhere`() = runTest2 {
+        val unspecified = purchase(1_000, token = "unspecified", state = PurchaseState.UNSPECIFIED_STATE)
+        val connection = BillingConnection(
+            client = clientReturning(
+                result(BillingResponseCode.OK) to listOf(unspecified),
+                result(BillingResponseCode.OK) to emptyList(),
+            ),
+        )
+        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(unspecified))
+
+        val refresh = connection.refreshPurchases()
+
+        // Neither owned nor a payment in progress: it must not reach state, refresh or UI.
+        refresh.purchases shouldBe emptyList()
+        connection.purchases.first() shouldBe emptyList()
+    }
+
+    @Test fun `a pending-only overlay survivor does not suppress absence bookkeeping`() = runTest2 {
+        // A pending payment arrives while a refresh is in flight: the queries verified empty, and
+        // the surviving PENDING overlay proves no ownership — the snapshot still proves absence,
+        // unlike the PURCHASED case (which must not start a false unconfirmed-grace episode).
+        val pendingListeners = mutableListOf<PurchasesResponseListener>()
+        val client = mockk<BillingClient>().apply {
+            every { queryPurchasesAsync(any<QueryPurchasesParams>(), any()) } answers {
+                pendingListeners.add(secondArg())
+            }
+        }
+        val connection = BillingConnection(client = client)
+
+        val refresh = async(start = CoroutineStart.UNDISPATCHED) { connection.refreshPurchases() }
+        runCurrent()
+        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(pendingPurchase(1_000)))
+        pendingListeners.forEach { it.onQueryPurchasesResponse(result(BillingResponseCode.OK), mutableListOf()) }
+        runCurrent()
+        refresh.await()
+
+        val update = connection.freshUpdates.first()
+        update.purchases shouldBe emptyList()
+        update.isFullSnapshot shouldBe true
+    }
+
+    @Test fun `a refresh reports only what its own queries confirmed`() = runTest2 {
+        val iapOwned = purchase(1_000, token = "iap")
+        val connection = BillingConnection(
+            client = clientReturning(
+                // Refresh 1: both succeed, IAP owned.
+                result(BillingResponseCode.OK) to listOf(iapOwned),
+                result(BillingResponseCode.OK) to emptyList(),
+                // Refresh 2: IAP fails (stale snapshot retained), SUB confirms a pending payment.
+                result(BillingResponseCode.ERROR) to emptyList(),
+                result(BillingResponseCode.OK) to listOf(
+                    pendingPurchase(2_000, token = "pending-sub", products = listOf(OurSku.Sub.PRO_UPGRADE.id))
+                ),
+            ),
+        )
+        connection.refreshPurchases()
+
+        val second = connection.refreshPurchases()
+
+        // The retained IAP purchase is in the committed view, but it is NOT something these
+        // queries confirmed — reporting it as confirmed Pro would keep the grace clock frozen
+        // through an indefinite outage.
+        second.purchases.map { it.purchaseToken } shouldContainExactly listOf("pending-sub", "iap")
+        second.confirmed shouldBe emptyList()
+        second.hasConfirmedProPurchase shouldBe false
+        second.isComplete shouldBe false
+        second.partialError.shouldNotBeNull()
+    }
+
+    @Test fun `a confirmed known purchase is reported as confirmed pro`() = runTest2 {
+        val connection = BillingConnection(
+            client = clientReturning(
+                result(BillingResponseCode.OK) to listOf(purchase(1_000, token = "iap")),
+                result(BillingResponseCode.ERROR) to emptyList(),
+            ),
+        )
+
+        val refresh = connection.refreshPurchases()
+
+        refresh.confirmed.map { it.purchaseToken } shouldBe listOf("iap")
+        refresh.hasConfirmedProPurchase shouldBe true
+        refresh.isComplete shouldBe false
+    }
+
+    @Test fun `a refresh is stamped with its commit time`() = runTest2 {
+        val before = System.currentTimeMillis()
+        val connection = BillingConnection(
+            client = clientReturning(
+                result(BillingResponseCode.OK) to emptyList(),
+                result(BillingResponseCode.OK) to emptyList(),
+            ),
+        )
+
+        val refresh = connection.refreshPurchases()
+        val after = System.currentTimeMillis()
+
+        (refresh.occurredAt in before..after) shouldBe true
+        // The same instant travels on the fresh update, so a confirmation and a later failure
+        // signal can be ordered against each other.
+        refresh.occurredAt shouldBe connection.freshUpdates.first().occurredAt
     }
 
     @Test fun `fresh updates arrive in commit order`() = runTest2 {
@@ -803,146 +995,6 @@ class BillingConnectionTest : BaseTest() {
         shouldThrow<BillingClientException> {
             connection.launchBillingFlow(mockk(), OurSku.Iap.PRO_UPGRADE, null)
         }
-    }
-
-    // endregion
-
-    // region querySubscriptions (pre-purchase gate)
-
-    @Test fun `querySubscriptions returns fresh subs and keeps the iap snapshot intact`() = runTest2 {
-        val iapOwned = purchase(1_000, token = "iap")
-        val subOwned = purchase(2_000, token = "sub", products = listOf(OurSku.Sub.PRO_UPGRADE.id))
-        val client = clientReturning(
-            // Refresh: IAP owned, no subs yet.
-            result(BillingResponseCode.OK) to listOf(iapOwned),
-            result(BillingResponseCode.OK) to emptyList(),
-            // SUBS-only gate query: sub found.
-            result(BillingResponseCode.OK) to listOf(subOwned),
-        )
-        val connection = BillingConnection(client = client)
-        connection.refreshPurchases()
-
-        val gateView = connection.querySubscriptions()
-
-        gateView shouldBe listOf(subOwned)
-        // The gate must have queried SUBS, not INAPP (clientReturning ignores the params, so this
-        // would otherwise go unnoticed). zza() is the params' only product-type accessor — a
-        // billing library upgrade renaming it breaks this line loudly at compile time.
-        verify(exactly = 2) {
-            client.queryPurchasesAsync(match<QueryPurchasesParams> { it.zza() == BillingClient.ProductType.SUBS }, any())
-        }
-        // The SUBS-only commit updates the reactive view WITHOUT disturbing the IAP snapshot —
-        // wiping it would briefly un-Pro a one-time-purchase owner.
-        connection.purchases.first().map { it.purchaseToken } shouldContainExactly listOf("sub", "iap")
-        val updates = connection.freshUpdates.take(2).toList()
-        // Partial by definition: it proves what the SUBS query found, never absence of the rest.
-        updates[1].purchases shouldBe listOf(subOwned)
-        updates[1].isFullSnapshot shouldBe false
-    }
-
-    @Test fun `a failed querySubscriptions propagates and commits nothing`() = runTest2 {
-        val iapOwned = purchase(1_000, token = "iap")
-        val subOwned = purchase(2_000, token = "sub", products = listOf(OurSku.Sub.PRO_UPGRADE.id))
-        val connection = BillingConnection(
-            client = clientReturning(
-                result(BillingResponseCode.OK) to listOf(iapOwned),
-                result(BillingResponseCode.OK) to listOf(subOwned),
-                result(BillingResponseCode.ERROR) to emptyList(),
-            ),
-        )
-        val freshUpdates = mutableListOf<BillingConnection.FreshUpdate>()
-        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
-            connection.freshUpdates.collect { freshUpdates.add(it) }
-        }
-        connection.refreshPurchases()
-
-        // Fail-closed contract: the gate must see the error, not an empty "no subscriptions".
-        shouldThrow<BillingClientException> { connection.querySubscriptions() }
-        runCurrent()
-
-        // No commit and no fresh emission from the failed query — only the refresh's own. Both
-        // snapshots survive, including the SUB one the failed query was about.
-        connection.purchases.first().map { it.purchaseToken } shouldContainExactly listOf("sub", "iap")
-        freshUpdates.size shouldBe 1
-    }
-
-    @Test fun `querySubscriptions clears an older sub overlay it could have seen`() = runTest2 {
-        // The sub arrived via purchase event, then the user refunded/cancelled it away: the gate
-        // query verifies empty and must supersede the stale event — otherwise the ghost sub keeps
-        // blocking the one-time purchase.
-        val subEvent = purchase(1_000, token = "sub-event", products = listOf(OurSku.Sub.PRO_UPGRADE.id))
-        val connection = BillingConnection(
-            client = clientReturning(result(BillingResponseCode.OK) to emptyList()),
-        )
-        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(subEvent))
-
-        connection.querySubscriptions() shouldBe emptyList()
-        connection.purchases.first() shouldBe emptyList()
-    }
-
-    @Test fun `querySubscriptions prefers a racing event's renewal state for the same token`() = runTest2 {
-        // The stale query result says the sub no longer renews, but a purchase event that landed
-        // while the query was in flight says it does (user just re-subscribed): the gate must see
-        // the overlay version, or the fail-closed double-billing check lets the buy through.
-        val queried = purchase(1_000, token = "same", products = listOf(OurSku.Sub.PRO_UPGRADE.id)).apply {
-            every { isAutoRenewing } returns false
-        }
-        val raced = purchase(1_000, token = "same", products = listOf(OurSku.Sub.PRO_UPGRADE.id)).apply {
-            every { isAutoRenewing } returns true
-        }
-        val pendingListeners = mutableListOf<PurchasesResponseListener>()
-        val client = mockk<BillingClient>().apply {
-            every { queryPurchasesAsync(any<QueryPurchasesParams>(), any()) } answers {
-                pendingListeners.add(secondArg())
-            }
-        }
-        val connection = BillingConnection(client = client)
-
-        val gate = async(start = CoroutineStart.UNDISPATCHED) { connection.querySubscriptions() }
-        runCurrent()
-        pendingListeners.size shouldBe 1
-
-        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(raced))
-        pendingListeners.single().onQueryPurchasesResponse(result(BillingResponseCode.OK), mutableListOf(queried))
-        runCurrent()
-
-        val gateView = gate.await()
-        gateView.single().isAutoRenewing shouldBe true
-    }
-
-    @Test fun `querySubscriptions excludes iap overlay entries but keeps untyped ones`() = runTest2 {
-        val iapEvent = purchase(1_000, token = "iap-event")
-        val unknownEvent = purchase(2_000, token = "unknown", products = listOf("some.unknown.product"))
-        val connection = BillingConnection(
-            client = clientReturning(result(BillingResponseCode.OK) to emptyList()),
-        )
-        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(iapEvent))
-        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(unknownEvent))
-
-        val gateView = connection.querySubscriptions()
-
-        // An IAP can't be the blocking subscription; an unknown product might be, so it stays in
-        // on the safe side.
-        gateView.map { it.purchaseToken } shouldBe listOf("unknown")
-        // Excluded from the gate view only — the reducer still owns both entries.
-        connection.purchases.first().map { it.purchaseToken } shouldContainExactly listOf("unknown", "iap-event")
-    }
-
-    @Test fun `querySubscriptions filters pending subscription results`() = runTest2 {
-        val pendingSub = mockk<Purchase>().apply {
-            every { purchaseState } returns PurchaseState.PENDING
-            every { purchaseTime } returns 1_000L
-            every { purchaseToken } returns "pending-sub"
-            every { this@apply.products } returns listOf(OurSku.Sub.PRO_UPGRADE.id)
-        }
-        val connection = BillingConnection(
-            client = clientReturning(result(BillingResponseCode.OK) to listOf(pendingSub)),
-        )
-
-        // A PENDING subscription is not an active one — it must neither block the gate nor
-        // surface as owned.
-        connection.querySubscriptions() shouldBe emptyList()
-        connection.purchases.first() shouldBe emptyList()
     }
 
     // endregion

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/GplayUpgradeOwnershipTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/GplayUpgradeOwnershipTest.kt
@@ -89,4 +89,38 @@ class GplayUpgradeOwnershipTest : BaseTest() {
 
         ownership.ownsAnything shouldBe false
     }
+
+    private fun pendingInfo(vararg pending: Purchase) = UpgradeRepoGplay.Info(
+        false,
+        BillingData(purchases = emptyList(), pendingPurchases = pending.toList()),
+        null,
+    )
+
+    @Test
+    fun `a pending payment sets the pending flag`() {
+        pendingInfo(mockPurchase("eu.darken.myperm.iap.upgrade.pro")).toPendingFlag().shouldBeTrue()
+        pendingInfo(mockPurchase("upgrade.pro")).toPendingFlag().shouldBeTrue()
+    }
+
+    @Test
+    fun `no pending payment leaves the flag off`() {
+        info(mockPurchase("eu.darken.myperm.iap.upgrade.pro")).toPendingFlag().shouldBeFalse()
+        pendingInfo().toPendingFlag().shouldBeFalse()
+    }
+
+    @Test
+    fun `an unknown pending product does not set the flag`() {
+        // Nothing to explain and nothing to lock: a product this app doesn't sell isn't the Pro
+        // upgrade the user is waiting for.
+        pendingInfo(mockPurchase("some.unknown.sku")).toPendingFlag().shouldBeFalse()
+    }
+
+    @Test
+    fun `a pending payment is not ownership`() {
+        val ownership = pendingInfo(mockPurchase("eu.darken.myperm.iap.upgrade.pro")).toOwnership()
+
+        ownership.hasIap.shouldBeFalse()
+        ownership.subscription.shouldBeNull()
+        ownership.ownsAnything.shouldBeFalse()
+    }
 }

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/GplayUpgradeScreenHostTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/GplayUpgradeScreenHostTest.kt
@@ -2,8 +2,10 @@ package eu.darken.myperm.common.upgrade.ui
 
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.SavedStateHandle
+import eu.darken.myperm.R
 import eu.darken.myperm.common.compose.PreviewWrapper
 import eu.darken.myperm.common.navigation.Nav
 import eu.darken.myperm.common.upgrade.core.UpgradeRepoGplay
@@ -41,6 +43,34 @@ class GplayUpgradeScreenHostTest : BaseTest() {
         // Relaxed mocks return a no-op Flow that never emits -- the state combine would starve.
         every { autoRestoreBusy } returns MutableStateFlow(false)
         every { purchaseLaunchSku } returns MutableStateFlow<Sku?>(null)
+    }
+
+    @Test
+    fun `a pending-purchase event puts the informational dialog on screen`() {
+        // Host-level wiring: the ViewModel tests prove the event is emitted, only a real
+        // composition proves it reaches a dialog (and survives as a rememberSaveable flag).
+        val repo = mockRepo()
+        coEvery { repo.querySkus(any()) } returns emptyList()
+        val vm = UpgradeViewModel(
+            handle = SavedStateHandle(mapOf("forced" to false)),
+            dispatcherProvider = TestDispatcherProvider(),
+            upgradeRepo = repo,
+            webpageTool = mockk(relaxed = true),
+        )
+
+        composeRule.setContent {
+            PreviewWrapper {
+                UpgradeScreenHost(route = Nav.Main.Upgrade(), vm = vm)
+            }
+        }
+        composeRule.waitForIdle()
+
+        vm.events.tryEmit(UpgradeEvents.PurchasePending)
+
+        val message = composeRule.activity.getString(R.string.upgrade_screen_pending_dialog_message)
+        composeRule.waitUntil {
+            composeRule.onAllNodesWithText(message, substring = true).fetchSemanticsNodes().isNotEmpty()
+        }
     }
 
     @Test

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/GplayUpgradeScreenTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/GplayUpgradeScreenTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
@@ -341,6 +342,88 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         )
         check(idle.iapEnabled) { "IAP buy should be enabled when idle" }
         check(idle.subscriptionEnabled) { "Subscription buy should be enabled when idle" }
+
+        // A pending payment locks BOTH, whichever product it belongs to: Play rejects a second
+        // purchase of the pending product, and the alternative would charge twice for Pro.
+        val pending = toLoadedState(
+            iap = SkuDetails(OurSku.Iap.PRO_UPGRADE, iapDetails),
+            sub = SkuDetails(OurSku.Sub.PRO_UPGRADE, subDetails),
+            ownership = Ownership(),
+            hasPendingPurchase = true,
+        )
+        check(!pending.iapEnabled) { "IAP buy must be disabled while a payment is pending" }
+        check(!pending.subscriptionEnabled) { "Subscription buy must be disabled while a payment is pending" }
+    }
+
+    @Test
+    fun `a pending payment shows the card and locks the offers for acquisition`() {
+        composeRule.setUpgradeContent {
+            UpgradeScreen(
+                uiState = GplayUpgradeUiState.Loaded(
+                    subscriptionAction = SubscriptionAction.STANDARD,
+                    subscriptionEnabled = false,
+                    subscriptionPrice = "$12.99",
+                    iapEnabled = false,
+                    iapPrice = "$24.99",
+                    hasPendingPurchase = true,
+                ),
+            )
+        }
+
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_PENDING).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_pending_card_body))
+            .assertCountEquals(1)
+        composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_SUBSCRIPTION).assertIsNotEnabled()
+        composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_IAP).assertIsNotEnabled()
+        // Restore stays available: re-checking with Play is exactly the right move for someone who
+        // believes the payment already went through.
+        composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_RESTORE).assertIsEnabled()
+    }
+
+    @Test
+    fun `a pending payment shows the card on the ownership screen and locks the switch`() {
+        composeRule.setUpgradeContent {
+            UpgradeScreen(
+                uiState = ownedState(Ownership(subscription = SubscriptionOwnership(isAutoRenewing = false)))
+                    .copy(hasPendingPurchase = true),
+            )
+        }
+
+        // The subscriber switching to the one-time purchase: the switch offer is unlocked by the
+        // non-renewing subscription, but a payment in progress must still hold it.
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_PENDING).assertCountEquals(1)
+        composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_IAP).assertIsNotEnabled()
+    }
+
+    @Test
+    fun `a pending payment shows the card during a young grace episode`() {
+        composeRule.setUpgradeContent {
+            UpgradeScreen(uiState = graceState(showDiagnostics = false).copy(hasPendingPurchase = true))
+        }
+
+        // The young grace stage hides the offers box entirely, so a card rendered inside it would
+        // never reach this audience — which is precisely the one waiting for a renewal payment.
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_PENDING).assertCountEquals(1)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_GRACE).assertCountEquals(1)
+    }
+
+    @Test
+    fun `the pending dialog is informational only`() {
+        var dismissals = 0
+        composeRule.setUpgradeContent { PurchasePendingDialog(onDismiss = { dismissals++ }) }
+
+        composeRule.onNodeWithText(
+            context.getString(R.string.upgrade_screen_pending_dialog_message),
+            substring = true,
+        ).assertExists()
+        // No support escalation and no restore tips: there is nothing for the user to do.
+        composeRule.onAllNodesWithText(context.getString(R.string.contact_support_label))
+            .assertCountEquals(0)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_restore_multiaccount_hint))
+            .assertCountEquals(0)
+
+        composeRule.onNodeWithText(context.getString(R.string.general_close_action)).performClick()
+        composeRule.runOnIdle { dismissals shouldBe 1 }
     }
 
     @Test

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/GplayUpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/GplayUpgradeViewModelTest.kt
@@ -11,6 +11,7 @@ import eu.darken.myperm.common.upgrade.core.UpgradeRepoGplay
 import eu.darken.myperm.common.upgrade.core.billing.BillingData
 import eu.darken.myperm.common.upgrade.core.billing.GplayServiceUnavailableException
 import eu.darken.myperm.common.upgrade.core.billing.OfferUnavailableBillingException
+import eu.darken.myperm.common.upgrade.core.billing.PendingPurchaseBillingException
 import eu.darken.myperm.common.upgrade.core.billing.Sku
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldBeEmpty
@@ -22,6 +23,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
@@ -294,6 +296,9 @@ class GplayUpgradeViewModelTest : BaseTest() {
         // Relaxed mocks return a no-op Flow that never emits -- the state combine would starve.
         every { autoRestoreBusy } returns MutableStateFlow(false)
         every { purchaseLaunchSku } returns MutableStateFlow<Sku?>(null)
+        // Both purchase paths run the pre-purchase gate: the default is a clean account (nothing
+        // owned, nothing pending), so tests only stub it when the gate IS the subject.
+        coEvery { verifyPurchaseStateNow() } returns UpgradeRepoGplay.Info(false, null, null, isSettled = true)
     }
 
     private fun buildVm(
@@ -317,6 +322,15 @@ class GplayUpgradeViewModelTest : BaseTest() {
         BillingData(purchases = purchases.toList()),
         null,
         // Ownership data implies a committed reconciliation -> always settled.
+        isSettled = true,
+    )
+
+    // Play is still processing a payment: nothing owned, nothing granted, but the purchase paths
+    // must treat it as a blocking answer.
+    private fun pendingInfo(skuId: String = OurSku.Iap.PRO_UPGRADE.id) = UpgradeRepoGplay.Info(
+        false,
+        BillingData(purchases = emptyList(), pendingPurchases = listOf(mockPurchase(skuId))),
+        null,
         isSettled = true,
     )
 
@@ -369,6 +383,22 @@ class GplayUpgradeViewModelTest : BaseTest() {
         advanceUntilIdle()
 
         event.await() shouldBe UpgradeEvents.RestoreFailed
+    }
+
+    @Test
+    fun `restore that finds a pending payment emits PurchasePending`() = runTest2(context = testDispatcher) {
+        // Play answered and DID find the purchase — it just isn't paid for yet. RestoreFailed would
+        // send this user through account troubleshooting and support for something that resolves
+        // itself.
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } returns checked(pendingInfo())
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.PurchasePending
     }
 
     @Test
@@ -524,7 +554,28 @@ class GplayUpgradeViewModelTest : BaseTest() {
     @Test
     fun `iap purchase is blocked while the subscription is still set to renew`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        coEvery { repo.queryCurrentSubscriptions() } returns listOf(mockPurchase("upgrade.pro", autoRenewing = true))
+        coEvery { repo.verifyPurchaseStateNow() } returns
+            proInfo(mockPurchase(OurSku.Sub.PRO_UPGRADE.id, autoRenewing = true))
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.onGoIap(mockk<Activity>(relaxed = true))
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.SubscriptionStillRenewing
+        coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `iap purchase is blocked by a renewing subscription with an unknown product`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // The gate reads the RAW purchases, never the mapped upgrades: a subscription whose product
+        // ID this build doesn't know (legacy SKU, renamed product) still renews and still bills, so
+        // letting the one-time purchase through here charges the user for Pro twice.
+        val repo = mockRepo()
+        coEvery { repo.verifyPurchaseStateNow() } returns
+            proInfo(mockPurchase("some.unknown.subscription", autoRenewing = true))
         val vm = buildVm(repo)
 
         val event = async { vm.events.first() }
@@ -538,7 +589,8 @@ class GplayUpgradeViewModelTest : BaseTest() {
     @Test
     fun `iap purchase proceeds when the subscription is not set to renew`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        coEvery { repo.queryCurrentSubscriptions() } returns listOf(mockPurchase("upgrade.pro", autoRenewing = false))
+        coEvery { repo.verifyPurchaseStateNow() } returns
+            proInfo(mockPurchase(OurSku.Sub.PRO_UPGRADE.id, autoRenewing = false))
         val vm = buildVm(repo)
 
         vm.onGoIap(mockk<Activity>(relaxed = true))
@@ -550,7 +602,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
     @Test
     fun `iap purchase proceeds without any subscription`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        coEvery { repo.queryCurrentSubscriptions() } returns emptyList()
+        coEvery { repo.verifyPurchaseStateNow() } returns UpgradeRepoGplay.Info(false, null, null, isSettled = true)
         val vm = buildVm(repo)
 
         vm.onGoIap(mockk<Activity>(relaxed = true))
@@ -560,12 +612,12 @@ class GplayUpgradeViewModelTest : BaseTest() {
     }
 
     @Test
-    fun `failing subscription verification blocks the purchase and forwards the error`() = runTest2(
+    fun `failing purchase verification blocks the purchase and forwards the error`() = runTest2(
         context = testDispatcher,
     ) {
         val repo = mockRepo()
         val boom = IllegalStateException("Play unavailable")
-        coEvery { repo.queryCurrentSubscriptions() } throws boom
+        coEvery { repo.verifyPurchaseStateNow() } throws boom
         val vm = buildVm(repo)
 
         val forwardedError = async { vm.errorEvents.first() }
@@ -577,13 +629,13 @@ class GplayUpgradeViewModelTest : BaseTest() {
     }
 
     @Test
-    fun `subscription verification timeout blocks the purchase with a check-failed event`() = runTest2(
+    fun `purchase verification timeout blocks the purchase with a check-failed event`() = runTest2(
         context = testDispatcher,
     ) {
         val repo = mockRepo()
-        coEvery { repo.queryCurrentSubscriptions() } coAnswers {
+        coEvery { repo.verifyPurchaseStateNow() } coAnswers {
             delay(30_000) // longer than the 10s verification timeout
-            emptyList()
+            UpgradeRepoGplay.Info(false, null, null, isSettled = true)
         }
         val vm = buildVm(repo)
 
@@ -591,16 +643,87 @@ class GplayUpgradeViewModelTest : BaseTest() {
         vm.onGoIap(mockk<Activity>(relaxed = true))
         advanceUntilIdle()
 
-        event.await() shouldBe UpgradeEvents.SubscriptionCheckFailed
+        event.await() shouldBe UpgradeEvents.PurchaseCheckFailed
         coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a subscription gate timeout blocks that purchase too`() = runTest2(context = testDispatcher) {
+        // The subscription path used to launch unverified: a slow Play means we don't know whether
+        // a payment is already pending, so it must fail closed like the one-time path.
+        val repo = mockRepo()
+        coEvery { repo.verifyPurchaseStateNow() } coAnswers {
+            delay(30_000)
+            UpgradeRepoGplay.Info(false, null, null, isSettled = true)
+        }
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.onGoSubscription(mockk<Activity>(relaxed = true))
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.PurchaseCheckFailed
+        coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a pending payment blocks the one-time purchase`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.verifyPurchaseStateNow() } returns pendingInfo()
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.onGoIap(mockk<Activity>(relaxed = true))
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.PurchasePending
+        coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a pending payment blocks the subscription purchase`() = runTest2(context = testDispatcher) {
+        // SKU-agnostic on purpose: the two products are alternatives, so a pending payment for
+        // either one must block both — completing both charges the user twice.
+        val repo = mockRepo()
+        coEvery { repo.verifyPurchaseStateNow() } returns pendingInfo()
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.onGoSubscriptionTrial(mockk<Activity>(relaxed = true))
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.PurchasePending
+        coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a pending-payment launch failure surfaces as the pending dialog`() = runTest2(context = testDispatcher) {
+        // Play can only report this at launch time (the gate saw a clean state moments earlier):
+        // the already-owned error dialog with its restore tips would be the wrong advice.
+        // The callback is captured and invoked from the test body rather than from inside the
+        // answer: on a suspend function the argument list carries the continuation, so grabbing the
+        // callback positionally there is a coin flip — and a wrong cast would surface as a hang.
+        val repo = mockRepo()
+        val onError = slot<(Throwable) -> Unit>()
+        coEvery { repo.launchBillingFlowNow(any(), any(), any(), capture(onError)) } returns Unit
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.onGoIap(mockk<Activity>(relaxed = true))
+        advanceUntilIdle()
+
+        onError.captured(PendingPurchaseBillingException())
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.PurchasePending
     }
 
     @Test
     fun `iap taps are single-flight while a verification is running`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        coEvery { repo.queryCurrentSubscriptions() } coAnswers {
+        coEvery { repo.verifyPurchaseStateNow() } coAnswers {
             delay(5_000)
-            emptyList()
+            UpgradeRepoGplay.Info(false, null, null, isSettled = true)
         }
         val vm = buildVm(repo)
 
@@ -609,7 +732,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
         vm.onGoIap(mockk<Activity>(relaxed = true))
         advanceUntilIdle()
 
-        coVerify(exactly = 1) { repo.queryCurrentSubscriptions() }
+        coVerify(exactly = 1) { repo.verifyPurchaseStateNow() }
         coVerify(exactly = 1) { repo.launchBillingFlowNow(any(), eq(OurSku.Iap.PRO_UPGRADE), isNull(), any()) }
     }
 
@@ -646,8 +769,9 @@ class GplayUpgradeViewModelTest : BaseTest() {
         advanceUntilIdle()
 
         // One arbiter for all three: the purchase and the restore would otherwise run concurrent
-        // Play operations against the same account state.
-        coVerify(exactly = 0) { repo.queryCurrentSubscriptions() }
+        // Play operations against the same account state. Exactly one gate ran — the subscription's
+        // own; the blocked IAP tap never got to verify anything.
+        coVerify(exactly = 1) { repo.verifyPurchaseStateNow() }
         coVerify(exactly = 0) { repo.restorePurchaseNow() }
         coVerify(exactly = 1) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
     }
@@ -670,7 +794,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
 
         coVerify(exactly = 1) { repo.restorePurchaseNow() }
         coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
-        coVerify(exactly = 0) { repo.queryCurrentSubscriptions() }
+        coVerify(exactly = 0) { repo.verifyPurchaseStateNow() }
     }
 
     @Test
@@ -966,6 +1090,43 @@ class GplayUpgradeViewModelTest : BaseTest() {
         advanceUntilIdle()
 
         event.await() shouldBe UpgradeEvents.RestoreFailed
+    }
+
+    @Test
+    fun `a pending payment renders while the price queries are still running`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // Price-independent like owners and grace users: the pending card is this user's answer and
+        // both offers are locked anyway, so waiting on prices would hide it behind Loading.
+        val repo = mockRepo()
+        every { repo.upgradeInfo } returns MutableStateFlow(pendingInfo())
+        coEvery { repo.querySkus(any()) } coAnswers {
+            delay(60_000) // effectively never within this test
+            emptyList()
+        }
+        val vm = buildVm(repo)
+
+        val collector = launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
+        testScheduler.advanceTimeBy(1_000)
+
+        val loaded = vm.state.value.shouldBeInstanceOf<GplayUpgradeUiState.Loaded>()
+        loaded.hasPendingPurchase shouldBe true
+        collector.cancel()
+    }
+
+    @Test
+    fun `a pending payment keeps its card when both price queries fail`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        every { repo.upgradeInfo } returns MutableStateFlow(pendingInfo())
+        coEvery { repo.querySkus(any()) } throws IllegalStateException("Play unavailable")
+        val vm = buildVm(repo)
+
+        val loaded = async { awaitLoaded(vm) }
+        advanceUntilIdle()
+
+        // Not the acquisition-style Unavailable card: the pending explanation must survive a price
+        // outage, exactly like the grace card does.
+        loaded.await().hasPendingPurchase shouldBe true
     }
 
     @Test

--- a/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/GplayUpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/myperm/common/upgrade/ui/GplayUpgradeViewModelTest.kt
@@ -697,6 +697,45 @@ class GplayUpgradeViewModelTest : BaseTest() {
     }
 
     @Test
+    fun `a subscription purchase is blocked when the fresh check finds an owned upgrade`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // The screen can be stale (the one-time purchase was made on another device) and Play sells
+        // the subscription right next to an owned IAP — launching here charges the user for Pro a
+        // second time.
+        val repo = mockRepo()
+        coEvery { repo.verifyPurchaseStateNow() } returns proInfo(mockPurchase(OurSku.Iap.PRO_UPGRADE.id))
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.onGoSubscription(mockk<Activity>(relaxed = true))
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.RestoreSucceeded
+        coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a subscription purchase is blocked when an unknown renewing subscription exists`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // Unknown product ID => zero mapped upgrades, so the ownership block above lets it through.
+        // It still renews and still bills, and a second subscription for the same features is the
+        // same double charge.
+        val repo = mockRepo()
+        coEvery { repo.verifyPurchaseStateNow() } returns
+            proInfo(mockPurchase("some.unknown.subscription", autoRenewing = true))
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.onGoSubscription(mockk<Activity>(relaxed = true))
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.SubscriptionStillRenewing
+        coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
+    }
+
+    @Test
     fun `a pending-payment launch failure surfaces as the pending dialog`() = runTest2(context = testDispatcher) {
         // Play can only report this at launch time (the gate saw a clean state moments earlier):
         // the already-owned error dialog with its restore tips would be the wrong advice.


### PR DESCRIPTION
## What changed

When Google Play is still processing a payment (cash, carrier billing, bank transfer), the app previously had no idea the user had bought anything: the upgrade screen kept selling, and a retry was rejected by Play as "already owned". Pending payments now travel through the billing stack: a "Payment pending" card explains the wait, both purchase buttons lock (buying the alternative product would double-charge), a restore that finds the unpaid purchase says so instead of suggesting account troubleshooting, and retrying the pending product gets the same explanation instead of a misleading "already owned" error.

Both purchase buttons also verify the account state with Play at tap time before opening the checkout: a pending payment, an existing Pro purchase made on another device, or a subscription still set to renew stops the launch instead of charging twice. If the check cannot complete, the purchase does not start.

## Technical Context

- Port of the canonical sdmaid-se implementation (d4rken-org/sdmaid-se#2653 plus its two follow-up gate corrections, sdmaid-se PR #2662); billing-core files are byte-parity with the donor modulo package rename, verified by a normalized diff in review.
- Pending purchases never touch entitlement: `BillingData` splits PURCHASED-only `purchases` from `pendingPurchases` at every exit, so granting Pro, stamping the grace cache, and the acknowledgement pass (which Play rejects permanently for pending purchases) stay PURCHASED-only by construction.
- The pre-purchase gate fails closed on anything short of a complete Play round-trip (`refreshStrict`), and invalidates a connection that died mid-check so later checks reconnect instead of reusing it.
- The renewal guard reads RAW purchases, not mapped SKUs, so a renewing subscription with a legacy or unknown product ID still blocks a double purchase.
