### PR TITLE
Fastlane: Bump json to 2.21.2 (GHSA-9hj4-r449-hfvc)

### DIFF
--- a/fastlane/Gemfile.lock
+++ b/fastlane/Gemfile.lock
@@ -173,7 +173,7 @@ GEM
     httpclient (2.9.0)
       mutex_m
     jmespath (1.6.2)
-    json (2.21.1)
+    json (2.21.2)
     jwt (3.2.0)
       base64
     logger (1.7.0)


### PR DESCRIPTION
## What changed

No user-facing behavior change. The `json` gem in the fastlane release bundle goes from 2.21.1 to 2.21.2, clearing the Dependabot alert for [GHSA-9hj4-r449-hfvc](https://github.com/advisories/GHSA-9hj4-r449-hfvc) / CVE-2026-71847 (low severity).

## Technical Context

* Root cause in the gem: `cResumableParser_parse` clears the resumable parser's input buffer but leaves `state.start`, `state.cursor` and `state.end` pointing into freed storage. A later `partial_value` on an incomplete object with duplicate keys reaches the duplicate-key warning path, which calls `cursor_position` and reads the released memory. Impact is process termination, no RCE and no information disclosure.
* The vulnerable path is not reachable from this repo. `json` is a transitive dependency of fastlane, fastlane never constructs a `JSON::ResumableParser`, and this lockfile is only consumed by `release-tag.yml` running `bundle exec fastlane` against Google Play on tag push. There is no untrusted JSON stream anywhere in that flow. Bumping because the fix is a one-line patch release, not because there is exposure.
* The lockfile was regenerated with `bundle lock --update=json` rather than hand-edited, so the resolver confirmed nothing else needed to move. The diff is the single version line.
* `release-tag.yml` is the only workflow that installs this bundle and it runs on tag push, so PR CI does not exercise the change. It was verified locally instead: `bundle install` compiles the json native extension, `fastlane --version` reports 2.237.0, and `JSON::VERSION` reports 2.21.2.